### PR TITLE
feat: グローバルなスナックバーを作成した

### DIFF
--- a/src/shared/snackbar/components/Snackbar/Snackbar.module.css
+++ b/src/shared/snackbar/components/Snackbar/Snackbar.module.css
@@ -1,0 +1,84 @@
+.toast-viewport {
+  --viewport-padding: var(--space-3);
+  position: fixed;
+  bottom: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  padding: var(--viewport-padding);
+  gap: var(--space-2);
+  width: 400px;
+  max-width: 100vw;
+  margin: 0;
+  list-style: none;
+  z-index: 2147483647;
+  outline: none;
+}
+
+.toast-root {
+  background-color: var(--accent-a3);
+  border-radius: var(--radius-4);
+  box-shadow:
+    hsl(206 22% 7% / 35%) 0px 10px 38px -10px,
+    hsl(206 22% 7% / 20%) 0px 10px 20px -15px;
+  padding: var(--space-4);
+  display: grid;
+  grid-template-areas: "description action";
+  grid-template-columns: auto max-content;
+  column-gap: var(--space-3);
+  align-items: center;
+}
+.toast-root[data-state="open"] {
+  animation: slideIn 150ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+.toast-root[data-state="closed"] {
+  animation: hide 100ms ease-in;
+}
+.toast-root[data-swipe="move"] {
+  transform: translateX(var(--radix-toast-swipe-move-x));
+}
+.toast-root[data-swipe="cancel"] {
+  transform: translateX(0);
+  transition: transform 200ms ease-out;
+}
+.toast-root[data-swipe="end"] {
+  animation: swipeOut 100ms ease-out;
+}
+
+@keyframes hide {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(calc(100% + var(--viewport-padding)));
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes swipeOut {
+  from {
+    transform: translateX(var(--radix-toast-swipe-end-x));
+  }
+  to {
+    transform: translateX(calc(100% + var(--viewport-padding)));
+  }
+}
+
+.toast-description {
+  grid-area: description;
+  margin: 0;
+  color: var(--accent-a11);
+  line-height: var(--line-height, var(--default-line-height));
+}
+
+.toast-action {
+  grid-area: action;
+}

--- a/src/shared/snackbar/components/Snackbar/Snackbar.stories.tsx
+++ b/src/shared/snackbar/components/Snackbar/Snackbar.stories.tsx
@@ -1,0 +1,57 @@
+import { Button } from "@radix-ui/themes"
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useCallback, useState } from "react"
+import { expect, fn, userEvent, within } from "storybook/test"
+import { Snackbar } from "./Snackbar"
+
+const meta = {
+  title: "Shared/Snackbar",
+  component: Snackbar,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {},
+  args: {
+    open: true,
+    onClose: fn(),
+  },
+  render: ({ onClose, ...args }) => {
+    const [open, setOpen] = useState(false)
+
+    const handleOpen = useCallback(() => {
+      setOpen(true)
+    }, [])
+
+    const handleClose = useCallback(() => {
+      setOpen(false)
+      onClose()
+    }, [onClose])
+
+    return (
+      <>
+        <Button onClick={handleOpen}>Open snackbar</Button>
+        <Snackbar {...args} open={open} onClose={handleClose} />
+      </>
+    )
+  },
+} satisfies Meta<typeof Snackbar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    message: "This is a message",
+    type: "info",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const button = canvas.getByRole("button", { name: "Open snackbar" })
+    await userEvent.click(button)
+
+    const body = within(canvasElement.ownerDocument.body)
+    const text = await body.findByText("This is a message")
+    expect(text).toBeInTheDocument()
+  },
+}

--- a/src/shared/snackbar/components/Snackbar/Snackbar.tsx
+++ b/src/shared/snackbar/components/Snackbar/Snackbar.tsx
@@ -1,0 +1,84 @@
+import { Cross1Icon } from "@radix-ui/react-icons"
+import { IconButton } from "@radix-ui/themes"
+import { Toast } from "radix-ui"
+import { type ReactNode, useCallback, useEffect, useRef } from "react"
+import styles from "./Snackbar.module.css"
+
+type SnackbarType = "info" | "success" | "warning" | "error"
+
+const accentColorMap = {
+  info: {
+    color: "white",
+  },
+  success: {
+    color: "green",
+  },
+  warning: {
+    color: "yellow",
+  },
+  error: {
+    color: "red",
+  },
+}
+
+type SnackbarProps = {
+  message: ReactNode
+  type?: SnackbarType
+  duration?: number
+  open: boolean
+  onClose: () => void
+}
+
+export function Snackbar({
+  message,
+  type = "info",
+  open,
+  duration = 3000,
+  onClose,
+}: SnackbarProps) {
+  const timerRef = useRef(0)
+
+  const handleToastAction = useCallback(() => {
+    window.clearTimeout(timerRef.current)
+    onClose()
+  }, [onClose])
+
+  useEffect(() => {
+    if (open) {
+      window.clearTimeout(timerRef.current)
+      timerRef.current = window.setTimeout(onClose, duration)
+    }
+    return () => clearTimeout(timerRef.current)
+  }, [open, duration, onClose])
+
+  return (
+    <Toast.Provider swipeDirection="right">
+      <Toast.Root
+        className={styles.toastRoot}
+        data-accent-color={accentColorMap[type].color}
+        open={open}
+      >
+        <Toast.Description className={styles.toastDescription}>
+          {message}
+        </Toast.Description>
+        <Toast.Action
+          asChild
+          className={styles.toastAction}
+          onClick={handleToastAction}
+          altText="Close this snackbar."
+        >
+          <CloseButton />
+        </Toast.Action>
+      </Toast.Root>
+      <Toast.Viewport className={styles.toastViewport} />
+    </Toast.Provider>
+  )
+}
+
+function CloseButton() {
+  return (
+    <IconButton size="2" radius="full" variant="soft">
+      <Cross1Icon />
+    </IconButton>
+  )
+}

--- a/src/shared/snackbar/components/Snackbar/index.ts
+++ b/src/shared/snackbar/components/Snackbar/index.ts
@@ -1,0 +1,1 @@
+export { Snackbar } from "./Snackbar"

--- a/src/shared/snackbar/context/SnackbarProvider.tsx
+++ b/src/shared/snackbar/context/SnackbarProvider.tsx
@@ -1,0 +1,61 @@
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useState,
+} from "react"
+import { Snackbar } from "../components/Snackbar"
+import type { OpenSnackbarFn, SnackbarState, SnackbarType } from "../types"
+
+// NOTE: 外部公開してはいけない
+const SnackbarContext = createContext<
+  { openSnackbar: OpenSnackbarFn } | undefined
+>(undefined)
+
+interface SnackbarProviderProps {
+  children: ReactNode
+}
+
+export function SnackbarProvider({ children }: SnackbarProviderProps) {
+  const [snackbarProps, setSnackbarProps] = useState<SnackbarState | null>(null)
+
+  const openSnackbar = useCallback(
+    (type: SnackbarType, message: string, duration?: number) => {
+      setSnackbarProps({
+        type: type,
+        message: message,
+        duration: duration,
+      })
+    },
+    [],
+  )
+
+  const closeSnackbar = useCallback(() => {
+    setSnackbarProps(null)
+  }, [])
+
+  return (
+    <SnackbarContext.Provider value={{ openSnackbar }}>
+      {children}
+      {snackbarProps && (
+        <Snackbar
+          type={snackbarProps.type}
+          open={!!snackbarProps}
+          message={snackbarProps.message}
+          duration={snackbarProps.duration}
+          onClose={closeSnackbar}
+        />
+      )}
+    </SnackbarContext.Provider>
+  )
+}
+
+// NOTE: `SnackbarContext` を公開したくないので `useSnackbar()` をここで定義している
+export function useSnackbar() {
+  const ctx = useContext(SnackbarContext)
+  if (!ctx) {
+    throw new Error("useSnackbarContext must be used within SnackbarProvider")
+  }
+  return ctx
+}

--- a/src/shared/snackbar/index.ts
+++ b/src/shared/snackbar/index.ts
@@ -1,0 +1,1 @@
+export { SnackbarProvider, useSnackbar } from "./context/SnackbarProvider"

--- a/src/shared/snackbar/types.ts
+++ b/src/shared/snackbar/types.ts
@@ -1,0 +1,13 @@
+export type SnackbarType = "success" | "error" | "info" | "warning"
+
+export type OpenSnackbarFn = (
+  type: SnackbarType,
+  message: string,
+  duration?: number,
+) => void
+
+export interface SnackbarState {
+  type: SnackbarType
+  message: string
+  duration?: number
+}


### PR DESCRIPTION
## 概要

グローバルで利用できるスナックバーを作成した。
これにより、各所でスナックバーを定義する必要もなく、開閉しているかどうかを確認しなくて良くなる。

## 変更内容
<!-- 主な変更点や追加機能を箇条書きで記載してください -->
- `SnackbarProvider` を作成し、ラップされたコンポーネントでスナックバーを利用可能にした

## 動作確認
<!-- 動作確認内容や手順、確認した環境などを記載してください -->
- [ ] ローカルでの動作確認
- [x] テストの実行
- [ ] UIの確認（必要な場合）

## 関連Issue
<!-- 関連するIssue番号があれば記載してください -->
#335 

## 補足
<!-- レビュー時に注意してほしい点や補足事項があれば記載してください -->
