### PR TITLE
Silence MSW logging in Storybook

### DIFF
--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -27,7 +27,7 @@ const preview: Preview = {
   loaders: [
     async () => {
       if (!mswStarted) {
-        await worker.start({ onUnhandledRequest: "bypass" })
+        await worker.start({ onUnhandledRequest: "bypass", quiet: true })
         mswStarted = true
       }
       // Supabase クライアントにモックセッションをセットし、


### PR DESCRIPTION
## Summary
- Storybook の MSW ワーカー起動時に `quiet: true` を指定してテストログの出力を抑制
- MSW を一度だけ起動する既存の仕組みは維持

## Testing
- Not run (not requested)