### PR TITLE
feat: Supabase Edge FunctionsにCORS対応を追加する

### DIFF
--- a/apps/api/supabase/functions/categories/src/interfaces/server.ts
+++ b/apps/api/supabase/functions/categories/src/interfaces/server.ts
@@ -1,4 +1,5 @@
 import { Hono } from "@hono/hono"
+import { cors } from "@hono/hono/cors"
 import type { SupabaseClient } from "@supabase/supabase-js"
 import { registerCategoriesRoutes } from "./routes/index.ts"
 import type { Database } from "../shared/types.ts"
@@ -14,6 +15,15 @@ type ServerDeps = {
 
 export const createServer = (deps: ServerDeps) => {
   const app = new Hono<{ Variables: Vars }>()
+
+  app.use(
+    "*",
+    cors({
+      origin: ["https://savingsv2.kosnu.dev", "http://localhost:5173"],
+      allowHeaders: ["Authorization", "Content-Type"],
+      allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    }),
+  )
 
   app.use("*", async (c, next) => {
     c.set("supabase", deps.supabaseFactory(c.req.raw))

--- a/apps/api/supabase/functions/import_map.json
+++ b/apps/api/supabase/functions/import_map.json
@@ -5,6 +5,7 @@
     "@supabase/functions-js/edge-runtime": "jsr:@supabase/functions-js@2.5.0/edge-runtime.d.ts",
     "@supabase/supabase-js": "jsr:@supabase/supabase-js@2.58.0",
     "@hono/hono": "jsr:@hono/hono@4.10.6",
+    "@hono/hono/cors": "jsr:@hono/hono@4.10.6/cors",
     "@hono/hono/factory": "jsr:@hono/hono@4.10.6/factory",
     "@zod/zod": "jsr:@zod/zod@^4.3.6",
     "jose": "jsr:@panva/jose@6"

--- a/apps/api/supabase/functions/payments/src/interfaces/server.ts
+++ b/apps/api/supabase/functions/payments/src/interfaces/server.ts
@@ -1,4 +1,5 @@
 import { Hono } from "@hono/hono"
+import { cors } from "@hono/hono/cors"
 import type { SupabaseClient } from "@supabase/supabase-js"
 import { registerPaymentsRoutes } from "./routes/index.ts"
 import type { Database } from "../shared/types.ts"
@@ -14,6 +15,15 @@ type ServerDeps = {
 
 export const createServer = (deps: ServerDeps) => {
   const app = new Hono<{ Variables: Vars }>()
+
+  app.use(
+    "*",
+    cors({
+      origin: ["https://savingsv2.kosnu.dev", "http://localhost:5173"],
+      allowHeaders: ["Authorization", "Content-Type"],
+      allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    }),
+  )
 
   app.use("*", async (c, next) => {
     c.set("supabase", deps.supabaseFactory(c.req.raw))


### PR DESCRIPTION
## 関連Issue

Close #964

## 変更内容

Supabase Edge Functions（payments, categories）にHonoのCORSミドルウェアを追加し、本番環境（`https://savingsv2.kosnu.dev`）からのクロスオリジンリクエストに対応した。

- `import_map.json` に `@hono/hono/cors` を追加
- `payments/src/interfaces/server.ts` にCORSミドルウェアを適用（認証より前に配置）
- `categories/src/interfaces/server.ts` にCORSミドルウェアを適用（認証より前に配置）

**CORS設定内容：**
- 許可Origin: `https://savingsv2.kosnu.dev`, `http://localhost:5173`
- 許可Headers: `Authorization`, `Content-Type`
- 許可Methods: `GET`, `POST`, `PUT`, `DELETE`, `OPTIONS`

## 動作確認

- [x] テストの実行（payments: 87テスト全パス、categories: 19テスト全パス）
- [x] ローカルでの動作確認
- [ ] 本番環境での動作確認

## 補足

CORSミドルウェアはSupabaseクライアント設定・認証ミドルウェアより前に配置しているため、OPTIONSプリフライトリクエストが認証チェックに引っかからずに正しく処理されます。