### PR TITLE
Supabaseテスト警告を抑止する

### DIFF
--- a/apps/web/src/features/categories/listCategory/fetchCategories.test.ts
+++ b/apps/web/src/features/categories/listCategory/fetchCategories.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest"
-import { getSupabaseTestClient } from "../../../test/utils/createSupabaseTestClient"
+import { supabaseTestClient } from "../../../test/utils/createSupabaseTestClient"
 import { fetchCategories } from "./fetchCategories"
 
 vi.mock("../../../lib/supabase", () => ({
-  getSupabaseClient: () => getSupabaseTestClient(),
+  getSupabaseClient: () => supabaseTestClient,
 }))
 
 describe("fetchCategories", () => {

--- a/apps/web/src/features/payments/listPayment/fetchPayments.test.ts
+++ b/apps/web/src/features/payments/listPayment/fetchPayments.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest"
-import { getSupabaseTestClient } from "../../../test/utils/createSupabaseTestClient"
+import { supabaseTestClient } from "../../../test/utils/createSupabaseTestClient"
 import { fetchPayments } from "./fetchPayments"
 
 vi.mock("../../../lib/supabase", () => ({
-  getSupabaseClient: () => getSupabaseTestClient(),
+  getSupabaseClient: () => supabaseTestClient,
 }))
 
 describe("fetchPayments", () => {

--- a/apps/web/src/test/utils/createSupabaseTestClient.ts
+++ b/apps/web/src/test/utils/createSupabaseTestClient.ts
@@ -1,23 +1,12 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js"
 import type { Database } from "../../types/database.types"
 
-let supabaseTestClient: SupabaseClient<Database> | null = null
-
-export function getSupabaseTestClient(): SupabaseClient<Database> {
-  if (!supabaseTestClient) {
-    supabaseTestClient = createClient<Database>(
-      "http://localhost:54321",
-      "test-anon-key",
-      {
-        auth: {
-          autoRefreshToken: false,
-          detectSessionInUrl: false,
-          persistSession: false,
-          storageKey: "supabase-test-auth-token",
-        },
-      },
-    )
-  }
-
-  return supabaseTestClient
-}
+export const supabaseTestClient: SupabaseClient<Database> =
+  createClient<Database>("http://localhost:54321", "test-anon-key", {
+    auth: {
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+      persistSession: false,
+      storageKey: "supabase-test-auth-token",
+    },
+  })


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- Supabase のテスト用クライアントを共通化し、モジュール読み込み時に 1 回だけ生成するよう変更
- `fetchPayments` / `fetchCategories` のテストで共有クライアントを使うよう変更
- `Multiple GoTrueClient instances detected` の警告がテスト実行時に出ない構成へ整理

## 動作確認

- [ ] ローカルでの動作確認
- [x] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

- `task web:check` と `task web:test` は実行済みです