### PR TITLE
#1148 入力フィールド基盤の責務整理

### DIFF
--- a/apps/web/src/components/inputs/BaseField/BaseField.stories.tsx
+++ b/apps/web/src/components/inputs/BaseField/BaseField.stories.tsx
@@ -1,13 +1,17 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { BaseField, type BaseFieldProps } from "./BaseField"
+import { BaseField, FieldLabel, FieldMessages, type BaseFieldProps } from "./BaseField"
 
 const meta: Meta<BaseFieldProps> = {
   title: "Common/Inputs/BaseField",
   component: BaseField,
   args: {
-    label: "Label",
-    children: <input type="text" placeholder="Input here" />,
+    children: (
+      <>
+        <FieldLabel htmlFor="base-field">Label</FieldLabel>
+        <input id="base-field" type="text" placeholder="Input here" />
+      </>
+    ),
   },
 }
 
@@ -19,13 +23,25 @@ export const Default: Story = {}
 
 export const Required: Story = {
   args: {
-    required: true,
+    children: (
+      <>
+        <FieldLabel htmlFor="base-field-required" required>
+          Label
+        </FieldLabel>
+        <input id="base-field-required" type="text" placeholder="Input here" />
+      </>
+    ),
   },
 }
 
 export const WithError: Story = {
   args: {
-    error: true,
-    message: "Error occurred",
+    children: (
+      <>
+        <FieldLabel htmlFor="base-field-error">Label</FieldLabel>
+        <input id="base-field-error" type="text" placeholder="Input here" />
+        <FieldMessages error messages={["Error occurred"]} />
+      </>
+    ),
   },
 }

--- a/apps/web/src/components/inputs/BaseField/BaseField.tsx
+++ b/apps/web/src/components/inputs/BaseField/BaseField.tsx
@@ -1,42 +1,25 @@
 import { Flex, type FlexProps, Text } from "@radix-ui/themes"
-import type { ReactNode } from "react"
+import { Fragment, type ReactNode } from "react"
 
 export type BaseFieldProps = {
   children?: ReactNode
-  required?: boolean
-  label: ReactNode
-  htmlFor?: string
-  error?: boolean
-  message?: ReactNode
 } & FlexProps
 
-export function BaseField({
-  children,
-  required = false,
-  label,
-  htmlFor,
-  error,
-  message,
-  ...props
-}: BaseFieldProps) {
+export function BaseField({ children, ...props }: BaseFieldProps) {
   return (
     <Flex direction="column" gap="1" {...props}>
-      <Label htmlFor={htmlFor} required={required}>
-        {label}
-      </Label>
       {children}
-      {message && <FieldMessage error={error}>{message}</FieldMessage>}
     </Flex>
   )
 }
 
-type LabelProps = {
+export type FieldLabelProps = {
   children: ReactNode
   htmlFor?: string
   required?: boolean
 }
 
-function Label({ children, htmlFor, required = false, ...props }: LabelProps) {
+export function FieldLabel({ children, htmlFor, required = false, ...props }: FieldLabelProps) {
   return (
     <Text as="label" htmlFor={htmlFor} size="2" weight="bold" {...props}>
       {children}
@@ -49,15 +32,24 @@ function Label({ children, htmlFor, required = false, ...props }: LabelProps) {
   )
 }
 
-interface FieldMessageProps {
-  children: ReactNode
+export interface FieldMessagesProps {
   error?: boolean
+  messages?: string[]
 }
 
-function FieldMessage({ children, error, ...props }: FieldMessageProps) {
+export function FieldMessages({ error, messages }: FieldMessagesProps) {
+  if (!messages || messages.length === 0) {
+    return null
+  }
+
   return (
-    <Text as="span" size="1" color={error ? "red" : undefined} {...props}>
-      {children}
+    <Text as="span" size="1" color={error ? "red" : undefined}>
+      {messages.map((message, index) => (
+        <Fragment key={message}>
+          {index > 0 && <br />}
+          {message}
+        </Fragment>
+      ))}
     </Text>
   )
 }

--- a/apps/web/src/components/inputs/BaseField/index.ts
+++ b/apps/web/src/components/inputs/BaseField/index.ts
@@ -1,1 +1,3 @@
 export { BaseField } from "./BaseField"
+export { FieldLabel } from "./BaseField"
+export { FieldMessages } from "./BaseField"

--- a/apps/web/src/features/payments/createPayment/AmountField/AmountField.tsx
+++ b/apps/web/src/features/payments/createPayment/AmountField/AmountField.tsx
@@ -1,7 +1,7 @@
-import { Text, TextField } from "@radix-ui/themes"
-import { Fragment, useId } from "react"
+import { TextField } from "@radix-ui/themes"
+import { useId } from "react"
 
-import { BaseField } from "../../../../components/inputs/BaseField"
+import { BaseField, FieldLabel, FieldMessages } from "../../../../components/inputs/BaseField"
 
 interface AmountFieldProps {
   error?: boolean
@@ -15,18 +15,10 @@ export function AmountField({ error, messages, value, onChange, autoFocus }: Amo
   const id = useId()
 
   return (
-    <BaseField
-      label="Amount"
-      required
-      htmlFor={id}
-      error={error}
-      message={messages?.map((msg, i) => (
-        <Fragment key={msg}>
-          {i > 0 && <br />}
-          <Text as="span">{msg}</Text>
-        </Fragment>
-      ))}
-    >
+    <BaseField>
+      <FieldLabel htmlFor={id} required>
+        Amount
+      </FieldLabel>
       <TextField.Root
         id={id}
         name="amount"
@@ -51,6 +43,7 @@ export function AmountField({ error, messages, value, onChange, autoFocus }: Amo
           }
         }}
       />
+      <FieldMessages error={error} messages={messages} />
     </BaseField>
   )
 }

--- a/apps/web/src/features/payments/createPayment/CategoryField/CategoryField.tsx
+++ b/apps/web/src/features/payments/createPayment/CategoryField/CategoryField.tsx
@@ -1,8 +1,8 @@
-import { Select, Text } from "@radix-ui/themes"
-import { Fragment, memo, Suspense, use, useId } from "react"
+import { Select } from "@radix-ui/themes"
+import { memo, Suspense, use, useId } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 
-import { BaseField } from "../../../../components/inputs/BaseField"
+import { BaseField, FieldLabel, FieldMessages } from "../../../../components/inputs/BaseField"
 import type { Category } from "../../../../types/category"
 import { useCategories } from "../../../categories/listCategory/useCategories"
 
@@ -23,18 +23,8 @@ export const CategoryField = memo(function CategoryField({
   const { promise: promiseCategories } = useCategories()
 
   return (
-    <BaseField
-      label="Category"
-      htmlFor={id}
-      error={Boolean(error)}
-      message={messages?.map((msg, i) => (
-        <Fragment key={msg}>
-          {i > 0 && <br />}
-          <Text as="span">{msg}</Text>
-        </Fragment>
-      ))}
-      width="300px"
-    >
+    <BaseField width="300px">
+      <FieldLabel htmlFor={id}>Category</FieldLabel>
       <Select.Root name="category" value={value} onValueChange={(val) => onChange?.(val)}>
         <Select.Trigger id={id} placeholder="Pick a category" />
         <Select.Content>
@@ -45,6 +35,7 @@ export const CategoryField = memo(function CategoryField({
           </ErrorBoundary>
         </Select.Content>
       </Select.Root>
+      <FieldMessages error={Boolean(error)} messages={messages} />
     </BaseField>
   )
 })

--- a/apps/web/src/features/payments/createPayment/NoteField/NoteField.tsx
+++ b/apps/web/src/features/payments/createPayment/NoteField/NoteField.tsx
@@ -1,7 +1,7 @@
-import { Text, TextField } from "@radix-ui/themes"
-import { Fragment, useId } from "react"
+import { TextField } from "@radix-ui/themes"
+import { useId } from "react"
 
-import { BaseField } from "../../../../components/inputs/BaseField"
+import { BaseField, FieldLabel, FieldMessages } from "../../../../components/inputs/BaseField"
 
 interface NoteFieldProps {
   error?: boolean
@@ -14,17 +14,8 @@ export function NoteField({ error, messages, value, onChange }: NoteFieldProps) 
   const id = useId()
 
   return (
-    <BaseField
-      label="Note"
-      htmlFor={id}
-      error={error}
-      message={messages?.map((msg, i) => (
-        <Fragment key={msg}>
-          {i > 0 && <br />}
-          <Text as="span">{msg}</Text>
-        </Fragment>
-      ))}
-    >
+    <BaseField>
+      <FieldLabel htmlFor={id}>Note</FieldLabel>
       <TextField.Root
         id={id}
         name="note"
@@ -32,6 +23,7 @@ export function NoteField({ error, messages, value, onChange }: NoteFieldProps) 
         value={value}
         onChange={(e) => onChange?.(e.target.value)}
       />
+      <FieldMessages error={error} messages={messages} />
     </BaseField>
   )
 }

--- a/apps/web/src/features/payments/createPayment/PaymentDateField/PaymentDateField.stories.tsx
+++ b/apps/web/src/features/payments/createPayment/PaymentDateField/PaymentDateField.stories.tsx
@@ -31,8 +31,11 @@ export const HasError: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     expect(canvas.getByText("Date")).toBeInTheDocument()
-    expect(canvas.getByText("日付が未選択です")).toBeInTheDocument()
-    expect(canvas.getByText("1年以上前の日付は選択できません")).toBeInTheDocument()
+    const message = canvas.getByText((_, element) => {
+      return element?.textContent === "日付が未選択です1年以上前の日付は選択できません"
+    })
+    expect(message).toHaveTextContent("日付が未選択です")
+    expect(message).toHaveTextContent("1年以上前の日付は選択できません")
     expect(canvas.getByRole("textbox")).toBeInTheDocument()
   },
 }

--- a/apps/web/src/features/payments/createPayment/PaymentDateField/PaymentDateField.tsx
+++ b/apps/web/src/features/payments/createPayment/PaymentDateField/PaymentDateField.tsx
@@ -1,7 +1,6 @@
-import { Text } from "@radix-ui/themes"
-import { Fragment, useId } from "react"
+import { useId } from "react"
 
-import { BaseField } from "../../../../components/inputs/BaseField"
+import { BaseField, FieldLabel, FieldMessages } from "../../../../components/inputs/BaseField"
 import { DatePicker } from "../../../../components/inputs/DatePicker"
 
 interface PaymentDateFieldProps {
@@ -15,20 +14,12 @@ export function PaymentDateField({ error, messages, value, onChange }: PaymentDa
   const id = useId()
 
   return (
-    <BaseField
-      label="Date"
-      htmlFor={id}
-      required
-      error={error}
-      message={messages?.map((msg, i) => (
-        <Fragment key={msg}>
-          {i > 0 && <br />}
-          <Text as="span">{msg}</Text>
-        </Fragment>
-      ))}
-      width="fit-content"
-    >
+    <BaseField width="fit-content">
+      <FieldLabel htmlFor={id} required>
+        Date
+      </FieldLabel>
       <DatePicker id={id} name="date" value={value} onChange={onChange} />
+      <FieldMessages error={error} messages={messages} />
     </BaseField>
   )
 }

--- a/apps/web/src/features/payments/listPayment/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
@@ -1,5 +1,6 @@
-import { Button, Flex, Separator, Strong, Text } from "@radix-ui/themes"
+import { Button, Flex, Separator, Text } from "@radix-ui/themes"
 
+import { BaseField } from "../../../../components/inputs/BaseField"
 import { ResponsiveOverlay } from "../../../../components/overlay/ResponsiveOverlay"
 import type { Category } from "../../../../types/category"
 import type { Payment } from "../../../../types/payment"
@@ -34,7 +35,7 @@ export function PaymentDetailsOverlay({
             <DetailField label="Date" value={formatDateToLocaleString(payment.date)} />
             <DetailField label="Category" value={category.name} />
             <DetailField label="Note" value={payment.note} />
-            <DetailField label="Amount" value={toCurrency(payment.amount)} weight="bold" />
+            <DetailField label="Amount" value={toCurrency(payment.amount)} />
           </Flex>
           {onDelete ? (
             <>
@@ -56,15 +57,14 @@ interface DetailFieldProps {
   label: string
   value: string
   align?: "left" | "right"
-  weight?: "regular" | "bold"
 }
 
-function DetailField({ label, value, align = "left", weight = "regular" }: DetailFieldProps) {
+function DetailField({ label, value, align = "left" }: DetailFieldProps) {
   const hasValue = value.trim().length > 0
   const displayValue = hasValue ? value : "No note"
 
   return (
-    <Flex direction="column" gap="2">
+    <BaseField gap="2">
       <Text size="2" color="gray">
         {label}
       </Text>
@@ -74,8 +74,8 @@ function DetailField({ label, value, align = "left", weight = "regular" }: Detai
         color={hasValue ? undefined : "gray"}
         style={{ minHeight: "1.75rem", fontStyle: hasValue ? "normal" : "italic" }}
       >
-        {weight === "bold" ? <Strong>{displayValue}</Strong> : displayValue}
+        {displayValue}
       </Text>
-    </Flex>
+    </BaseField>
   )
 }


### PR DESCRIPTION
## 関連Issue

- closes #1148

## 変更内容

- `BaseField` を frame と補助コンポーネントの compose 前提へ整理
- create payment 系 field を新しい構造へ移行し、ラベルとメッセージ責務を分離
- `PaymentDetailsOverlay` も同じ field 基盤に寄せつつ、表示トーンは維持

## 動作確認

- [x] ローカルでの動作確認
- [x] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

- `task web:verify` を実行済み
- Issue #1148 の ToDo と Definition of Done を完了状態へ更新済み
