### PR TITLE
chore: スキルの確認ステップ削除とモデル指定を更新

### DIFF
--- a/.claude/skills/committing-changes/SKILL.md
+++ b/.claude/skills/committing-changes/SKILL.md
@@ -2,7 +2,7 @@
 name: committing-changes
 description: Stages and commits changes with workspace-specific verification and Japanese commit messages. Use when the user asks to commit, stage changes, or says "コミットして".
 disable-model-invocation: true
-model: claude-sonnet-4-5
+model: sonnet
 ---
 
 # Commit Changes
@@ -17,7 +17,8 @@ model: claude-sonnet-4-5
 3. Stage files individually (`git add -A` only when all changes are confirmed intentional)
 4. Split commits by concern (feature, bugfix, refactor, etc.)
 5. Run `git diff --staged --stat` to verify staged changes match the task goal
-6. Present commit message to user for approval before committing
+6. Commit without asking for approval
+7. Show result with `git log -1 --pretty=format:"%h: %s"`
 
 ## Commit Message Format
 
@@ -34,7 +35,6 @@ Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`
 ## Rules
 
 - Do not include unrelated changes
-- Always get user approval on the commit message
 
 ## Next Action
 

--- a/.claude/skills/creating-branch/SKILL.md
+++ b/.claude/skills/creating-branch/SKILL.md
@@ -2,7 +2,7 @@
 name: creating-branch
 description: Creates a feature branch from a GitHub issue number. Use when the user asks to create a branch, start working on an issue, or says "ブランチを切って".
 disable-model-invocation: true
-model: claude-sonnet-4-5
+model: sonnet
 argument-hint: "[issue-number]"
 ---
 
@@ -12,16 +12,11 @@ argument-hint: "[issue-number]"
 
 1. Run `gh issue view $ARGUMENTS` to get the issue title and content
 2. Generate a short English slug from the issue title (lowercase, hyphen-separated, 2-4 words)
-3. Present branch name `issue-{number}/{slug}` to user for confirmation
-4. Create the branch from latest main:
+3. Create the branch from latest main without asking for confirmation:
    ```bash
    git fetch origin main
    git switch -c issue-{number}/{slug} origin/main
    ```
-
-## Rules
-
-- Always get user confirmation before creating the branch
 
 ## Next Action
 

--- a/.claude/skills/creating-draft-pr/SKILL.md
+++ b/.claude/skills/creating-draft-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: creating-draft-pr
 description: Creates a Draft Pull Request using the repository's PR template. Use when the user asks to create a PR, draft PR, or says "PRを作って".
 disable-model-invocation: true
-model: claude-sonnet-4-5
+model: sonnet
 argument-hint: "[issue-number]"
 ---
 
@@ -17,13 +17,11 @@ argument-hint: "[issue-number]"
    - Describe changes based on actual diffs
    - Only check off verified items (never mark unverified as done)
    - Add review points in notes section
-4. Present PR body to user for approval before creating
-5. Create with `gh pr create --draft`
-6. Verify title, body, branch, and issue link after creation
+4. Create with `gh pr create --draft` without asking for approval
+5. Verify title, body, branch, and issue link after creation
 
 ## Rules
 
 - Default to Draft (only mark Ready for Review when explicitly requested)
 - Keep all template headings intact
 - No empty fields or placeholder text
-- Always get user approval on the PR body


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- `committing-changes`、`creating-branch`、`creating-draft-pr` の各スキルからユーザー承認ステップを削除し、自動実行に変更
- モデル指定を `claude-sonnet-4-5` から `sonnet` に統一
- `committing-changes` コミット後に `git log -1 --pretty=format:"%h: %s"` で結果を表示するよう変更

## 動作確認

- [x] ローカルでの動作確認
- [ ] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

スキルファイルのみの変更のため、アプリケーションへの影響はなし。