### PR TITLE
feat: Supabase Edge Functionを東京リージョンにデプロイ

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -51,7 +51,7 @@ jobs:
         working-directory: apps/api
 
       - name: Deploy Edge Functions
-        run: supabase functions deploy
+        run: supabase functions deploy --region ap-northeast-1
         working-directory: apps/api
 
   # --- Frontend (React + Vite) のデプロイ ---


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

Supabase Edge Functionのデプロイ先リージョンを東京（ap-northeast-1）に指定しました。

- `.github/workflows/deploy.yaml`の`supabase functions deploy`コマンドに`--region ap-northeast-1`フラグを追加

## 動作確認

- [ ] ローカルでの動作確認
- [ ] テストの実行
- [ ] UIの確認（スクリーンショット等）

※ CI/CD設定の変更のため、次回デプロイ実行時にリージョンが反映されることを確認予定

## 補足

次回のデプロイワークフロー実行時に、Edge Functionが東京リージョンで起動されます。既存のデプロイ済みFunctionは次回デプロイ時に自動的に移行されます。