### PR TITLE
カテゴリ取得時の並び順を固定化し、nullチェックを追加

### DIFF
--- a/apps/web/src/features/categories/listCategory/fetchCategories.ts
+++ b/apps/web/src/features/categories/listCategory/fetchCategories.ts
@@ -12,11 +12,14 @@ function toCategoryFromRow(row: CategoryRow): Category {
 
 export async function fetchCategories(): Promise<Category[]> {
   const supabase = getSupabaseClient()
-  const { data, error } = await supabase.from("categories").select("*")
+  const { data, error } = await supabase
+    .from("categories")
+    .select("*")
+    .order("id", { ascending: true })
 
   if (error) {
     throw error
   }
 
-  return data.map(toCategoryFromRow)
+  return (data ?? []).map(toCategoryFromRow)
 }


### PR DESCRIPTION
## 関連Issue

<!-- 関連するIssue番号を記載してください (例: #123) -->

## 変更内容

- `fetchCategories()`でカテゴリ取得時に`id`の昇順でソートするよう`.order()`を追加
- Supabaseからのレスポンスがnullの場合に対応するため、`data ?? []`でnullチェックを実装
- クエリビルダーの可読性向上のため、メソッドチェーンを複数行に分割

## 動作確認

- [ ] ローカルでの動作確認
- [ ] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

カテゴリ一覧の表示順序が一貫性を持つようになり、エッジケース（nullレスポンス）への対応も強化されました。

https://claude.ai/code/session_01VccitR923pqjpWrooGLF5f