### PR TITLE
Webタスク定義とRenovate設定を整理

### DIFF
--- a/apps/web/Taskfile.yml
+++ b/apps/web/Taskfile.yml
@@ -10,10 +10,10 @@ tasks:
     cmd: task -l
   dev:
     desc: Start development server
-    cmd: pnpm dev -- {{.CLI_ARGS}}
+    cmd: pnpm dev {{.CLI_ARGS}}
   storybook:
     desc: Start Storybook for UI component development
-    cmd: pnpm storybook -- {{.CLI_ARGS}}
+    cmd: pnpm storybook {{.CLI_ARGS}}
   format:
     desc: Format files
     cmd: pnpm format
@@ -28,7 +28,7 @@ tasks:
     cmd: pnpm typecheck
   test:
     desc: Run tests
-    cmd: pnpm test -- --silent --reporter=dot {{.CLI_ARGS}}
+    cmd: pnpm test --silent --reporter=dot {{.CLI_ARGS}}
   verify:
     desc: Run all verification tasks
     deps:
@@ -38,4 +38,4 @@ tasks:
       - test
   build:
     desc: Build the application for production
-    cmd: pnpm build -- {{.CLI_ARGS}}
+    cmd: pnpm build {{.CLI_ARGS}}

--- a/renovate.json5
+++ b/renovate.json5
@@ -8,9 +8,6 @@
   vulnerabilityAlerts: {
     enabled: true,
   },
-  lockFileMaintenance: {
-    enabled: true,
-  },
   packageRules: [
     {
       matchDepTypes: [


### PR DESCRIPTION
## 関連Issue

- なし

## 変更内容

- apps/web の Taskfile で pnpm 実行時の不要な -- を除去し、CLI 引数の委譲を整理
- Renovate の lock file maintenance 設定を削除して設定を簡素化

## 動作確認

- [x] task web:verify