### PR TITLE
feat: 支払い詳細の日付フィールドをインライン編集対応

### DIFF
--- a/apps/web/src/components/inputs/DatePicker/DatePicker.test.tsx
+++ b/apps/web/src/components/inputs/DatePicker/DatePicker.test.tsx
@@ -48,3 +48,10 @@ test("Select today", async () => {
     expect(screen.queryByRole("button", { name: /今日/i })).not.toBeInTheDocument()
   })
 })
+
+test("autoFocus のときは初期表示でカレンダーを開く", async () => {
+  render(<SelectToday autoFocus />, { userOptions: { delay: null } })
+
+  expect(screen.getByRole("textbox")).toBeInTheDocument()
+  expect(await screen.findByRole("button", { name: /今日/i })).toBeInTheDocument()
+})

--- a/apps/web/src/components/inputs/DatePicker/DatePicker.tsx
+++ b/apps/web/src/components/inputs/DatePicker/DatePicker.tsx
@@ -35,7 +35,7 @@ export function DatePicker(props: DatePickerProps) {
     value,
     ...restProps
   } = props
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(() => Boolean(autoFocus && !disabled))
   const sameDayClickRef = useRef(false)
 
   const handleTriggerClick = useCallback(() => {

--- a/apps/web/src/components/inputs/DatePicker/DatePicker.tsx
+++ b/apps/web/src/components/inputs/DatePicker/DatePicker.tsx
@@ -1,6 +1,7 @@
 import { CalendarIcon } from "@radix-ui/react-icons"
 import { Popover, TextField } from "@radix-ui/themes"
-import { useCallback, useState } from "react"
+import { isSameDay } from "date-fns"
+import { type KeyboardEvent, useCallback, useRef, useState } from "react"
 import { DayPicker } from "react-day-picker"
 import { ja } from "react-day-picker/locale"
 
@@ -18,11 +19,24 @@ type DatePickerProps = {
   disabled?: boolean
   id?: string
   name?: string
+  onEscapeKeyDown?: () => void
+  required?: boolean
 } & ModeSingleProps
 
 export function DatePicker(props: DatePickerProps) {
-  const { autoFocus, disabled, id, name, onChange, value, ...restProps } = props
+  const {
+    autoFocus,
+    disabled,
+    id,
+    name,
+    onChange,
+    onEscapeKeyDown,
+    required,
+    value,
+    ...restProps
+  } = props
   const [open, setOpen] = useState(false)
+  const sameDayClickRef = useRef(false)
 
   const handleTriggerClick = useCallback(() => {
     if (disabled) return
@@ -31,10 +45,29 @@ export function DatePicker(props: DatePickerProps) {
 
   const handleChange = useCallback(
     (date: Date | undefined) => {
+      if (sameDayClickRef.current && date && value && isSameDay(date, value)) {
+        sameDayClickRef.current = false
+        return
+      }
+
+      sameDayClickRef.current = false
       onChange?.(date)
       setOpen(false)
     },
-    [onChange],
+    [onChange, value],
+  )
+
+  const handleDayClick = useCallback(
+    (day: Date) => {
+      if (!required || !value || !isSameDay(day, value)) {
+        return
+      }
+
+      sameDayClickRef.current = true
+      onChange?.(day)
+      setOpen(false)
+    },
+    [onChange, required, value],
   )
 
   const handleFocusOut = useCallback(() => {
@@ -43,12 +76,25 @@ export function DatePicker(props: DatePickerProps) {
 
   const handleEscapeKeyDown = useCallback(() => {
     setOpen(false)
-  }, [])
+    onEscapeKeyDown?.()
+  }, [onEscapeKeyDown])
 
   const handleInputChange = useCallback(() => {
     // 入力欄は日付表示専用で、値変更はカレンダー選択でのみ受け付ける。
     // `readOnly` は既存の見た目に影響するため使わず、controlled input 警告の抑止だけを行う。
   }, [])
+
+  const handleInputKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key !== "Escape") return
+
+      event.preventDefault()
+      event.stopPropagation()
+      setOpen(false)
+      onEscapeKeyDown?.()
+    },
+    [onEscapeKeyDown],
+  )
 
   return (
     <div>
@@ -63,6 +109,7 @@ export function DatePicker(props: DatePickerProps) {
               placeholder="Pick a date"
               value={value ? formatDateToLocaleString(value) : ""}
               onChange={handleInputChange}
+              onKeyDown={handleInputKeyDown}
             >
               <TextField.Slot>
                 <CalendarIcon width="18" height="18" />
@@ -75,7 +122,9 @@ export function DatePicker(props: DatePickerProps) {
             {...restProps}
             locale={ja}
             mode="single"
+            required={required}
             selected={value}
+            onDayClick={handleDayClick}
             onSelect={handleChange}
           />
         </Popover.Content>

--- a/apps/web/src/features/payments/paymentDetails/PaymentDateField/PaymentDateField.stories.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDateField/PaymentDateField.stories.tsx
@@ -1,16 +1,46 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { QueryClientProvider } from "@tanstack/react-query"
+import { fn } from "storybook/test"
 
+import { createQueryClient } from "../../../../lib/queryClient"
+import { SnackbarProvider } from "../../../../providers/snackbar"
+import { ThemeProvider } from "../../../../providers/theme/ThemeProvider"
+import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
 import { PaymentDateField } from "./PaymentDateField"
 
 const meta = {
   title: "Features/PaymentDetails/PaymentDateField",
   component: PaymentDateField,
+  parameters: {
+    layout: "centered",
+    mockingDate: new Date(2025, 5, 2),
+    msw: {
+      handlers: createPaymentHandlers(),
+    },
+  },
   args: {
+    paymentId: 1,
     date: new Date(2025, 5, 2),
   },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={createQueryClient()}>
+        <ThemeProvider>
+          <SnackbarProvider>
+            <Story />
+          </SnackbarProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    ),
+  ],
 } satisfies Meta<typeof PaymentDateField>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  args: {
+    onEditStart: fn(),
+    onEditEnd: fn(),
+  },
+}

--- a/apps/web/src/features/payments/paymentDetails/PaymentDateField/PaymentDateField.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDateField/PaymentDateField.test.tsx
@@ -1,16 +1,149 @@
 import { composeStories } from "@storybook/react-vite"
-import { describe, expect, test } from "vitest"
+import { setDefaultOptions } from "date-fns"
+import { enUS, ja } from "date-fns/locale"
+import { HttpResponse, http } from "msw"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
-import { render, screen } from "../../../../test/test-utils"
+import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
+import { server } from "../../../../test/msw/server"
+import { render, screen, waitFor } from "../../../../test/test-utils"
+import { PaymentDateField } from "./PaymentDateField"
 import * as stories from "./PaymentDateField.stories"
 
 const { Default } = composeStories(stories)
 
+beforeEach(() => {
+  vi.stubGlobal("jest", {
+    advanceTimersByTime: vi.advanceTimersByTime.bind(vi),
+  })
+
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date("2025-06-02T12:00:00+09:00"))
+  setDefaultOptions({ locale: enUS })
+  server.resetHandlers(...createPaymentHandlers())
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  setDefaultOptions({ locale: ja })
+})
+
 describe("PaymentDetails PaymentDateField", () => {
-  test("Default story ではラベルと日付を表示する", () => {
-    render(<Default />)
+  test("Default story ではラベルと日付と編集ボタンを表示する", () => {
+    render(<Default />, { userOptions: { delay: null } })
 
     expect(screen.getByText("Date")).toBeInTheDocument()
     expect(screen.getByText("2025/06/02")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /edit date/i })).toBeInTheDocument()
+  })
+
+  test("編集ボタンを押すと日付入力欄を開く", async () => {
+    const { user } = render(<Default />, { userOptions: { delay: null } })
+
+    await user.click(screen.getByRole("button", { name: /edit date/i }))
+
+    expect(screen.getByRole("textbox", { name: /date/i })).toBeInTheDocument()
+  })
+
+  test("日付を選ぶと保存して editor を閉じる", async () => {
+    const { user } = render(<Default />, { userOptions: { delay: null } })
+
+    await user.click(screen.getByRole("button", { name: /edit date/i }))
+    await user.click(screen.getByRole("textbox", { name: /date/i }))
+    await user.click(await screen.findByRole("button", { name: /2025年6月3日/ }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("textbox", { name: /date/i })).not.toBeInTheDocument()
+    })
+  })
+
+  test("同日を再選択すると API は呼ばずに editor と popover が閉じる", async () => {
+    let updateCalls = 0
+
+    server.use(
+      http.patch("*/rest/v1/payments*", async () => {
+        updateCalls += 1
+        return HttpResponse.json({ message: "Updated" })
+      }),
+    )
+
+    const { user } = render(<Default />, { userOptions: { delay: null } })
+
+    await user.click(screen.getByRole("button", { name: /edit date/i }))
+    await user.click(screen.getByRole("textbox", { name: /date/i }))
+    await user.click(await screen.findByRole("button", { name: /2025年6月2日/ }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("textbox", { name: /date/i })).not.toBeInTheDocument()
+    })
+    expect(updateCalls).toBe(0)
+  })
+
+  test("保存失敗時は編集状態を維持してエラーを表示する", async () => {
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        update: { error: true },
+      }),
+    )
+
+    const { user } = render(<Default />, { userOptions: { delay: null } })
+
+    await user.click(screen.getByRole("button", { name: /edit date/i }))
+    await user.click(screen.getByRole("textbox", { name: /date/i }))
+    await user.click(await screen.findByRole("button", { name: /2025年6月3日/ }))
+
+    expect(
+      await screen.findByText("Failed to update date.", { selector: "span" }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole("textbox", { name: /date/i })).toBeInTheDocument()
+  })
+
+  test("保存中は日付入力欄を操作不可にする", async () => {
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        update: { durationOrMode: 1000 },
+      }),
+    )
+
+    const { user } = render(<Default />, { userOptions: { delay: null } })
+
+    await user.click(screen.getByRole("button", { name: /edit date/i }))
+    await user.click(screen.getByRole("textbox", { name: /date/i }))
+    await user.click(await screen.findByRole("button", { name: /2025年6月3日/ }))
+
+    expect(screen.getByRole("textbox", { name: /date/i })).toBeDisabled()
+  })
+
+  test("Escape で編集を閉じると onEditEnd を呼ぶ", async () => {
+    let editStartCalls = 0
+    let editEndCalls = 0
+    const onEditStart = () => {
+      editStartCalls += 1
+    }
+    const onEditEnd = () => {
+      editEndCalls += 1
+    }
+    const { user } = render(
+      <PaymentDateField
+        paymentId={1}
+        date={new Date(2025, 5, 2)}
+        onEditStart={onEditStart}
+        onEditEnd={onEditEnd}
+      />,
+      {
+        userOptions: { delay: null },
+      },
+    )
+
+    await user.click(screen.getByRole("button", { name: /edit date/i }))
+    await user.click(screen.getByRole("textbox", { name: /date/i }))
+    await user.keyboard("{Escape}")
+
+    await waitFor(() => {
+      expect(screen.queryByRole("textbox", { name: /date/i })).not.toBeInTheDocument()
+    })
+    expect(editStartCalls).toBe(1)
+    expect(editEndCalls).toBe(1)
   })
 })

--- a/apps/web/src/features/payments/paymentDetails/PaymentDateField/PaymentDateField.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDateField/PaymentDateField.test.tsx
@@ -38,12 +38,13 @@ describe("PaymentDetails PaymentDateField", () => {
     expect(screen.getByRole("button", { name: /edit date/i })).toBeInTheDocument()
   })
 
-  test("編集ボタンを押すと日付入力欄を開く", async () => {
+  test("編集ボタンを押すと日付入力欄とカレンダーを開く", async () => {
     const { user } = render(<Default />, { userOptions: { delay: null } })
 
     await user.click(screen.getByRole("button", { name: /edit date/i }))
 
     expect(screen.getByRole("textbox", { name: /date/i })).toBeInTheDocument()
+    expect(await screen.findByRole("button", { name: /今日/i })).toBeInTheDocument()
   })
 
   test("日付を選ぶと保存して editor を閉じる", async () => {

--- a/apps/web/src/features/payments/paymentDetails/PaymentDateField/PaymentDateField.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDateField/PaymentDateField.tsx
@@ -1,17 +1,139 @@
 import { Text } from "@radix-ui/themes"
+import { format } from "date-fns"
+import { useCallback, useEffect, useId, useRef, useState } from "react"
 
-import { BaseField, FieldLabel } from "../../../../components/inputs/BaseField"
+import { DatePicker } from "../../../../components/inputs/DatePicker"
+import { useSnackbar } from "../../../../providers/snackbar"
+import type { PaymentId } from "../../../../types/payment"
 import { formatDateToLocaleString } from "../../../../utils/formatter/formatDateToLocaleString"
+import { getZodErrorMessages } from "../../../../utils/getZodErrorMessages"
+import { dateFieldSchema } from "../../paymentFormSchema"
+import { useUpdatePayment } from "../../updatePayment/useUpdatePayment"
+import { EditableField } from "../EditableField"
 
 interface PaymentDateFieldProps {
+  paymentId: PaymentId
   date: Date
+  disabled?: boolean
+  onEditStart: () => void
+  onEditEnd: () => void
 }
 
-export function PaymentDateField({ date }: PaymentDateFieldProps) {
-  return (
-    <BaseField gap="2">
-      <FieldLabel>Date</FieldLabel>
-      <Text size="4">{formatDateToLocaleString(date)}</Text>
-    </BaseField>
+export function PaymentDateField({
+  paymentId,
+  date,
+  disabled = false,
+  onEditStart,
+  onEditEnd,
+}: PaymentDateFieldProps) {
+  const id = useId()
+  const { openSnackbar } = useSnackbar()
+  const { updatePayment, isPending } = useUpdatePayment()
+  const [editing, setEditing] = useState(false)
+  const editingRef = useRef(false)
+  const [draftDate, setDraftDate] = useState<Date | undefined>(date)
+  const [messages, setMessages] = useState<string[] | undefined>()
+
+  useEffect(() => {
+    return () => {
+      if (editingRef.current) {
+        onEditEnd()
+      }
+    }
+  }, [onEditEnd])
+
+  const closeEditor = useCallback(() => {
+    if (!editingRef.current) return
+
+    editingRef.current = false
+    setEditing(false)
+    onEditEnd()
+  }, [onEditEnd])
+
+  const handleEdit = useCallback(() => {
+    setDraftDate(date)
+    setMessages(undefined)
+    editingRef.current = true
+    setEditing(true)
+    onEditStart()
+  }, [date, onEditStart])
+
+  const handleCancel = useCallback(() => {
+    if (isPending) return
+
+    setDraftDate(date)
+    setMessages(undefined)
+    closeEditor()
+  }, [closeEditor, date, isPending])
+
+  const handleChange = useCallback(
+    async (nextDate: Date | undefined) => {
+      if (isPending) return
+
+      const result = dateFieldSchema.safeParse(nextDate)
+
+      if (!result.success) {
+        setMessages(getZodErrorMessages(result.error))
+        return
+      }
+
+      setDraftDate(result.data)
+
+      if (toDateOnlyKey(result.data) === toDateOnlyKey(date)) {
+        setMessages(undefined)
+        closeEditor()
+        return
+      }
+
+      try {
+        setMessages(undefined)
+        await updatePayment({
+          paymentId,
+          patch: { date: result.data },
+        })
+        closeEditor()
+      } catch {
+        const message = "Failed to update date."
+
+        setMessages([message])
+        openSnackbar("error", message)
+      }
+    },
+    [closeEditor, date, isPending, openSnackbar, paymentId, updatePayment],
   )
+
+  return (
+    <EditableField
+      label="Date"
+      htmlFor={id}
+      required
+      editing={editing}
+      disabled={disabled && !editing}
+      editButtonLabel="Edit date"
+      onEdit={handleEdit}
+      error={Boolean(messages?.length)}
+      messages={messages}
+      view={
+        <Text size="4" style={{ flex: 1 }}>
+          {formatDateToLocaleString(date)}
+        </Text>
+      }
+      editor={
+        <DatePicker
+          autoFocus
+          disabled={isPending}
+          id={id}
+          name="date"
+          required
+          value={draftDate}
+          onChange={handleChange}
+          onEscapeKeyDown={handleCancel}
+        />
+      }
+    />
+  )
+}
+
+function toDateOnlyKey(date: Date): string {
+  return format(date, "yyyy-MM-dd")
 }

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
@@ -116,13 +116,13 @@ describe("PaymentDetailsOverlay", () => {
       expect(await within(dialog).findByRole("button", { name: /edit date/i })).toBeInTheDocument()
     })
 
-    test("date 編集中は他フィールドの編集導線を無効化する", async () => {
+    test("date 編集中はカレンダーを開き、他フィールドの編集導線を無効化する", async () => {
       const { user } = render(<Default />, { userOptions: { delay: null } })
 
       const dialog = await screen.findByRole("dialog", { name: /payment details/i })
       await user.click(await within(dialog).findByRole("button", { name: /edit date/i }))
-      await user.click(within(dialog).getByRole("textbox", { name: /date/i }))
 
+      expect(await screen.findByRole("button", { name: /今日/i })).toBeInTheDocument()
       expect(within(dialog).getByRole("button", { name: /edit note/i })).toBeDisabled()
       expect(within(dialog).getByRole("button", { name: /edit amount/i })).toBeDisabled()
     })

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
@@ -1,6 +1,8 @@
 import { composeStories } from "@storybook/react-vite"
+import { setDefaultOptions } from "date-fns"
+import { enUS, ja } from "date-fns/locale"
 import { HttpResponse, http } from "msw"
-import { beforeEach, describe, expect, test } from "vitest"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
 import { payments } from "../../../../test/data/payments"
 import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
@@ -88,6 +90,73 @@ describe("PaymentDetailsOverlay", () => {
     await user.click(await within(dialog).findByRole("button", { name: /edit note/i }))
 
     expect(within(dialog).getByRole("button", { name: /edit amount/i })).toBeDisabled()
+  })
+
+  describe("Date editing", () => {
+    beforeEach(() => {
+      vi.stubGlobal("jest", {
+        advanceTimersByTime: vi.advanceTimersByTime.bind(vi),
+      })
+
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date("2025-06-02T12:00:00+09:00"))
+      setDefaultOptions({ locale: enUS })
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+      vi.unstubAllGlobals()
+      setDefaultOptions({ locale: ja })
+    })
+
+    test("Default story では日付編集ボタンも表示する", async () => {
+      render(<Default />, { userOptions: { delay: null } })
+
+      const dialog = await screen.findByRole("dialog", { name: /payment details/i })
+      expect(await within(dialog).findByRole("button", { name: /edit date/i })).toBeInTheDocument()
+    })
+
+    test("date 編集中は他フィールドの編集導線を無効化する", async () => {
+      const { user } = render(<Default />, { userOptions: { delay: null } })
+
+      const dialog = await screen.findByRole("dialog", { name: /payment details/i })
+      await user.click(await within(dialog).findByRole("button", { name: /edit date/i }))
+      await user.click(within(dialog).getByRole("textbox", { name: /date/i }))
+
+      expect(within(dialog).getByRole("button", { name: /edit note/i })).toBeDisabled()
+      expect(within(dialog).getByRole("button", { name: /edit amount/i })).toBeDisabled()
+    })
+
+    test("date 編集中の Escape はオーバーレイを閉じずに編集だけ解除する", async () => {
+      const { user } = render(<Default />, { userOptions: { delay: null } })
+
+      const dialog = await screen.findByRole("dialog", { name: /payment details/i })
+      await user.click(await within(dialog).findByRole("button", { name: /edit date/i }))
+      await user.click(within(dialog).getByRole("textbox", { name: /date/i }))
+      await user.keyboard("{Escape}")
+
+      expect(screen.getByRole("dialog", { name: /payment details/i })).toBeInTheDocument()
+      expect(within(dialog).queryByRole("textbox", { name: /date/i })).not.toBeInTheDocument()
+      expect(within(dialog).getByText("2025/06/02")).toBeInTheDocument()
+    })
+
+    test("オーバーレイを閉じて再表示すると date の draft はリセットされる", async () => {
+      const { user, rerender } = render(<Default />, { userOptions: { delay: null } })
+
+      const dialog = await screen.findByRole("dialog", { name: /payment details/i })
+      await user.click(await within(dialog).findByRole("button", { name: /edit date/i }))
+      await user.click(within(dialog).getByRole("textbox", { name: /date/i }))
+
+      rerender(<Default open={false} />)
+      rerender(<Default open />)
+
+      const reopenedDialog = await screen.findByRole("dialog", { name: /payment details/i })
+      await user.click(await within(reopenedDialog).findByRole("button", { name: /edit date/i }))
+
+      expect(within(reopenedDialog).getByRole("textbox", { name: /date/i })).toHaveValue(
+        "2025/06/02",
+      )
+    })
   })
 
   test("詳細が見つからない場合は description に not found を表示し詳細操作を出さない", async () => {

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
@@ -65,7 +65,13 @@ export function PaymentDetailsOverlay({
       {hasPayment ? (
         <Flex direction="column" gap="4">
           <Flex direction="column" gap="4">
-            <PaymentDateField date={payment.date} />
+            <PaymentDateField
+              paymentId={payment.id}
+              date={payment.date}
+              disabled={isEditingField}
+              onEditStart={handleEditStart}
+              onEditEnd={handleEditEnd}
+            />
             <CategoryField categoryName={payment.category?.name ?? unknownCategory.name} />
             <NoteField
               paymentId={payment.id}


### PR DESCRIPTION
## 関連Issue

- #1146

## 変更内容

- `PaymentDetailsOverlay` の `Date` をインライン編集できるように変更
- 同日再選択では更新 API を呼ばずに editor / popover を閉じる挙動を追加
- `PaymentDateField` と `PaymentDetailsOverlay` の Story/Test を更新

## 動作確認

- [x] ローカルでの動作確認
- [x] テストの実行 (`task web:verify`)
- [ ] UIの確認（スクリーンショット等）

## 補足

- `Date` のみを対象にした実装で、Issue 1146 全体はまだ完了していません