### PR TITLE
undici の脆弱性を回避する

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  undici@>=7.0.0 <7.24.0: '>=7.24.0'
-  undici@>=7.17.0 <7.24.0: '>=7.24.0'
+  undici@>=7.0.0 <7.24.0: '^7.24.0'
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,5 +6,4 @@ onlyBuiltDependencies:
   - msw
   - supabase
 overrides:
-  undici@>=7.0.0 <7.24.0: '>=7.24.0'
-  undici@>=7.17.0 <7.24.0: '>=7.24.0'
+  undici@>=7.0.0 <7.24.0: '^7.24.0'


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- `pnpm-workspace.yaml` に `undici` の override を追加し、7.24.0 未満へ解決されないようにした
- `pnpm-lock.yaml` を更新し、`undici` を 7.24.5 へ引き上げた
- `pnpm audit --fix` で必要になった依存修正を lockfile に反映した

## 動作確認

- [ ] ローカルでの動作確認
- [x] テストの実行 (`task web:verify`)
- [ ] UIの確認（スクリーンショット等）