### PR TITLE
fix: FirestoreのDB接続先をテスト時に指定するように修正した

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       VITE_FIREBASE_PROJECT_ID: "savings-test",
       VITE_FIRESTORE_EMULATOR_HOST: "localhost:8080",
       VITE_FIREBASE_AUTH_DOMAIN: "http://localhost:9099",
+      VITE_FIRESTORE_DATABASE_ID: "savings-test",
     },
     fakeTimers: {
       toFake: [


### PR DESCRIPTION
## 概要
<!-- このPRの目的や背景を簡潔に記載してください -->
FirestoreのDB接続先は環境変数で指定するように変更したため。Vitestの設定変更は漏れていた。

## 変更内容
<!-- 主な変更点や追加機能を箇条書きで記載してください -->
- Vitestの環境変数を渡すところでFirestoreのDB接続先を追記した
-

## 動作確認
<!-- 動作確認内容や手順、確認した環境などを記載してください -->
- [ ] ローカルでの動作確認
- [ ] テストの実行
- [ ] UIの確認（必要な場合）

## 関連Issue
<!-- 関連するIssue番号があれば記載してください -->

## 補足
<!-- レビュー時に注意してほしい点や補足事項があれば記載してください -->
