### PR TITLE
fix: deploy workflowのskip条件を修正

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   # --- Backend (Supabase Edge Functions) のデプロイ ---
   deploy-api:
-    if: ${{ !github.event.inputs.skip_api }} # skip_api が true の場合はこのジョブをスキップ
+    if: ${{ github.event.inputs.skip_api != 'true' }} # skip_api が true の場合はこのジョブをスキップ
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment }}
     steps:
@@ -49,7 +49,7 @@ jobs:
 
   # --- Frontend (React + Vite) のデプロイ ---
   deploy-web:
-    if: ${{ !github.event.inputs.skip_web && (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') }}
+    if: ${{ github.event.inputs.skip_web != 'true' && (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') }}
     needs: deploy-api
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment }}


### PR DESCRIPTION
## 関連Issue

なし（軽微な修正）

## 変更内容

deploy workflowのskip条件を修正しました。

- `if: !github.event.inputs.skip_api` を `if: github.event.inputs.skip_api != 'true'` に変更
- `if: !github.event.inputs.skip_web && ...` を `if: github.event.inputs.skip_web != 'true' && ...` に変更

## 動作確認

- [x] ワークフロー構文の確認（yamlファイルの編集のみ）
- [ ] ローカルでの動作確認（GitHub Actionsのため不要）
- [ ] テストの実行（ワークフロー変更のため不要）
- [ ] UIの確認（ワークフロー変更のため不要）

## 補足

### 問題の原因
GitHub Actionsの `workflow_dispatch` inputs は `type: boolean` でも**文字列**として渡されます。そのため、`skip_api: false` を指定すると値は文字列 `'false'` になります。

`!'false'` は「非空文字列の否定」となり `false` と評価されるため、skip未指定でもジョブがスキップされていました。

### 修正内容
文字列 `'true'` との明示的な比較に変更することで、boolean inputsを正しく扱えるようになりました。