### PR TITLE
Firebase EmulatorのDockerイメージの修正

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ./docker/firebase/.firebaserc:/usr/src/app/firebaserc
       - ./docker/firebase/firebase.json:/usr/src/app/firebase.json
-      - ./docker/firebase/data:/tmp/emulator_data
+      - ./docker/firebase/data:/tmp/data
     ports:
       - 9099:9099 # Firebase Authentication
       - 8080:8080 # Cloud Firestore

--- a/docker/firebase/Dockerfile
+++ b/docker/firebase/Dockerfile
@@ -13,8 +13,11 @@ RUN npm install -g firebase-tools
 # Firebase Emulator の設定ファイルをコンテナにコピー
 COPY docker/firebase/.firebaserc docker/firebase/firebase.json ./
 
+# データインポートするためのディレクトリを作成する
+RUN mkdir -p /tmp/data/emulator_data
+
 # 必要なポートを公開
 EXPOSE 8080 9099 4400
 
 # Firebase Emulator を起動
-CMD ["firebase", "emulators:start", "--only", "firestore,auth", "--import", "/tmp/emulator_data/emulator_data"]
+CMD ["firebase", "emulators:start", "--only", "firestore,auth", "--import", "/tmp/data/emulator_data"]


### PR DESCRIPTION
## 概要
<!-- このPRの目的や背景を簡潔に記載してください -->
Firebaseのデータインポート先のディレクトリがないことでローカル以外が起動しなくなっていた。

https://github.com/kosnu/savings/actions/runs/16859817438

## 変更内容
<!-- 主な変更点や追加機能を箇条書きで記載してください -->
- ビルド時にインポート先のディレクトリを作成するようにした
- ディレクトリ名が重複していたのでわかりやすくするために変更した

## 動作確認
<!-- 動作確認内容や手順、確認した環境などを記載してください -->
- [x] ローカルでの動作確認
- [ ] テストの実行
- [ ] UIの確認（必要な場合）

## 関連Issue
<!-- 関連するIssue番号があれば記載してください -->

## 補足
<!-- レビュー時に注意してほしい点や補足事項があれば記載してください -->
