### PR TITLE
fix: supabase link時にconfig.tomlのenv()参照用の環境変数を渡す

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,6 +27,12 @@ jobs:
     environment: ${{ github.event.inputs.environment }}
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      AUTH_SITE_URL: ${{ secrets.AUTH_SITE_URL }}
+      AUTH_REDIRECT_URL: ${{ secrets.AUTH_REDIRECT_URL }}
+      SUPABASE_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_GOOGLE_CLIENT_ID }}
+      SUPABASE_GOOGLE_CLIENT_SECRET: ${{ secrets.SUPABASE_GOOGLE_CLIENT_SECRET }}
+      SUPABASE_GOOGLE_REDIRECT_URL: ${{ secrets.SUPABASE_GOOGLE_REDIRECT_URL }}
+      SUPABASE_GOOGLE_SKIP_NONCE_CHECK: ${{ secrets.SUPABASE_GOOGLE_SKIP_NONCE_CHECK }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -39,13 +45,6 @@ jobs:
       - name: Link Supabase Project
         run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_ID }}
         working-directory: apps/api
-        env:
-          AUTH_SITE_URL: ${{ secrets.AUTH_SITE_URL }}
-          AUTH_REDIRECT_URL: ${{ secrets.AUTH_REDIRECT_URL }}
-          SUPABASE_GOOGLE_CLIENT_ID: ${{ secrets.SUPABASE_GOOGLE_CLIENT_ID }}
-          SUPABASE_GOOGLE_CLIENT_SECRET: ${{ secrets.SUPABASE_GOOGLE_CLIENT_SECRET }}
-          SUPABASE_GOOGLE_REDIRECT_URL: ${{ secrets.SUPABASE_GOOGLE_REDIRECT_URL }}
-          SUPABASE_GOOGLE_SKIP_NONCE_CHECK: ${{ secrets.SUPABASE_GOOGLE_SKIP_NONCE_CHECK }}
 
       - name: Push Database Migrations
         run: supabase db push


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

`supabase link` 実行時に `config.toml` の `env()` 参照が解決できずエラーになる問題を修正しました。

- `.github/workflows/deploy.yaml` の Link Supabase Project ステップに環境変数を追加
  - `AUTH_SITE_URL`
  - `AUTH_REDIRECT_URL`
  - `SUPABASE_GOOGLE_CLIENT_ID`
  - `SUPABASE_GOOGLE_CLIENT_SECRET`
  - `SUPABASE_GOOGLE_REDIRECT_URL`
  - `SUPABASE_GOOGLE_SKIP_NONCE_CHECK`

## 動作確認

- [ ] ローカルでの動作確認
- [ ] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

`config.toml` の `env()` は Supabase CLI 実行時の OS 環境変数から解決されるため、GitHub Actions の Secrets として環境変数を渡す必要があります。デプロイ前に該当する Secrets をリポジトリに登録してください。