### PR TITLE
Renovate の supabase/setup-cli digest 解決エラーを修正

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1
+        uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
         with:
           version: latest
 


### PR DESCRIPTION
## 関連Issue

#1098

## 変更内容

- `supabase/setup-cli` の SHA pin に付ける注釈を `v1` から実在する tag `v1.6.0` に修正
- Renovate が `github-tags` と digest を対応づけられる形に揃え、Dependency Lookup Warning の解消を狙う

## 動作確認

- [ ] ローカルでの動作確認
- [x] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

- `task web:verify` を実行済み
- UI 変更はありません
