### PR TITLE
当月支払額表示のレイアウトシフトを抑制する

### DIFF
--- a/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.tsx
@@ -15,7 +15,7 @@ function MonthlyTotals() {
       </Text>
       <Flex justify="end" align="center">
         <ErrorBoundary fallback={<Text color="red">An unexpected error has occurred.</Text>}>
-          <Suspense fallback={<Skeleton data-testid="skeleton" width="120px" height="28px" />}>
+          <Suspense fallback={<MoneyText loading />}>
             <MoneyText getValue={promise} />
           </Suspense>
         </ErrorBoundary>
@@ -24,16 +24,41 @@ function MonthlyTotals() {
   )
 }
 
-const MoneyText = memo(function MoneyText({ getValue }: { getValue: Promise<number | null> }) {
-  const data = use(getValue)
-  const text = data === null ? "-" : toCurrency(data)
+interface MoneyTextProps {
+  getValue?: Promise<number | null>
+  loading?: boolean
+}
+
+const MoneyText = memo(function MoneyText({ getValue, loading = false }: MoneyTextProps) {
+  const data = getValue ? use(getValue) : null
+  const text = getMoneyText(data, loading)
 
   return (
-    <Text align="right" size="6" weight="bold">
-      {text}
-    </Text>
+    <Skeleton loading={loading} data-testid={loading ? "skeleton" : undefined}>
+      <Text
+        align="right"
+        size="6"
+        weight="bold"
+        style={{ display: "inline-block", minWidth: "10ch" }}
+        aria-hidden={loading}
+      >
+        {text}
+      </Text>
+    </Skeleton>
   )
 })
+
+function getMoneyText(data: number | null, loading: boolean): string {
+  if (loading) {
+    return "\u00A0"
+  }
+
+  if (data === null) {
+    return "-"
+  }
+
+  return toCurrency(data)
+}
 
 const MemoisedMonthlyTotals = memo(MonthlyTotals)
 


### PR DESCRIPTION
## 関連Issue

- closes #1121

## 変更内容

- `MonthlyTotals` の loading 表示を固定サイズの fallback から、実表示と同じ行ボックスを維持する構成へ変更
- プレースホルダー表示と金額表示の分岐を整理し、レビュー指摘に合わせて可読性も調整

## 動作確認

- [x] テストの実行 (`task web:verify`)
- [x] ローカルでの動作確認
- [ ] UIの確認（スクリーンショット等）