### PR TITLE
Supabaseクライアントにリクエストの認証ヘッダーを転送

### DIFF
--- a/apps/api/supabase/functions/payments/src/interfaces/server.ts
+++ b/apps/api/supabase/functions/payments/src/interfaces/server.ts
@@ -42,6 +42,11 @@ export const createServer = () => {
       "supabase",
       createClient<Database>(supabaseUrl, supabaseKey, {
         auth: { persistSession: false },
+        global: {
+          headers: {
+            Authorization: c.req.raw.headers.get("Authorization") ?? "",
+          },
+        },
       }),
     )
     await next()


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

リクエストの Authorization ヘッダーを Supabase クライアントに転送するよう設定を追加しました。

- `apps/api/supabase/functions/payments/src/interfaces/server.ts` で Supabase クライアント作成時に `global.headers.Authorization` を設定
- リクエストヘッダーから Authorization を取得し、Supabase への API 呼び出しに転送

## 動作確認

- [x] ローカルでの動作確認
- [x] テストの実行（89 passed）
- [ ] UIの確認（スクリーンショット等）

## 補足

API側の変更のため、UIの確認は不要です。