### PR TITLE
chore: 生成物ディレクトリを解析対象から除外

### DIFF
--- a/apps/web/.oxfmtrc.json
+++ b/apps/web/.oxfmtrc.json
@@ -1,6 +1,14 @@
 {
   "semi": false,
   "trailingComma": "all",
-  "ignorePatterns": [".vscode/**", "generators/**", "public/mockServiceWorker.js"],
+  "ignorePatterns": [
+    ".vscode/**",
+    "coverage/**",
+    "dist/**",
+    "node_modules/**",
+    "storybook-static/**",
+    "generators/**",
+    "public/mockServiceWorker.js"
+  ],
   "sortImports": {}
 }

--- a/apps/web/.oxlintrc.json
+++ b/apps/web/.oxlintrc.json
@@ -21,5 +21,13 @@
       }
     }
   },
-  "ignorePatterns": [".vscode/**", "generators/**", "public/mockServiceWorker.js"]
+  "ignorePatterns": [
+    ".vscode/**",
+    "coverage/**",
+    "dist/**",
+    "node_modules/**",
+    "storybook-static/**",
+    "generators/**",
+    "public/mockServiceWorker.js"
+  ]
 }


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- `oxfmt` の `ignorePatterns` に生成物ディレクトリを追加
- `oxlint` の `ignorePatterns` に生成物ディレクトリを追加
- `coverage` / `dist` / `node_modules` / `storybook-static` を解析対象から除外

## 動作確認

- [x] ローカルでの動作確認
- [x] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

- `task web:check` が成功することを確認
- `task web:test` が成功することを確認
