### PR TITLE
chore: Node.jsのバージョンを package.json から取得するように変更した

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version-file: "package.json"
       - name: Cache node modules
         id: cache-npm
         uses: actions/cache@v4
@@ -28,7 +28,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: npm ci
       - name: Biome check
         run: npm run check
       - name: Test


### PR DESCRIPTION
その際に必要のない `--legacy-peer-deps` のオプションを `npm ci` から外した