### PR TITLE
chore: コミットスキルのトークン使用量を最適化

### DIFF
--- a/.claude/skills/committing-changes/SKILL.md
+++ b/.claude/skills/committing-changes/SKILL.md
@@ -9,14 +9,15 @@ model: claude-sonnet-4-5
 
 ## 手順
 
-1. `git status` と `git diff` で変更状況を把握する
+1. `git status` と `git diff --stat` で変更状況を把握する（`git diff` でフル差分を出さない。変更内容は自分が把握済み）
 2. 変更が入ったワークスペースの検証を実行する:
    - `apps/web/`: `task check` → `task test`
    - `apps/api/`: 該当function ディレクトリで `deno test --allow-read --allow-env`
    - 検証失敗時はコミットしない
+   - 直前にテスト・lint実行済みの場合はスキップしてよい
 3. ファイル単位でステージングする（`git add -A` は意図した差分のみと確認できた場合に限る）
 4. 観点ごと（機能追加、バグ修正、リファクタリング等）にコミットを分割する
-5. `git diff --staged` でタスク目的との一致を確認する
+5. `git diff --staged --stat` でタスク目的との一致を確認する
 6. コミットメッセージ案をユーザーに提示し、承認を得てからコミットする
 7. コミット後、`git log --oneline -1` と `git show --stat HEAD` で結果を確認する
 


### PR DESCRIPTION
## 関連Issue

なし（内部改善）

## 変更内容

コミットスキル（`/committing-changes`）実行時のトークン使用量を削減した。

- `git diff` → `git diff --stat` に変更（フル差分を出さず、変更サマリーのみ表示）
- 直前にテスト・lint実行済みの場合はスキップ可能と明記
- `git diff --staged` → `git diff --staged --stat` に変更

## 動作確認

- [x] 本PRのコミット作成で動作確認済み

## 補足

実測で新規ファイル作成時に647行のフル差分が出力されていたケースを削減。