### PR TITLE
fix: github-digest更新でstability-daysを適用しない

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,12 +13,6 @@
   },
   packageRules: [
     {
-      matchDatasources: [
-        'github-digest',
-      ],
-      minimumReleaseAge: null,
-    },
-    {
       matchDepTypes: [
         'dependencies',
       ],
@@ -41,6 +35,15 @@
       ],
       automerge: true,
       automergeType: 'pr',
+    },
+    {
+      matchDatasources: [
+        'github-digest',
+      ],
+      matchManagers: [
+        'github-actions',
+      ],
+      minimumReleaseAge: null,
     },
   ],
 }


### PR DESCRIPTION
## 関連Issue

- close #1094

## 変更内容

- github-digest 更新を `minimumReleaseAge` 対象外に変更
- GitHub Actions の digest 更新で `renovate/stability-days` が残り続ける問題を回避

## 動作確認

- [ ] ローカルでの動作確認
- [x] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

- `task web:verify` 実行済み
