### PR TITLE
カテゴリ情報毎の支払い額をアコーディオンに閉じ込めた

### DIFF
--- a/apps/web/src/app/routes/PaymentsPage/PaymentPage.stories.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentPage.stories.tsx
@@ -53,6 +53,6 @@ export const Default: Story = {
     expect(await canvas.findAllByText("コンビニ")).toHaveLength(3)
     expect(await canvas.findByText("スーパー")).toBeInTheDocument()
     expect(await canvas.findByText("2025/06/02")).toBeInTheDocument()
-    expect(await canvas.findAllByText("￥4,000")).toHaveLength(3)
+    expect(await canvas.findAllByText("￥4,000")).toHaveLength(2)
   },
 }

--- a/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.stories.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.stories.tsx
@@ -43,7 +43,7 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    expect(await canvas.findByText("Expenditures")).toBeInTheDocument()
+    expect(await canvas.findByText("Total spending")).toBeInTheDocument()
     expect(await canvas.findByText("￥4,000")).toBeInTheDocument()
   },
 }

--- a/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.tsx
@@ -9,7 +9,7 @@ function MonthlyTotals() {
 
   return (
     <Flex gap="1" direction="column">
-      <Text>Expenditures</Text>
+      <Text>Total spending</Text>
       <ErrorBoundary
         fallback={<Text color="red">An unexpected error has occurred.</Text>}
       >

--- a/apps/web/src/features/summaryByMonth/Summary/Summary.stories.tsx
+++ b/apps/web/src/features/summaryByMonth/Summary/Summary.stories.tsx
@@ -52,11 +52,17 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, userEvent }) => {
     const canvas = within(canvasElement)
 
-    expect(await canvas.findByText("Expenditures")).toBeInTheDocument()
+    expect(await canvas.findByText("Total spending")).toBeInTheDocument()
     expect(await canvas.findByText("￥5,000")).toBeInTheDocument()
+
+    const accordionTrigger = canvas.getByRole("button", {
+      name: /by category/i,
+    })
+    expect(accordionTrigger).toBeInTheDocument()
+    await userEvent.click(accordionTrigger)
 
     for (const category of Object.values(categories)) {
       expect(await canvas.findByText(category.name)).toBeInTheDocument()

--- a/apps/web/src/features/summaryByMonth/Summary/Summary.tsx
+++ b/apps/web/src/features/summaryByMonth/Summary/Summary.tsx
@@ -1,13 +1,28 @@
 import { Card, Flex } from "@radix-ui/themes"
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "../../../components/misc/Accordion"
 import { CategoryTotals } from "../CategoryTotals"
 import { MonthlyTotals } from "../MonthlyTotals"
 
 export function Summary() {
   return (
     <Card size="2">
-      <Flex gap="3" direction="column" width="100%">
+      <Flex gap="1" direction="column" width="100%">
         <MonthlyTotals />
-        <CategoryTotals />
+        <Accordion type="single" collapsible>
+          <AccordionItem value="item-1">
+            <AccordionTrigger style={{ padding: 0 }}>
+              Spending by Category
+            </AccordionTrigger>
+            <AccordionContent>
+              <CategoryTotals />
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       </Flex>
     </Card>
   )


### PR DESCRIPTION
Why: スマホ画面だと半分くらい表示領域が占有されてしまうため

## 関連Issue

<!-- 関連するIssue番号を記載してください (例: #123) -->

#598 

## 変更内容

<!-- このPRで行った変更の概要と、具体的な変更点を箇条書きで記載してください。 -->

- カテゴリ情報毎の支払い額を初回非表示にするようにした

## 動作確認

<!-- 動作確認内容や手順、確認した環境などを記載してください -->

- [x] ローカルでの動作確認
- [x] テストの実行
- [x] UIの確認（スクリーンショット等）

<img width="787" height="222" alt="スクリーンショット 2025-09-15 17 40 34" src="https://github.com/user-attachments/assets/7715028c-b788-4d74-8c5e-bbacc16ffab1" />

## 補足

<!-- レビュー時に特に見てほしい点や、その他補足事項があれば記載してください -->
