### PR TITLE
#902 支払い情報作成の継続チェックを確定行に配置

### DIFF
--- a/apps/web/src/features/payments/createPayment/ContinueCreatingCheckbox/ContinueCreatingCheckbox.tsx
+++ b/apps/web/src/features/payments/createPayment/ContinueCreatingCheckbox/ContinueCreatingCheckbox.tsx
@@ -1,0 +1,29 @@
+import { Checkbox, Flex, Text } from "@radix-ui/themes"
+import { useId } from "react"
+
+interface ContinueCreatingCheckboxProps {
+  checked: boolean
+  onCheckedChange: (checked: boolean) => void
+}
+
+export function ContinueCreatingCheckbox({
+  checked,
+  onCheckedChange,
+}: ContinueCreatingCheckboxProps) {
+  const checkboxId = useId()
+
+  return (
+    <Text as="label" size="2" htmlFor={checkboxId}>
+      <Flex gap="2" align="center">
+        <Checkbox
+          id={checkboxId}
+          checked={checked}
+          onCheckedChange={(nextChecked) =>
+            onCheckedChange(nextChecked === true)
+          }
+        />
+        Continue creating
+      </Flex>
+    </Text>
+  )
+}

--- a/apps/web/src/features/payments/createPayment/ContinueCreatingCheckbox/index.ts
+++ b/apps/web/src/features/payments/createPayment/ContinueCreatingCheckbox/index.ts
@@ -1,0 +1,1 @@
+export { ContinueCreatingCheckbox } from "./ContinueCreatingCheckbox"

--- a/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.tsx
+++ b/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.tsx
@@ -5,6 +5,7 @@ import { CancelButton } from "../../../../components/buttons/CancelButton"
 import { SubmitButton } from "../../../../components/buttons/SubmitButton"
 import { AmountField } from "../AmountField/AmountField"
 import { CategoryField } from "../CategoryField"
+import { ContinueCreatingCheckbox } from "../ContinueCreatingCheckbox"
 import { type FormSchema, submitFormSchema } from "../formSchema"
 import { NoteField } from "../NoteField"
 import { PaymentDateField } from "../PaymentDateField"
@@ -15,6 +16,8 @@ interface CreatePaymentFormProps {
   onError?: (error?: Error) => void
   onCancel: () => void
   onResetReady?: (resetFn: () => void) => void
+  continuousMode?: boolean
+  onContinuousModeChange?: (checked: boolean) => void
 }
 
 function getErrorMessages(errors: unknown): string[] | undefined {
@@ -51,6 +54,8 @@ export function CreatePaymentForm({
   onError,
   onCancel,
   onResetReady,
+  continuousMode,
+  onContinuousModeChange,
 }: CreatePaymentFormProps) {
   const { createPayment } = useCreatePayment(onSuccess, onError)
 
@@ -156,9 +161,22 @@ export function CreatePaymentForm({
           }}
         </form.Field>
       </Flex>
-      <Flex gap="3" mt="4" justify="end">
-        <CancelButton onClick={handleCancel} />
-        <SubmitButton>Create</SubmitButton>
+      <Flex
+        mt="4"
+        gap="3"
+        align="center"
+        justify={onContinuousModeChange ? "between" : "end"}
+      >
+        {onContinuousModeChange ? (
+          <ContinueCreatingCheckbox
+            checked={continuousMode ?? false}
+            onCheckedChange={onContinuousModeChange}
+          />
+        ) : null}
+        <Flex gap="3">
+          <CancelButton onClick={handleCancel} />
+          <SubmitButton>Create</SubmitButton>
+        </Flex>
       </Flex>
     </form>
   )

--- a/apps/web/src/features/payments/createPayment/CreatePaymentModal/CreatePaymentModal.tsx
+++ b/apps/web/src/features/payments/createPayment/CreatePaymentModal/CreatePaymentModal.tsx
@@ -1,5 +1,5 @@
-import { Button, Checkbox, Dialog, Flex, Text } from "@radix-ui/themes"
-import { useCallback, useId, useRef, useState } from "react"
+import { Button, Dialog } from "@radix-ui/themes"
+import { useCallback, useRef, useState } from "react"
 import { useDialog } from "../../../../utils/useDialog"
 import { CreatePaymentForm } from "../CreatePaymentForm"
 
@@ -9,7 +9,6 @@ interface CreatePaymentModalProps {
 
 export function CreatePaymentModal({ onSuccess }: CreatePaymentModalProps) {
   const { open, openDialog, closeDialog } = useDialog()
-  const checkboxId = useId()
   const [continuousMode, setContinuousMode] = useState(false)
   const formResetRef = useRef<(() => void) | null>(null)
 
@@ -50,21 +49,9 @@ export function CreatePaymentModal({ onSuccess }: CreatePaymentModalProps) {
           onError={handleError}
           onCancel={handleCancel}
           onResetReady={handleResetReady}
+          continuousMode={continuousMode}
+          onContinuousModeChange={setContinuousMode}
         />
-        <Flex gap="3" mt="3" justify="start">
-          <Text as="label" size="2" htmlFor={checkboxId}>
-            <Flex gap="2" align="center">
-              <Checkbox
-                id={checkboxId}
-                checked={continuousMode}
-                onCheckedChange={(checked) =>
-                  setContinuousMode(checked === true)
-                }
-              />
-              Continue creating
-            </Flex>
-          </Text>
-        </Flex>
       </Dialog.Content>
     </Dialog.Root>
   )


### PR DESCRIPTION
## 関連Issue

- #902

## 変更内容

- `ContinueCreatingCheckbox` コンポーネントを新規作成し、チェックボックスUIを切り出し
- `CreatePaymentModal` からチェックボックス描画を削除し、`continuousMode` の state 管理のみを担当するよう整理
- `CreatePaymentForm` に `continuousMode` / `onContinuousModeChange` を受け取る props を追加し、Cancel/Create ボタンと同じ行にチェックボックスを表示
- チェック状態は tanstack/form に載せず、モーダル側 state で継続管理する構成を維持

## 動作確認

- [x] ローカルでの動作確認
  - モーダル表示時にチェックボックスが確定ボタン行に表示されること
  - チェックONで確定後にフォームがリセットされ、チェック状態が保持されること
- [x] テストの実行
  - `cd apps/web && npm run check`
  - `cd apps/web && npm run test -- CreatePaymentForm.test.tsx`
  - `cd apps/web && npm run build`
- [x] UIの確認（スクリーンショット等）
  - Storybook既存シナリオ（`ContinuousCreationEnabled` / `ContinuousCreationDisabled`）の想定に沿うUI配置へ変更

## 補足

- 既存の成功時挙動（継続OFF時はモーダルを閉じる、継続ON時はフォームをreset）は変更していません。
