### PR TITLE
chore(web): VSCodeタスクのpath設定を整理

### DIFF
--- a/apps/web/.vscode/tasks.json
+++ b/apps/web/.vscode/tasks.json
@@ -7,7 +7,6 @@
       "label": "dev: web",
       "type": "npm",
       "script": "dev",
-      "path": "apps/web/",
       "problemMatcher": [],
       "detail": "vite"
     },


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- `apps/web/.vscode/tasks.json` の `dev: web` タスクから `path` 指定を削除
- VSCode タスク実行時のワークスペース設定をシンプル化

## 動作確認

- [x] ローカルでの動作確認
- [ ] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

- 事前に `apps/web` の既存チェックを実行し、成功を確認済みです。
