### PR TITLE
test: テストのカテゴリ情報選択時にローディングを待つように調整した

### DIFF
--- a/src/components/inputs/Select/Select.tsx
+++ b/src/components/inputs/Select/Select.tsx
@@ -18,7 +18,7 @@ export function Select({
   children,
 }: SelectProps) {
   const id = useId()
-  const [value, setValue] = useState<string | undefined>()
+  const [value, setValue] = useState<string>("")
 
   const handleChange = useCallback((value: string) => {
     setValue(value)

--- a/src/features/createPayment/CategorySelect/CategorySelect.stories.tsx
+++ b/src/features/createPayment/CategorySelect/CategorySelect.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { MemoryRouter } from "react-router-dom"
-import { userEvent, within } from "storybook/test"
+import { expect, userEvent, waitFor, within } from "storybook/test"
 import { categories } from "../../../test/data/categories"
 import { user } from "../../../test/data/users"
 import { insertCategories } from "../../../test/utils/insertCategories"
@@ -59,6 +59,14 @@ export const Filled: Story = {
 
     const body = within(canvasElement.ownerDocument.body)
     const listbox = await body.findByRole("listbox")
+
+    await waitFor(() => {
+      // "loading" ラベルの要素が存在しないことを確認
+      expect(
+        within(listbox).queryByLabelText(/loading/),
+      ).not.toBeInTheDocument()
+    })
+
     const option = await within(listbox).findByRole("option", {
       name: /food/i,
     })

--- a/src/features/createPayment/CategorySelect/CategorySelect.tsx
+++ b/src/features/createPayment/CategorySelect/CategorySelect.tsx
@@ -34,6 +34,7 @@ const CategorySelectOptions = memo(function CategorySelectInner({
     <>
       {categories.map((category) => (
         <SelectItem
+          aria-label={category.name}
           key={category.id}
           label={category.name}
           value={category?.id ?? ""}

--- a/src/features/createPayment/CreatePaymentForm/CreatePaymentForm.stories.tsx
+++ b/src/features/createPayment/CreatePaymentForm/CreatePaymentForm.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { within } from "@testing-library/react"
-import { fn, userEvent } from "storybook/test"
+import { expect, fn, userEvent, waitFor } from "storybook/test"
 import { categories } from "../../../test/data/categories"
 import { payments } from "../../../test/data/payments"
 import { user } from "../../../test/data/users"
@@ -72,11 +72,19 @@ export const Fiiled: Story = {
       await userEvent.click(todayButton)
     }
     {
-      const select = canvas.getByRole("combobox", { name: /category/i })
+      const select = await canvas.findByRole("combobox", { name: /category/i })
       await userEvent.click(select)
 
       const body = within(canvasElement.ownerDocument.body)
       const listbox = await body.findByRole("listbox")
+
+      await waitFor(() => {
+        // "loading" ラベルの要素が存在しないことを確認
+        expect(
+          within(listbox).queryByLabelText(/loading/),
+        ).not.toBeInTheDocument()
+      })
+
       const option = await within(listbox).findByRole("option", {
         name: /food/i,
       })


### PR DESCRIPTION
## 概要
<!-- このPRの目的や背景を簡潔に記載してください -->

まず、カテゴリ情報選択を実装してから（たぶん）テストがたまに落ちてしまう不具合が出ている。

いくつか警告文が出ていて、その対応をまず行う。

## 変更内容
<!-- 主な変更点や追加機能を箇条書きで記載してください -->
- カテゴリ情報の候補は描画時に取得するようにしているので、その取得読み込みを待つようにした
- `Select` コンポーネントが Uncontrolled なコンポーネントになっているので修正した

## 動作確認
<!-- 動作確認内容や手順、確認した環境などを記載してください -->
- [x] ローカルでの動作確認
- [x] テストの実行
- [ ] UIの確認（必要な場合）

## 関連Issue

None

## 補足
<!-- レビュー時に注意してほしい点や補足事項があれば記載してください -->

これでも `act()` を使えという警告文は消えない
