### PR TITLE
月合計支払い額のUI変更

### DIFF
--- a/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.tsx
@@ -9,7 +9,9 @@ function MonthlyTotals() {
 
   return (
     <Flex gap="1" direction="column">
-      <Text>Total spending</Text>
+      <Text size="3" color="gray">
+        Total spending
+      </Text>
       <ErrorBoundary
         fallback={<Text color="red">An unexpected error has occurred.</Text>}
       >
@@ -30,7 +32,7 @@ const MoneyText = memo(function MoneyText({
   const text = data === null ? "-" : toCurrency(data)
 
   return (
-    <Text weight="bold" size="5">
+    <Text align="right" size="6" weight="bold">
       {text}
     </Text>
   )


### PR DESCRIPTION
Why: 他のカードと同じく金額を右詰にした

## 関連Issue

<!-- 関連するIssue番号を記載してください (例: #123) -->

## 変更内容

<!-- このPRで行った変更の概要と、具体的な変更点を箇条書きで記載してください。 -->

- 月合計支払い額を右詰にした

## 動作確認

<!-- 動作確認内容や手順、確認した環境などを記載してください -->

- [x] ローカルでの動作確認
- [ ] テストの実行
- [x] UIの確認（スクリーンショット等）

| Before | After |
|--------|--------|
| <img width="424" height="147" alt="スクリーンショット 2025-09-15 19 56 14" src="https://github.com/user-attachments/assets/7ed84a9e-0483-4dec-abb2-83310afa33fa" /> | <img width="420" height="147" alt="スクリーンショット 2025-09-15 19 56 01" src="https://github.com/user-attachments/assets/e3c380c4-a69c-4184-84c1-1315e8d22e28" /> | 

## 補足

<!-- レビュー時に特に見てほしい点や、その他補足事項があれば記載してください -->
