### PR TITLE
feat: RLSポリシーを追加する

### DIFF
--- a/apps/api/supabase/migrations/20260304141154_add_rls_policies.sql
+++ b/apps/api/supabase/migrations/20260304141154_add_rls_policies.sql
@@ -22,7 +22,8 @@ create policy "Users can insert own payments"
 create policy "Users can update own payments"
   on payments for update
   to authenticated
-  using (user_id in (select id from users where external_id = auth.uid()::text));
+  using (user_id in (select id from users where external_id = auth.uid()::text))
+  with check (user_id in (select id from users where external_id = auth.uid()::text));
 
 create policy "Users can delete own payments"
   on payments for delete


### PR DESCRIPTION
## 関連Issue

#1010

## 変更内容

RLS有効化後に `User not found for the given external_id` エラーが発生していた問題を修正する。
RLSが有効でポリシーが存在しない場合、Supabaseはデフォルトで全行アクセスを拒否するため、各テーブルにRLSポリシーを追加した。

- `users` テーブルに RLS を有効化し、認証ユーザーが自分の行のみ読み取れるポリシーを追加した（`external_id = auth.uid()::text`）
- `payments` テーブルに RLS を有効化し、認証ユーザーが自分の支払いのみ SELECT / INSERT / UPDATE / DELETE できるポリシーを追加した
- `categories` テーブルに RLS を有効化し、全 `authenticated` ユーザーが読み取れるポリシーを追加した

## 動作確認

- [ ] ローカルでの動作確認
- [x] テストの実行（`task api:verify && task api:test` — payments 93件・categories 26件 全通過）
- [ ] UIの確認（スクリーンショット等）

## 補足

- `get_monthly_total_amount` 関数はデフォルトの `SECURITY INVOKER` のままで問題ない。関数内の WHERE 句が `auth.uid()` でフィルタしており、追加したRLSポリシーと整合する
- `payments` のポリシーはサブクエリで `users` テーブルを参照している（`user_id in (select id from users where external_id = auth.uid()::text)`）