### PR TITLE
chore: @sentry/cli を onlyBuiltDependencies に追加

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - apps/*
 onlyBuiltDependencies:
+  - '@sentry/cli'
   - esbuild
   - msw
   - supabase


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- `pnpm-workspace.yaml` の `onlyBuiltDependencies` に `@sentry/cli` を追加
- `pnpm approve-builds` の結果を反映し、Sentry CLI のビルドを許可

## 動作確認

- [ ] ローカルでの動作確認
- [ ] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

- 設定変更のみのため UI 変更はありません