### PR TITLE
chore: SupabaseとCloudflare Pagesへのデプロイワークフローを追加

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,11 +16,15 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   # --- Backend (Supabase Edge Functions) のデプロイ ---
   deploy-api:
     if: ${{ !github.event.inputs.skip_api }} # skip_api が true の場合はこのジョブをスキップ
     runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -45,9 +49,10 @@ jobs:
 
   # --- Frontend (React + Vite) のデプロイ ---
   deploy-web:
-    if: ${{ !github.event.inputs.skip_web }} # skip_web が true の場合はこのジョブをスキップ
+    if: ${{ !github.event.inputs.skip_web && (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') }}
     needs: deploy-api
     runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## 関連Issue

#961

## 変更内容

SupabaseとCloudflare Pagesへの自動デプロイワークフローを追加しました。

- `.github/workflows/deploy.yaml` を新規作成
  - Supabase Edge FunctionsとCloudflare Pagesへデプロイする設定を追加

## 動作確認

- [x] ワークフローファイルの構文確認
- [ ] 実際のデプロイ動作確認（mainブランチマージ後）

## 補足

初回のワークフロー追加のため、実際のデプロイ動作はmainブランチマージ後に確認する必要があります。
必要なシークレット（SUPABASE_ACCESS_TOKEN, CLOUDFLARE_API_TOKEN等）が設定されているか確認してください。