### PR TITLE
fix: 日付パラメータがない場合にpaymentsのフェッチを抑制

### DIFF
--- a/apps/web/src/features/payments/listPayment/usePayments.ts
+++ b/apps/web/src/features/payments/listPayment/usePayments.ts
@@ -15,6 +15,7 @@ export function usePayments(): UseGetPaymentsReturn {
   const query = useQuery({
     queryKey: ["payments", date?.toISOString() ?? "all"],
     queryFn: () => fetchPayments(dateRange),
+    enabled: date !== null,
     staleTime: 3000, // 3秒
   })
 


### PR DESCRIPTION
## Summary

- `/payments` ページでURLに `year`/`month` パラメータがない場合、不要なAPIリクエストが発行されていた問題を修正
- `useQuery` に `enabled: date !== null` を追加し、日付がある場合のみフェッチを実行するように変更

## Test plan

- [x] `task check` パス
- [x] `task test` パス（43ファイル、132テスト通過）

Closes #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)