### PR TITLE
chore: react/canary の使用を取りやめた

### DIFF
--- a/src/features/listPayment/PaymentList/PaymentList.tsx
+++ b/src/features/listPayment/PaymentList/PaymentList.tsx
@@ -1,6 +1,5 @@
 import { Spinner, Table } from "@radix-ui/themes"
 import { Suspense, memo, use } from "react"
-import {} from "react/canary"
 import type { Payment } from "../../../types/payment"
 import { PaymentItem } from "../PaymentItem"
 import { useGetPayments } from "../useGetPayments"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,11 +4,6 @@ import { defineConfig } from "vite"
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  resolve: {
-    alias: {
-      "react/canary": "react",
-    },
-  },
   css: {
     modules: {
       localsConvention: "dashes",


### PR DESCRIPTION
why: `use` 関数の利用がv19から使えるようになったため