### PR TITLE
支払い詳細でノートをインライン編集できるようにする

### DIFF
--- a/apps/web/src/features/payments/components/NoteInput/NoteInput.tsx
+++ b/apps/web/src/features/payments/components/NoteInput/NoteInput.tsx
@@ -1,14 +1,26 @@
 import { TextField } from "@radix-ui/themes"
 
 interface Props {
+  autoFocus?: boolean
+  disabled?: boolean
   id?: string
   value?: string
   onChange?: (note: string) => void
 }
 
-export function NoteInput({ id, value, onChange }: Props) {
+export function NoteInput({ autoFocus, disabled, id, value, onChange }: Props) {
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     onChange?.(e.target.value)
   }
-  return <TextField.Root id={id} name="note" type="text" value={value} onChange={handleChange} />
+  return (
+    <TextField.Root
+      autoFocus={autoFocus}
+      disabled={disabled}
+      id={id}
+      name="note"
+      type="text"
+      value={value}
+      onChange={handleChange}
+    />
+  )
 }

--- a/apps/web/src/features/payments/paymentDetails/AmountField/AmountField.stories.tsx
+++ b/apps/web/src/features/payments/paymentDetails/AmountField/AmountField.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { QueryClientProvider } from "@tanstack/react-query"
+import { fn } from "storybook/test"
 
 import { createQueryClient } from "../../../../lib/queryClient"
 import { SnackbarProvider } from "../../../../providers/snackbar"
@@ -35,4 +36,9 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  args: {
+    onEditStart: fn(),
+    onEditEnd: fn(),
+  },
+}

--- a/apps/web/src/features/payments/paymentDetails/AmountField/AmountField.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/AmountField/AmountField.test.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from "@storybook/react-vite"
-import { beforeEach, describe, expect, test } from "vitest"
+import { beforeEach, describe, expect, test, vi } from "vitest"
 
 import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
 import { server } from "../../../../test/msw/server"
@@ -121,5 +121,17 @@ describe("AmountField", () => {
     rerender(<Default amount={3000} />)
 
     expect(screen.getByRole("textbox", { name: /amount/i })).toHaveValue("2500")
+  })
+
+  test("Escape で編集を閉じると onEditEnd を呼ぶ", async () => {
+    const onEditStart = vi.fn()
+    const onEditEnd = vi.fn()
+    const { user } = render(<Default onEditStart={onEditStart} onEditEnd={onEditEnd} />)
+
+    await user.click(screen.getByRole("button", { name: /edit amount/i }))
+    await user.keyboard("{Escape}")
+
+    expect(onEditStart).toHaveBeenCalledTimes(1)
+    expect(onEditEnd).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/features/payments/paymentDetails/AmountField/AmountField.tsx
+++ b/apps/web/src/features/payments/paymentDetails/AmountField/AmountField.tsx
@@ -22,10 +22,16 @@ import { SubmitIconButton } from "../SubmitIconButton"
 interface AmountFieldProps {
   paymentId?: PaymentId
   amount: number
+  disabled?: boolean
   onEditingChange?: (editing: boolean) => void
 }
 
-export function AmountField({ paymentId, amount, onEditingChange }: AmountFieldProps) {
+export function AmountField({
+  paymentId,
+  amount,
+  disabled = false,
+  onEditingChange,
+}: AmountFieldProps) {
   const id = useId()
   const { openSnackbar } = useSnackbar()
   const { updatePayment, isPending } = useUpdatePayment()
@@ -101,6 +107,7 @@ export function AmountField({ paymentId, amount, onEditingChange }: AmountFieldP
       htmlFor={id}
       required
       editing={editing}
+      disabled={disabled}
       editButtonLabel="Edit amount"
       onEdit={handleEdit}
       error={Boolean(messages?.length)}

--- a/apps/web/src/features/payments/paymentDetails/AmountField/AmountField.tsx
+++ b/apps/web/src/features/payments/paymentDetails/AmountField/AmountField.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useEffect,
   useId,
+  useRef,
   useState,
 } from "react"
 
@@ -23,47 +24,53 @@ interface AmountFieldProps {
   paymentId?: PaymentId
   amount: number
   disabled?: boolean
-  onEditingChange?: (editing: boolean) => void
+  onEditStart: () => void
+  onEditEnd: () => void
 }
 
 export function AmountField({
   paymentId,
   amount,
   disabled = false,
-  onEditingChange,
+  onEditStart,
+  onEditEnd,
 }: AmountFieldProps) {
   const id = useId()
   const { openSnackbar } = useSnackbar()
   const { updatePayment, isPending } = useUpdatePayment()
   const [editing, setEditing] = useState(false)
+  // 親が open=false を直接渡して field が unmount されるときに、編集中だった場合だけ onEditEnd を返す。
+  const editingRef = useRef(false)
   const [draftAmount, setDraftAmount] = useState<number | undefined>(amount)
   const [messages, setMessages] = useState<string[] | undefined>()
 
   useEffect(() => {
-    onEditingChange?.(editing)
-  }, [editing, onEditingChange])
-
-  useEffect(() => {
     return () => {
-      onEditingChange?.(false)
+      if (editingRef.current) {
+        onEditEnd()
+      }
     }
-  }, [onEditingChange])
+  }, [onEditEnd])
 
   const handleEdit = useCallback(() => {
     if (paymentId === undefined) return
 
     setDraftAmount(amount)
     setMessages(undefined)
+    editingRef.current = true
     setEditing(true)
-  }, [amount, paymentId])
+    onEditStart()
+  }, [amount, onEditStart, paymentId])
 
   const handleCancel = useCallback(() => {
     if (isPending) return
 
     setDraftAmount(amount)
     setMessages(undefined)
+    editingRef.current = false
     setEditing(false)
-  }, [amount, isPending])
+    onEditEnd()
+  }, [amount, isPending, onEditEnd])
 
   const handleChange = useCallback((nextAmount: number | undefined) => {
     setDraftAmount(nextAmount)
@@ -75,7 +82,9 @@ export function AmountField({
 
     if (draftAmount === amount) {
       setMessages(undefined)
+      editingRef.current = false
       setEditing(false)
+      onEditEnd()
       return
     }
 
@@ -92,14 +101,16 @@ export function AmountField({
         paymentId,
         patch: { amount: result.data },
       })
+      editingRef.current = false
       setEditing(false)
+      onEditEnd()
     } catch {
       const message = "Failed to update amount."
 
       setMessages([message])
       openSnackbar("error", message)
     }
-  }, [amount, draftAmount, isPending, openSnackbar, paymentId, updatePayment])
+  }, [amount, draftAmount, isPending, onEditEnd, openSnackbar, paymentId, updatePayment])
 
   return (
     <EditableField
@@ -107,7 +118,7 @@ export function AmountField({
       htmlFor={id}
       required
       editing={editing}
-      disabled={disabled}
+      disabled={disabled && !editing}
       editButtonLabel="Edit amount"
       onEdit={handleEdit}
       error={Boolean(messages?.length)}

--- a/apps/web/src/features/payments/paymentDetails/EditableField/EditableField.tsx
+++ b/apps/web/src/features/payments/paymentDetails/EditableField/EditableField.tsx
@@ -9,6 +9,7 @@ interface EditableFieldProps {
   htmlFor?: string
   required?: boolean
   editing: boolean
+  disabled?: boolean
   view: ReactNode
   editor: ReactNode
   editButtonLabel: string
@@ -22,6 +23,7 @@ export function EditableField({
   htmlFor,
   required = false,
   editing,
+  disabled = false,
   view,
   editor,
   editButtonLabel,
@@ -47,6 +49,7 @@ export function EditableField({
             color="gray"
             highContrast
             aria-label={editButtonLabel}
+            disabled={disabled}
             onClick={onEdit}
             style={{
               width: "100%",

--- a/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.stories.tsx
+++ b/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { QueryClientProvider } from "@tanstack/react-query"
+import { fn } from "storybook/test"
 
 import { createQueryClient } from "../../../../lib/queryClient"
 import { SnackbarProvider } from "../../../../providers/snackbar"
@@ -35,10 +36,17 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  args: {
+    onEditStart: fn(),
+    onEditEnd: fn(),
+  },
+}
 
 export const EmptyNote: Story = {
   args: {
     note: "",
+    onEditStart: fn(),
+    onEditEnd: fn(),
   },
 }

--- a/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.stories.tsx
+++ b/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.stories.tsx
@@ -1,13 +1,35 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { QueryClientProvider } from "@tanstack/react-query"
 
+import { createQueryClient } from "../../../../lib/queryClient"
+import { SnackbarProvider } from "../../../../providers/snackbar"
+import { ThemeProvider } from "../../../../providers/theme/ThemeProvider"
+import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
 import { NoteField } from "./NoteField"
 
 const meta = {
   title: "Features/PaymentDetails/NoteField",
   component: NoteField,
+  parameters: {
+    msw: {
+      handlers: createPaymentHandlers(),
+    },
+  },
   args: {
+    paymentId: 1,
     note: "コンビニ",
   },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={createQueryClient()}>
+        <ThemeProvider>
+          <SnackbarProvider>
+            <Story />
+          </SnackbarProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    ),
+  ],
 } satisfies Meta<typeof NoteField>
 
 export default meta

--- a/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.test.tsx
@@ -1,22 +1,116 @@
 import { composeStories } from "@storybook/react-vite"
-import { describe, expect, test } from "vitest"
+import { beforeEach, describe, expect, test, vi } from "vitest"
 
-import { render, screen } from "../../../../test/test-utils"
+import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
+import { server } from "../../../../test/msw/server"
+import { render, screen, waitFor } from "../../../../test/test-utils"
 import * as stories from "./NoteField.stories"
 
 const { Default, EmptyNote } = composeStories(stories)
 
 describe("PaymentDetails NoteField", () => {
+  beforeEach(() => {
+    server.resetHandlers(...createPaymentHandlers())
+  })
+
   test("Default story ではラベルとノートを表示する", () => {
     render(<Default />)
 
     expect(screen.getByText("Note")).toBeInTheDocument()
     expect(screen.getByText("コンビニ")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /edit note/i })).toBeInTheDocument()
   })
 
   test("EmptyNote story ではプレースホルダーを表示する", () => {
     render(<EmptyNote />)
 
     expect(screen.getByText("No note")).toBeInTheDocument()
+  })
+
+  test("編集ボタンを押すと入力欄を開く", async () => {
+    const { user } = render(<Default />)
+
+    await user.click(screen.getByRole("button", { name: /edit note/i }))
+
+    expect(screen.getByRole("textbox", { name: /note/i })).toBeInTheDocument()
+  })
+
+  test("Enter でノートを保存できる", async () => {
+    const { user } = render(<Default />)
+
+    await user.click(screen.getByRole("button", { name: /edit note/i }))
+    const noteInput = screen.getByRole("textbox", { name: /note/i })
+    await user.clear(noteInput)
+    await user.type(noteInput, "ドラッグストア{Enter}")
+
+    await waitFor(() => {
+      expect(screen.queryByRole("textbox", { name: /note/i })).not.toBeInTheDocument()
+    })
+  })
+
+  test("編集中の Escape は編集だけ解除する", async () => {
+    const { user } = render(<Default />)
+
+    await user.click(screen.getByRole("button", { name: /edit note/i }))
+    const noteInput = screen.getByRole("textbox", { name: /note/i })
+    await user.clear(noteInput)
+    await user.type(noteInput, "ドラッグストア")
+    await user.keyboard("{Escape}")
+
+    expect(screen.queryByRole("textbox", { name: /note/i })).not.toBeInTheDocument()
+    expect(screen.getByText("コンビニ")).toBeInTheDocument()
+  })
+
+  test("保存失敗時は編集状態を維持してエラーを表示する", async () => {
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        update: { error: true },
+      }),
+    )
+
+    const { user } = render(<Default />)
+
+    await user.click(screen.getByRole("button", { name: /edit note/i }))
+    const noteInput = screen.getByRole("textbox", { name: /note/i })
+    await user.clear(noteInput)
+    await user.type(noteInput, "ドラッグストア")
+    await user.click(screen.getByRole("button", { name: /save note/i }))
+
+    expect(
+      await screen.findByText("Failed to update note.", { selector: "span" }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole("textbox", { name: /note/i })).toBeInTheDocument()
+  })
+
+  test("保存中は入力欄と保存ボタンを操作不可にする", async () => {
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        update: { durationOrMode: 1000 },
+      }),
+    )
+
+    const { user } = render(<Default />)
+
+    await user.click(screen.getByRole("button", { name: /edit note/i }))
+    const noteInput = screen.getByRole("textbox", { name: /note/i })
+    await user.clear(noteInput)
+    await user.type(noteInput, "ドラッグストア")
+    const saveButton = screen.getByRole("button", { name: /save note/i })
+    await user.click(saveButton)
+
+    expect(noteInput).toBeDisabled()
+    expect(saveButton).toBeDisabled()
+    expect(screen.getByLabelText("saving")).toBeInTheDocument()
+  })
+
+  test("未変更なら update を呼ばずに編集を閉じる", async () => {
+    const onEditingChange = vi.fn()
+    const { user } = render(<Default onEditingChange={onEditingChange} />)
+
+    await user.click(screen.getByRole("button", { name: /edit note/i }))
+    await user.click(screen.getByRole("button", { name: /save note/i }))
+
+    expect(screen.queryByRole("textbox", { name: /note/i })).not.toBeInTheDocument()
+    expect(onEditingChange).toHaveBeenLastCalledWith(false)
   })
 })

--- a/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.test.tsx
@@ -104,13 +104,27 @@ describe("PaymentDetails NoteField", () => {
   })
 
   test("未変更なら update を呼ばずに編集を閉じる", async () => {
-    const onEditingChange = vi.fn()
-    const { user } = render(<Default onEditingChange={onEditingChange} />)
+    const onEditStart = vi.fn()
+    const onEditEnd = vi.fn()
+    const { user } = render(<Default onEditStart={onEditStart} onEditEnd={onEditEnd} />)
 
     await user.click(screen.getByRole("button", { name: /edit note/i }))
     await user.click(screen.getByRole("button", { name: /save note/i }))
 
     expect(screen.queryByRole("textbox", { name: /note/i })).not.toBeInTheDocument()
-    expect(onEditingChange).toHaveBeenLastCalledWith(false)
+    expect(onEditStart).toHaveBeenCalledTimes(1)
+    expect(onEditEnd).toHaveBeenCalledTimes(1)
+  })
+
+  test("Escape で編集を閉じると onEditEnd を呼ぶ", async () => {
+    const onEditStart = vi.fn()
+    const onEditEnd = vi.fn()
+    const { user } = render(<Default onEditStart={onEditStart} onEditEnd={onEditEnd} />)
+
+    await user.click(screen.getByRole("button", { name: /edit note/i }))
+    await user.keyboard("{Escape}")
+
+    expect(onEditStart).toHaveBeenCalledTimes(1)
+    expect(onEditEnd).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.tsx
+++ b/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.tsx
@@ -19,7 +19,7 @@ import { SubmitIconButton } from "../SubmitIconButton"
 const notePlaceholder = "No note"
 
 interface NoteFieldProps {
-  paymentId?: PaymentId
+  paymentId: PaymentId
   note: string
   disabled?: boolean
   onEditingChange?: (editing: boolean) => void
@@ -46,12 +46,10 @@ export function NoteField({ paymentId, note, disabled = false, onEditingChange }
   }, [onEditingChange])
 
   const handleEdit = useCallback(() => {
-    if (paymentId === undefined) return
-
     setDraftNote(note)
     setMessages(undefined)
     setEditing(true)
-  }, [note, paymentId])
+  }, [note])
 
   const handleCancel = useCallback(() => {
     if (isPending) return
@@ -67,7 +65,7 @@ export function NoteField({ paymentId, note, disabled = false, onEditingChange }
   }, [])
 
   const handleSubmit = useCallback(async () => {
-    if (paymentId === undefined || isPending) return
+    if (isPending) return
 
     if (draftNote === note) {
       setMessages(undefined)

--- a/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.tsx
+++ b/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.tsx
@@ -1,27 +1,165 @@
-import { Text } from "@radix-ui/themes"
+import { Flex, Text } from "@radix-ui/themes"
+import {
+  type KeyboardEvent,
+  type ReactNode,
+  type SubmitEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useState,
+} from "react"
 
-import { BaseField, FieldLabel } from "../../../../components/inputs/BaseField"
+import { useSnackbar } from "../../../../providers/snackbar"
+import type { PaymentId } from "../../../../types/payment"
+import { NoteInput } from "../../components/NoteInput"
+import { useUpdatePayment } from "../../updatePayment/useUpdatePayment"
+import { EditableField } from "../EditableField"
+import { SubmitIconButton } from "../SubmitIconButton"
 
 const notePlaceholder = "No note"
 
 interface NoteFieldProps {
+  paymentId?: PaymentId
   note: string
+  disabled?: boolean
+  onEditingChange?: (editing: boolean) => void
 }
 
-export function NoteField({ note }: NoteFieldProps) {
+export function NoteField({ paymentId, note, disabled = false, onEditingChange }: NoteFieldProps) {
+  const id = useId()
+  const { openSnackbar } = useSnackbar()
+  const { updatePayment, isPending } = useUpdatePayment()
+  const [editing, setEditing] = useState(false)
+  const [draftNote, setDraftNote] = useState(note)
+  const [messages, setMessages] = useState<string[] | undefined>()
   const hasNote = note.trim().length > 0
   const value = hasNote ? note : notePlaceholder
 
+  useEffect(() => {
+    onEditingChange?.(editing)
+  }, [editing, onEditingChange])
+
+  useEffect(() => {
+    return () => {
+      onEditingChange?.(false)
+    }
+  }, [onEditingChange])
+
+  const handleEdit = useCallback(() => {
+    if (paymentId === undefined) return
+
+    setDraftNote(note)
+    setMessages(undefined)
+    setEditing(true)
+  }, [note, paymentId])
+
+  const handleCancel = useCallback(() => {
+    if (isPending) return
+
+    setDraftNote(note)
+    setMessages(undefined)
+    setEditing(false)
+  }, [isPending, note])
+
+  const handleChange = useCallback((nextNote: string) => {
+    setDraftNote(nextNote)
+    setMessages(undefined)
+  }, [])
+
+  const handleSubmit = useCallback(async () => {
+    if (paymentId === undefined || isPending) return
+
+    if (draftNote === note) {
+      setMessages(undefined)
+      setEditing(false)
+      return
+    }
+
+    try {
+      setMessages(undefined)
+      await updatePayment({
+        paymentId,
+        patch: { note: draftNote },
+      })
+      setEditing(false)
+    } catch {
+      const message = "Failed to update note."
+
+      setMessages([message])
+      openSnackbar("error", message)
+    }
+  }, [draftNote, isPending, note, openSnackbar, paymentId, updatePayment])
+
   return (
-    <BaseField gap="2">
-      <FieldLabel>Note</FieldLabel>
-      <Text
-        size="4"
-        color={hasNote ? undefined : "gray"}
-        style={{ minHeight: "1.75rem", fontStyle: hasNote ? "normal" : "italic" }}
-      >
-        {value}
-      </Text>
-    </BaseField>
+    <EditableField
+      label="Note"
+      htmlFor={id}
+      editing={editing}
+      disabled={disabled}
+      editButtonLabel="Edit note"
+      onEdit={handleEdit}
+      error={Boolean(messages?.length)}
+      messages={messages}
+      view={
+        <Text
+          size="4"
+          color={hasNote ? undefined : "gray"}
+          style={{
+            flex: 1,
+            minHeight: "1.75rem",
+            fontStyle: hasNote ? "normal" : "italic",
+          }}
+        >
+          {value}
+        </Text>
+      }
+      editor={
+        <InlineForm onSubmit={handleSubmit} onCancel={handleCancel} saving={isPending}>
+          <Flex align="center" gap="2">
+            <div style={{ flex: 1 }}>
+              <NoteInput
+                autoFocus
+                disabled={isPending}
+                id={id}
+                value={draftNote}
+                onChange={handleChange}
+              />
+            </div>
+            <SubmitIconButton ariaLabel="Save note" loading={isPending} />
+          </Flex>
+        </InlineForm>
+      }
+    />
+  )
+}
+
+interface InlineFormProps {
+  children: ReactNode
+  onSubmit?: () => void | Promise<void>
+  onCancel?: () => void
+  saving?: boolean
+}
+
+function InlineForm({ children, onSubmit, onCancel, saving = false }: InlineFormProps) {
+  function handleKeyDown(event: KeyboardEvent<HTMLFormElement>) {
+    if (event.key !== "Escape") return
+
+    event.preventDefault()
+    event.stopPropagation()
+    if (!saving) {
+      onCancel?.()
+    }
+  }
+
+  function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
+    event.preventDefault()
+    event.stopPropagation()
+    onSubmit?.()
+  }
+
+  return (
+    <form onKeyDownCapture={handleKeyDown} onSubmit={handleSubmit}>
+      {children}
+    </form>
   )
 }

--- a/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.tsx
+++ b/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useEffect,
   useId,
+  useRef,
   useState,
 } from "react"
 
@@ -22,42 +23,53 @@ interface NoteFieldProps {
   paymentId: PaymentId
   note: string
   disabled?: boolean
-  onEditingChange?: (editing: boolean) => void
+  onEditStart: () => void
+  onEditEnd: () => void
 }
 
-export function NoteField({ paymentId, note, disabled = false, onEditingChange }: NoteFieldProps) {
+export function NoteField({
+  paymentId,
+  note,
+  disabled = false,
+  onEditStart,
+  onEditEnd,
+}: NoteFieldProps) {
   const id = useId()
   const { openSnackbar } = useSnackbar()
   const { updatePayment, isPending } = useUpdatePayment()
   const [editing, setEditing] = useState(false)
+  // 親が open=false を直接渡して field が unmount されるときに、編集中だった場合だけ onEditEnd を返す。
+  const editingRef = useRef(false)
   const [draftNote, setDraftNote] = useState(note)
   const [messages, setMessages] = useState<string[] | undefined>()
   const hasNote = note.trim().length > 0
   const value = hasNote ? note : notePlaceholder
 
   useEffect(() => {
-    onEditingChange?.(editing)
-  }, [editing, onEditingChange])
-
-  useEffect(() => {
     return () => {
-      onEditingChange?.(false)
+      if (editingRef.current) {
+        onEditEnd()
+      }
     }
-  }, [onEditingChange])
+  }, [onEditEnd])
 
   const handleEdit = useCallback(() => {
     setDraftNote(note)
     setMessages(undefined)
+    editingRef.current = true
     setEditing(true)
-  }, [note])
+    onEditStart()
+  }, [note, onEditStart])
 
   const handleCancel = useCallback(() => {
     if (isPending) return
 
     setDraftNote(note)
     setMessages(undefined)
+    editingRef.current = false
     setEditing(false)
-  }, [isPending, note])
+    onEditEnd()
+  }, [isPending, note, onEditEnd])
 
   const handleChange = useCallback((nextNote: string) => {
     setDraftNote(nextNote)
@@ -69,7 +81,9 @@ export function NoteField({ paymentId, note, disabled = false, onEditingChange }
 
     if (draftNote === note) {
       setMessages(undefined)
+      editingRef.current = false
       setEditing(false)
+      onEditEnd()
       return
     }
 
@@ -79,21 +93,23 @@ export function NoteField({ paymentId, note, disabled = false, onEditingChange }
         paymentId,
         patch: { note: draftNote },
       })
+      editingRef.current = false
       setEditing(false)
+      onEditEnd()
     } catch {
       const message = "Failed to update note."
 
       setMessages([message])
       openSnackbar("error", message)
     }
-  }, [draftNote, isPending, note, openSnackbar, paymentId, updatePayment])
+  }, [draftNote, isPending, note, onEditEnd, openSnackbar, paymentId, updatePayment])
 
   return (
     <EditableField
       label="Note"
       htmlFor={id}
       editing={editing}
-      disabled={disabled}
+      disabled={disabled && !editing}
       editButtonLabel="Edit note"
       onEdit={handleEdit}
       error={Boolean(messages?.length)}

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
@@ -50,16 +50,46 @@ describe("PaymentDetailsOverlay", () => {
     const { user } = render(<Default />)
 
     const dialog = await screen.findByRole("dialog", { name: /payment details/i })
-    await user.click(await within(dialog).findByRole("button", { name: /edit amount/i }))
+    await user.click(await within(dialog).findByRole("button", { name: /edit note/i }))
 
-    const amountInput = within(dialog).getByRole("textbox", { name: /amount/i })
-    await user.clear(amountInput)
-    await user.type(amountInput, "2500")
+    const noteInput = within(dialog).getByRole("textbox", { name: /note/i })
+    await user.clear(noteInput)
+    await user.type(noteInput, "ドラッグストア")
     await user.keyboard("{Escape}")
 
     expect(screen.getByRole("dialog", { name: /payment details/i })).toBeInTheDocument()
-    expect(within(dialog).queryByRole("textbox", { name: /amount/i })).not.toBeInTheDocument()
-    expect(within(dialog).getByText(/1,000/)).toBeInTheDocument()
+    expect(within(dialog).queryByRole("textbox", { name: /note/i })).not.toBeInTheDocument()
+    expect(within(dialog).getByText("コンビニ")).toBeInTheDocument()
+  })
+
+  test("オーバーレイを閉じて再表示すると note の draft はリセットされる", async () => {
+    const { user, rerender } = render(<Default />)
+
+    const dialog = await screen.findByRole("dialog", { name: /payment details/i })
+    await user.click(await within(dialog).findByRole("button", { name: /edit note/i }))
+
+    const noteInput = within(dialog).getByRole("textbox", { name: /note/i })
+    await user.clear(noteInput)
+    await user.type(noteInput, "ドラッグストア")
+
+    rerender(<Default open={false} />)
+    rerender(<Default open />)
+
+    const reopenedDialog = await screen.findByRole("dialog", { name: /payment details/i })
+    await user.click(await within(reopenedDialog).findByRole("button", { name: /edit note/i }))
+
+    expect(within(reopenedDialog).getByRole("textbox", { name: /note/i })).toHaveValue("コンビニ")
+  })
+
+  test("note 編集中は amount の編集導線を無効化する", async () => {
+    const { user } = render(<Default />)
+
+    const dialog = await screen.findByRole("dialog", { name: /payment details/i })
+    await user.click(await within(dialog).findByRole("button", { name: /edit note/i }))
+
+    await waitFor(() => {
+      expect(within(dialog).getByRole("button", { name: /edit amount/i })).toBeDisabled()
+    })
   })
 
   test("詳細が見つからない場合は description に not found を表示し詳細操作を出さない", async () => {

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
@@ -87,9 +87,7 @@ describe("PaymentDetailsOverlay", () => {
     const dialog = await screen.findByRole("dialog", { name: /payment details/i })
     await user.click(await within(dialog).findByRole("button", { name: /edit note/i }))
 
-    await waitFor(() => {
-      expect(within(dialog).getByRole("button", { name: /edit amount/i })).toBeDisabled()
-    })
+    expect(within(dialog).getByRole("button", { name: /edit amount/i })).toBeDisabled()
   })
 
   test("詳細が見つからない場合は description に not found を表示し詳細操作を出さない", async () => {

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
@@ -1,5 +1,5 @@
 import { Button, Flex, Separator } from "@radix-ui/themes"
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 import { ResponsiveOverlay } from "../../../../components/overlay/ResponsiveOverlay"
 import type { Payment, PaymentDetails, PaymentId } from "../../../../types/payment"
@@ -24,7 +24,7 @@ export function PaymentDetailsOverlay({
   onDelete,
 }: PaymentDetailsOverlayProps) {
   const { data: payment, isLoading, error } = usePaymentDetails(paymentId)
-  const [isEditingField, setIsEditingField] = useState(false)
+  const [editingField, setEditingField] = useState<"amount" | "note" | null>(null)
   const hasPayment = payment !== null && payment !== undefined
   const isNotFound =
     !isLoading && !error && paymentId !== null && (payment === null || payment === undefined)
@@ -33,16 +33,22 @@ export function PaymentDetailsOverlay({
     : isNotFound
       ? "Payment not found."
       : "Review the payment details."
+  const handleNoteEditingChange = useCallback((editing: boolean) => {
+    setEditingField(editing ? "note" : null)
+  }, [])
+  const handleAmountEditingChange = useCallback((editing: boolean) => {
+    setEditingField(editing ? "amount" : null)
+  }, [])
 
   function handleEscapeKeyDown(event: KeyboardEvent) {
-    if (!isEditingField) return
+    if (editingField === null) return
     event.preventDefault()
   }
 
   useEffect(() => {
     if (open) return
 
-    setIsEditingField(false)
+    setEditingField(null)
   }, [open])
 
   return (
@@ -58,11 +64,17 @@ export function PaymentDetailsOverlay({
           <Flex direction="column" gap="4">
             <PaymentDateField date={payment.date} />
             <CategoryField categoryName={payment.category?.name ?? unknownCategory.name} />
-            <NoteField note={payment.note} />
+            <NoteField
+              paymentId={payment.id}
+              note={payment.note}
+              disabled={editingField !== null && editingField !== "note"}
+              onEditingChange={handleNoteEditingChange}
+            />
             <AmountField
               paymentId={payment.id}
               amount={payment.amount}
-              onEditingChange={setIsEditingField}
+              disabled={editingField !== null && editingField !== "amount"}
+              onEditingChange={handleAmountEditingChange}
             />
           </Flex>
           {onDelete ? (

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
@@ -1,5 +1,5 @@
 import { Button, Flex, Separator } from "@radix-ui/themes"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useState } from "react"
 
 import { ResponsiveOverlay } from "../../../../components/overlay/ResponsiveOverlay"
 import type { Payment, PaymentDetails, PaymentId } from "../../../../types/payment"
@@ -24,7 +24,7 @@ export function PaymentDetailsOverlay({
   onDelete,
 }: PaymentDetailsOverlayProps) {
   const { data: payment, isLoading, error } = usePaymentDetails(paymentId)
-  const [editingField, setEditingField] = useState<"amount" | "note" | null>(null)
+  const [isEditingField, setIsEditingField] = useState(false)
   const hasPayment = payment !== null && payment !== undefined
   const isNotFound =
     !isLoading && !error && paymentId !== null && (payment === null || payment === undefined)
@@ -33,28 +33,31 @@ export function PaymentDetailsOverlay({
     : isNotFound
       ? "Payment not found."
       : "Review the payment details."
-  const handleNoteEditingChange = useCallback((editing: boolean) => {
-    setEditingField(editing ? "note" : null)
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        setIsEditingField(false)
+      }
+      onOpenChange(nextOpen)
+    },
+    [onOpenChange],
+  )
+  const handleEditStart = useCallback(() => {
+    setIsEditingField(true)
   }, [])
-  const handleAmountEditingChange = useCallback((editing: boolean) => {
-    setEditingField(editing ? "amount" : null)
+  const handleEditEnd = useCallback(() => {
+    setIsEditingField(false)
   }, [])
 
   function handleEscapeKeyDown(event: KeyboardEvent) {
-    if (editingField === null) return
+    if (!isEditingField) return
     event.preventDefault()
   }
-
-  useEffect(() => {
-    if (open) return
-
-    setEditingField(null)
-  }, [open])
 
   return (
     <ResponsiveOverlay
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={handleOpenChange}
       onEscapeKeyDown={handleEscapeKeyDown}
       title="Payment details"
       description={description}
@@ -67,14 +70,16 @@ export function PaymentDetailsOverlay({
             <NoteField
               paymentId={payment.id}
               note={payment.note}
-              disabled={editingField !== null && editingField !== "note"}
-              onEditingChange={handleNoteEditingChange}
+              disabled={isEditingField}
+              onEditStart={handleEditStart}
+              onEditEnd={handleEditEnd}
             />
             <AmountField
               paymentId={payment.id}
               amount={payment.amount}
-              disabled={editingField !== null && editingField !== "amount"}
-              onEditingChange={handleAmountEditingChange}
+              disabled={isEditingField}
+              onEditStart={handleEditStart}
+              onEditEnd={handleEditEnd}
             />
           </Flex>
           {onDelete ? (


### PR DESCRIPTION
## 関連Issue

- #1146

## 変更内容

- PaymentDetailsOverlay の Note をインライン編集できるようにしました
- Enter または保存アイコンで保存でき、Escape で編集だけ解除できるようにしました
- 保存中・失敗時のフィードバックと、関連 Story/Test を更新しました

## 動作確認

- [x] `task web:verify`
- [x] ローカル環境でメモの更新

## 補足

- Issue #1146 のうち、Note のインライン編集に絞った対応です
