### PR TITLE
feat: 支払い一覧の年月選択フィールドの順序を年→月に変更

### DIFF
--- a/apps/web/src/components/inputs/MonthPicker/MonthPicker.test.tsx
+++ b/apps/web/src/components/inputs/MonthPicker/MonthPicker.test.tsx
@@ -36,7 +36,7 @@ describe("MonthPicker", () => {
     renderWithTheme(<MonthPicker value={initialDate} onChange={handleChange} />)
 
     // 月のボタンをクリック
-    const monthButton = screen.getAllByRole("combobox")[0]
+    const monthButton = screen.getAllByRole("combobox")[1]
     await user.click(monthButton)
 
     // 6月を選択
@@ -58,7 +58,7 @@ describe("MonthPicker", () => {
     renderWithTheme(<MonthPicker value={initialDate} onChange={handleChange} />)
 
     // 年のボタンをクリック
-    const yearButton = screen.getAllByRole("combobox")[1]
+    const yearButton = screen.getAllByRole("combobox")[0]
     await user.click(yearButton)
 
     // 2026年を選択
@@ -75,14 +75,14 @@ describe("MonthPicker", () => {
   test("id属性が正しく設定される", () => {
     renderWithTheme(<MonthPicker id="month-picker" />)
 
-    const monthButton = screen.getAllByRole("combobox")[0]
-    expect(monthButton).toHaveAttribute("id", "month-picker")
+    const yearButton = screen.getAllByRole("combobox")[0]
+    expect(yearButton).toHaveAttribute("id", "month-picker")
   })
 
   test("name属性が正しく設定される", () => {
     renderWithTheme(<MonthPicker name="month" />)
 
-    const monthButton = screen.getAllByRole("combobox")[0]
-    expect(monthButton).toHaveAttribute("name", "month")
+    const yearButton = screen.getAllByRole("combobox")[0]
+    expect(yearButton).toHaveAttribute("name", "month")
   })
 })

--- a/apps/web/src/components/inputs/MonthPicker/MonthPicker.tsx
+++ b/apps/web/src/components/inputs/MonthPicker/MonthPicker.tsx
@@ -62,23 +62,23 @@ export function MonthPicker(props: MonthPickerProps) {
 
   return (
     <Flex gap="2" align="center">
-      <Select.Root value={currentMonth} onValueChange={handleMonthChange}>
-        <Select.Trigger id={id} name={name} placeholder="月を選択" />
+      <Select.Root value={currentYear} onValueChange={handleYearChange}>
+        <Select.Trigger id={id} name={name} placeholder="年を選択" />
         <Select.Content>
-          {MONTHS.map((month) => (
-            <Select.Item key={month.value} value={month.value}>
-              {month.label}
+          {YEARS.map((year) => (
+            <Select.Item key={year.value} value={year.value}>
+              {year.label}
             </Select.Item>
           ))}
         </Select.Content>
       </Select.Root>
       <span>/</span>
-      <Select.Root value={currentYear} onValueChange={handleYearChange}>
-        <Select.Trigger placeholder="年を選択" />
+      <Select.Root value={currentMonth} onValueChange={handleMonthChange}>
+        <Select.Trigger placeholder="月を選択" />
         <Select.Content>
-          {YEARS.map((year) => (
-            <Select.Item key={year.value} value={year.value}>
-              {year.label}
+          {MONTHS.map((month) => (
+            <Select.Item key={month.value} value={month.value}>
+              {month.label}
             </Select.Item>
           ))}
         </Select.Content>

--- a/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.test.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.test.tsx
@@ -83,7 +83,7 @@ describe("MonthSelector", () => {
     })
 
     // 月のボタンをクリック
-    const monthButton = screen.getAllByRole("combobox")[0]
+    const monthButton = screen.getAllByRole("combobox")[1]
     await user.click(monthButton)
 
     // 6月を選択


### PR DESCRIPTION
## 関連Issue

- Close #1036

## 変更内容

- `MonthPicker.tsx`: 年月セレクトの表示順を「月 / 年」から「年 / 月」に入れ替え
- `MonthPicker.test.tsx`: comboboxインデックスを新しい表示順に合わせて修正
- `MonthSelector.test.tsx`: 同様にcomboboxインデックスを修正

## 動作確認

- [x] ローカルでの動作確認
- [x] テストの実行（全42ファイル・101テスト通過）
- [ ] UIの確認（スクリーンショット等）

## 補足

`id` / `name` プロパティは先頭のセレクト（年）に付与するよう実装を変更しています。