### PR TITLE
Web検証とドキュメント方針を整理する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Personal savings management app. Monorepo with two apps (`apps/web/` and `apps/a
 ## Key Conventions
 
 - Web design decisions: `apps/web/docs/adr/`
+- Storybook browser test policy: `docs/storybook-browser-tests.md`
 - Commit messages in Japanese, type in English (feat/fix/chore/refactor/test/docs)
 - No unrelated code changes
 - When changing an existing workflow, command path, or configuration surface, follow the established pattern in the same layer unless there is a clear reason to change it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,8 +17,11 @@ Personal savings management app. Monorepo with two apps (`apps/web/` and `apps/a
 
 ## Key Conventions
 
-- Web design decisions: `apps/web/docs/adr/`
-- Storybook browser test policy: `docs/storybook-browser-tests.md`
+- Repository-wide docs: `docs/`
+- App-specific docs: `apps/*/docs/`
+- Documentation policy: `docs/documentation-policy.md`
+- When a task may touch documented design decisions, policies, or operational guidance, inspect Markdown front matter in the docs directories and read the relevant docs for the current session.
+- Use front matter fields such as `area`, `applies_to`, `topics`, `when_to_read`, and `status` to choose which docs apply. Do not rely on `deprecated` docs unless the task explicitly concerns deprecated behavior.
 - Commit messages in Japanese, type in English (feat/fix/chore/refactor/test/docs)
 - No unrelated code changes
 - When changing an existing workflow, command path, or configuration surface, follow the established pattern in the same layer unless there is a clear reason to change it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,4 +42,15 @@ Documentation-only changes or other changes
 that do not affect runtime behavior, build output, or type safety
 do not require verification.
 
-- **Web** (`apps/web/`): `task web:verify`
+- Define verification as the concrete commands for each app, not a `verify` wrapper task.
+- When application code changes, run the verification commands for the affected app from the repository root.
+- If the current diff is exactly identical to the diff for the most recent run of the same verification commands, you may skip rerunning them.
+
+- **Web** (`apps/web/`)
+  `task web:lint`
+  `task web:format-check`
+  `task web:typecheck`
+  `task web:test-unit`
+  `task web:test-storybook`
+- **API** (`apps/api`)
+  No dedicated verification commands are currently defined. If verification commands are added later, define the concrete commands here.

--- a/apps/web/.storybook-test/main.ts
+++ b/apps/web/.storybook-test/main.ts
@@ -1,0 +1,18 @@
+import type { StorybookConfig } from "@storybook/react-vite"
+
+const config: StorybookConfig = {
+  stories: ["../src/app/routes/**/*.stories.tsx"],
+  addons: [
+    "@storybook/addon-onboarding",
+    "@chromatic-com/storybook",
+    "storybook-addon-mock-date",
+    "@storybook/addon-vitest",
+    "@storybook/addon-docs",
+  ],
+  framework: {
+    name: "@storybook/react-vite",
+    options: {},
+  },
+}
+
+export default config

--- a/apps/web/.storybook-test/preview.tsx
+++ b/apps/web/.storybook-test/preview.tsx
@@ -1,0 +1,1 @@
+export { default } from "../.storybook/preview"

--- a/apps/web/.storybook-test/vitest.setup.ts
+++ b/apps/web/.storybook-test/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "../.storybook/vitest.setup"

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -93,7 +93,16 @@ pnpm lint
 pnpm format
 ```
 
-まとめて確認したい場合は `task verify` で lint、format check、typecheck、test を直列実行できます。
+検証は個別コマンドを順に実行します。
+
+```bash
+task lint
+task format-check
+task typecheck
+task test-unit
+task test-storybook
+```
+
 型チェックは `task typecheck` で明示的に実行できます。`task build` でも `tsc -b` を通るため、ビルド時にも型チェックされます。
 `pnpm typecheck` を直接実行しても同じチェックが走ります。
 

--- a/apps/web/Taskfile.yml
+++ b/apps/web/Taskfile.yml
@@ -28,10 +28,10 @@ tasks:
     cmd: pnpm typecheck
   test-unit:
     desc: Run unit and integration tests
-    cmd: pnpm test:unit --silent --reporter=dot {{.CLI_ARGS}}
+    cmd: pnpm test:unit --reporter=dot {{.CLI_ARGS}}
   test-storybook:
     desc: Run Storybook interaction tests
-    cmd: pnpm test:storybook --silent --reporter=dot {{.CLI_ARGS}}
+    cmd: pnpm test:storybook --reporter=dot {{.CLI_ARGS}}
   test:
     desc: Run all tests sequentially
     cmds:

--- a/apps/web/Taskfile.yml
+++ b/apps/web/Taskfile.yml
@@ -37,14 +37,6 @@ tasks:
     cmds:
       - task test-unit -- {{.CLI_ARGS}}
       - task test-storybook -- {{.CLI_ARGS}}
-  verify:
-    desc: Run all verification tasks sequentially
-    cmds:
-      - task lint
-      - task format-check
-      - task typecheck
-      - task test-unit
-      - task test-storybook
   build:
     desc: Build the application for production
     cmd: pnpm build {{.CLI_ARGS}}

--- a/apps/web/docs/adr/feature_directory.md
+++ b/apps/web/docs/adr/feature_directory.md
@@ -1,3 +1,19 @@
+---
+title: ディレクトリ構成について
+doc_type: adr
+status: accepted
+area: web
+applies_to:
+  - apps/web/src/features
+topics:
+  - feature-directory
+  - project-structure
+  - frontend-architecture
+when_to_read:
+  - Webアプリに新しい機能ディレクトリを追加するとき
+  - features配下の構成を変更するとき
+---
+
 # ADR: ディレクトリ構成について
 
 ## ステータス

--- a/apps/web/docs/policies/storybook-browser-tests.md
+++ b/apps/web/docs/policies/storybook-browser-tests.md
@@ -1,3 +1,20 @@
+---
+title: Storybook Browser Tests
+doc_type: policy
+status: accepted
+area: web
+applies_to:
+  - apps/web
+topics:
+  - storybook
+  - browser-test
+  - vitest
+when_to_read:
+  - Storybookのブラウザテスト対象を変更するとき
+  - Page storyを追加または変更するとき
+  - task web:test-storybookの対象範囲を確認するとき
+---
+
 # Storybook Browser Tests
 
 Storybook のブラウザテストは opt-in で運用します。

--- a/apps/web/docs/policies/storybook-browser-tests.md
+++ b/apps/web/docs/policies/storybook-browser-tests.md
@@ -19,7 +19,9 @@ when_to_read:
 
 Storybook のブラウザテストは opt-in で運用します。
 
-`task web:test-storybook` は `browser-test` tag が付いた story だけを対象にします。ブラウザ実行はコストが高いため、Storybook 上の全 story を網羅するのではなく、ページ単位または統合境界をまたぐ story に絞ります。
+`task web:test-storybook` は `apps/web/.storybook-test/` の Storybook 設定を使い、`apps/web/src/app/routes/**/*.stories.tsx` 配下の Page story だけを読み込みます。その上で、`browser-test` tag が付いた story だけを対象にします。
+
+ブラウザ実行はコストが高いため、Storybook 上の全 story を網羅するのではなく、ページ単位または統合境界をまたぐ story に絞ります。
 
 ## 対象にする story
 
@@ -47,3 +49,5 @@ const meta = {
 ```
 
 Page 以外の story に `browser-test` を付ける場合は、ブラウザテスト対象にする理由が story の責務から読み取れるようにしてください。
+
+通常の Storybook は `apps/web/.storybook/` を使い、カタログ用途として全 story を読み込みます。`apps/web/.storybook-test/` は `task web:test-storybook` 専用で、テスト実行時の読み込み負荷を抑えるために Page story へ限定します。

--- a/apps/web/src/app/routes/AuthPage/AuthPage.stories.tsx
+++ b/apps/web/src/app/routes/AuthPage/AuthPage.stories.tsx
@@ -5,6 +5,7 @@ import { AuthPage } from "./AuthPage"
 
 const meta = {
   component: AuthPage,
+  tags: ["browser-test"],
 } satisfies Meta<typeof AuthPage>
 
 export default meta

--- a/apps/web/src/app/routes/PaymentsPage/PaymentPage.stories.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentPage.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
       ],
     },
   },
-  tags: ["autodocs"],
+  tags: ["autodocs", "browser-test"],
   decorators: [createStoryRouter("/payments?year=2025&month=6", paymentsRouteBuilder)],
   argTypes: {},
   args: {},

--- a/apps/web/src/app/routes/TopPage/TopPage.stories.tsx
+++ b/apps/web/src/app/routes/TopPage/TopPage.stories.tsx
@@ -7,7 +7,7 @@ const meta = {
   title: "Pages/TopPage",
   component: TopPage,
   parameters: {},
-  tags: ["autodocs"],
+  tags: ["autodocs", "browser-test"],
   decorators: [createStoryRouter("/")],
   argTypes: {},
   args: {},

--- a/apps/web/src/features/payments/components/CategorySelect/CategorySelect.stories.tsx
+++ b/apps/web/src/features/payments/components/CategorySelect/CategorySelect.stories.tsx
@@ -60,22 +60,6 @@ export const Empty: Story = {
   },
 }
 
-export const EmptyWithAllowEmptyOption: Story = {
-  args: {
-    allowEmptyOption: true,
-    children: categoryOptions,
-    value: "",
-  },
-}
-
-export const AllowEmptyOption: Story = {
-  args: {
-    allowEmptyOption: true,
-    children: categoryOptions,
-    value: String(categories[0]?.id),
-  },
-}
-
 export const Loading: Story = {
   args: {
     children: <LoadingCategoryOption />,

--- a/apps/web/src/features/payments/components/CategorySelect/CategorySelect.test.tsx
+++ b/apps/web/src/features/payments/components/CategorySelect/CategorySelect.test.tsx
@@ -5,34 +5,22 @@ import { describe, expect, test, vi } from "vitest"
 import { render, screen } from "../../../../test/test-utils"
 import * as stories from "./CategorySelect.stories"
 
-const { AllowEmptyOption, Default, Empty, EmptyWithAllowEmptyOption, ErrorState, Filled, Loading } =
-  composeStories(stories)
+const { Default, Empty, ErrorState, Filled, Loading } = composeStories(stories)
 
 const renderWithTheme = (component: React.ReactElement) => {
   return render(<Theme>{component}</Theme>)
 }
 
 describe("CategorySelect", () => {
-  test("allowEmptyOption が false のとき空文字は未選択として扱う", async () => {
-    const { user } = renderWithTheme(<Empty />)
-
-    const combobox = screen.getByRole("combobox")
-    expect(combobox).toHaveTextContent("Pick a category")
-
-    await user.click(combobox)
-
-    expect(screen.queryByRole("option", { name: /^none$/i })).not.toBeInTheDocument()
-  })
-
-  test("allowEmptyOption が true のとき空文字は None を選択値にする", () => {
-    renderWithTheme(<EmptyWithAllowEmptyOption />)
+  test("空文字は None を選択値にする", () => {
+    renderWithTheme(<Empty />)
 
     expect(screen.getByRole("combobox")).toHaveTextContent("None")
   })
 
   test("none を選ぶと空文字へ変換して通知する", async () => {
     const handleChange = vi.fn()
-    const { user } = renderWithTheme(<AllowEmptyOption onChange={handleChange} />)
+    const { user } = renderWithTheme(<Filled onChange={handleChange} />)
 
     await user.click(screen.getByRole("combobox"))
     await user.click(await screen.findByRole("option", { name: /^none$/i }))

--- a/apps/web/src/features/payments/components/CategorySelect/CategorySelect.tsx
+++ b/apps/web/src/features/payments/components/CategorySelect/CategorySelect.tsx
@@ -6,21 +6,14 @@ import { Category } from "../../../../types/category"
 interface CategorySelectProps {
   id?: string
   value?: string
-  allowEmptyOption?: boolean
   children?: React.ReactNode
   onChange?: (category: string) => void
 }
 
 const NONE_CATEGORY_VALUE = "none"
 
-export function CategorySelect({
-  id,
-  value,
-  allowEmptyOption = false,
-  children,
-  onChange,
-}: CategorySelectProps) {
-  const selectValue = value === "" ? (allowEmptyOption ? NONE_CATEGORY_VALUE : undefined) : value
+export function CategorySelect({ id, value, children, onChange }: CategorySelectProps) {
+  const selectValue = value === undefined || value === "" ? NONE_CATEGORY_VALUE : value
 
   const handleChange = useCallback(
     (val: string) => {
@@ -37,7 +30,7 @@ export function CategorySelect({
     <Select.Root name="category" value={selectValue} onValueChange={handleChange}>
       <Select.Trigger id={id} placeholder="Pick a category" />
       <Select.Content>
-        {allowEmptyOption && <NoneCategoryOption />}
+        <NoneCategoryOption />
         {children}
       </Select.Content>
     </Select.Root>

--- a/apps/web/src/features/payments/createPayment/CategoryField/CategoryField.test.tsx
+++ b/apps/web/src/features/payments/createPayment/CategoryField/CategoryField.test.tsx
@@ -1,4 +1,5 @@
 import { composeStories } from "@storybook/react-vite"
+import { useState } from "react"
 import { describe, expect, test, vi } from "vitest"
 
 import { render, screen, waitFor, within } from "../../../../test/test-utils"
@@ -10,6 +11,20 @@ function renderStory(story: React.ReactElement) {
   return render(story)
 }
 
+function ControlledDefault({ onChange }: { onChange: (category: string) => void }) {
+  const [value, setValue] = useState("")
+
+  return (
+    <Default
+      value={value}
+      onChange={(category) => {
+        setValue(category)
+        onChange(category)
+      }}
+    />
+  )
+}
+
 describe("CreatePayment CategoryField", () => {
   test("Default story ではカテゴリ入力欄を表示する", async () => {
     renderStory(<Default />)
@@ -19,7 +34,7 @@ describe("CreatePayment CategoryField", () => {
 
   test("カテゴリを選択できる", async () => {
     const onChange = vi.fn()
-    const { user } = renderStory(<Default onChange={onChange} />)
+    const { user } = renderStory(<ControlledDefault onChange={onChange} />)
 
     const select = await screen.findByRole("combobox", { name: /category/i })
     await user.click(select)

--- a/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.test.tsx
+++ b/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.test.tsx
@@ -5,14 +5,16 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 import { createCategoryHandlers } from "../../../../test/msw/handlers/categories"
 import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
 import { server } from "../../../../test/msw/server"
-import { render, screen, type TestUser, waitFor, within } from "../../../../test/test-utils"
+import { act, render, screen, type TestUser, waitFor, within } from "../../../../test/test-utils"
 import * as stories from "./CreatePaymentForm.stories"
 
 const { Default } = composeStories(stories)
 const PAYMENTS_REST_URL = "*/rest/v1/payments*"
 
-function renderStory(story: React.ReactElement) {
-  return render(story)
+async function renderStory(story: React.ReactElement) {
+  return await act(async () => {
+    return render(story)
+  })
 }
 
 async function selectFoodCategory(user: TestUser) {
@@ -34,14 +36,14 @@ describe("CreatePaymentForm", () => {
   })
 
   test("Default story では amount 入力欄に自動フォーカスする", async () => {
-    renderStory(<Default />)
+    await renderStory(<Default />)
 
     const amountField = await screen.findByRole("textbox", { name: /amount/i })
     expect(document.activeElement).toBe(amountField)
   })
 
   test("カテゴリの非同期読み込み後に入力を進められる", async () => {
-    const { user } = renderStory(<Default />)
+    const { user } = await renderStory(<Default />)
 
     await user.click(await screen.findByRole("textbox", { name: /date/i }))
     await selectFoodCategory(user)
@@ -58,7 +60,7 @@ describe("CreatePaymentForm", () => {
   })
 
   test("amount 未入力で送信するとバリデーションエラーを表示する", async () => {
-    const { user } = renderStory(<Default />)
+    const { user } = await renderStory(<Default />)
 
     await user.click(screen.getByRole("button", { name: /create/i }))
 
@@ -77,7 +79,7 @@ describe("CreatePaymentForm", () => {
       }),
     )
 
-    const { user } = renderStory(<Default onSuccess={onSuccess} />)
+    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
 
     await user.type(screen.getByRole("textbox", { name: /amount/i }), "1080")
     await user.click(screen.getByRole("button", { name: /create/i }))
@@ -106,7 +108,7 @@ describe("CreatePaymentForm", () => {
       }),
     )
 
-    const { user } = renderStory(<Default onSuccess={onSuccess} />)
+    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
 
     await selectFoodCategory(user)
     await user.type(screen.getByRole("textbox", { name: /note/i }), "dinner")

--- a/apps/web/src/features/payments/createPayment/CreatePaymentModal/CreatePaymentModal.test.tsx
+++ b/apps/web/src/features/payments/createPayment/CreatePaymentModal/CreatePaymentModal.test.tsx
@@ -5,6 +5,7 @@ import { createCategoryHandlers } from "../../../../test/msw/handlers/categories
 import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
 import { server } from "../../../../test/msw/server"
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -15,6 +16,22 @@ import {
 import * as stories from "./CreatePaymentModal.stories"
 
 const { Default } = composeStories(stories)
+
+async function renderStory(story: React.ReactElement) {
+  return await act(async () => {
+    return render(story)
+  })
+}
+
+async function openCreatePaymentModal() {
+  await act(async () => {
+    // user.click ではモーダル表示時の Suspense 更新が act 内で完了せず警告が出るため、
+    // ここではクリックによる開閉だけを fireEvent で同期的に発火する。
+    fireEvent.click(screen.getByRole("button", { name: /create payment/i }))
+  })
+
+  return await screen.findByRole("dialog", { name: /create payment/i })
+}
 
 async function fillAndSubmit(
   user: TestUser,
@@ -50,36 +67,32 @@ describe("CreatePaymentModal", () => {
   })
 
   test("should stay open when Escape is pressed", async () => {
-    const { user } = render(<Default />)
+    const { user, baseElement } = await renderStory(<Default />)
 
-    await user.click(screen.getByRole("button", { name: /create payment/i }))
-
-    const dialog = await screen.findByRole("dialog", { name: /create payment/i })
+    const dialog = await openCreatePaymentModal()
     expect(dialog).toBeInTheDocument()
 
-    fireEvent.pointerDown(document.body)
-    fireEvent.click(document.body)
-    expect(screen.getByRole("dialog", { name: /create payment/i })).toBeInTheDocument()
+    fireEvent.pointerDown(baseElement) // モーダルの外をクリックするために baseElement をクリック
+    fireEvent.click(baseElement) // モーダルの外をクリックするために baseElement をクリック
 
+    expect(screen.getByRole("dialog", { name: /create payment/i })).toBeInTheDocument()
     await user.keyboard("{Escape}")
+
     expect(screen.getByRole("dialog", { name: /create payment/i })).toBeInTheDocument()
   })
 
   test("トリガー操作でダイアログと amount 入力欄を表示する", async () => {
-    const { user } = render(<Default />)
+    await renderStory(<Default />)
 
-    await user.click(screen.getByRole("button", { name: /create payment/i }))
-
-    const dialog = await screen.findByRole("dialog", { name: /create payment/i })
+    const dialog = await openCreatePaymentModal()
     expect(dialog).toBeInTheDocument()
     expect(await within(dialog).findByLabelText(/amount/i)).toBeInTheDocument()
   })
 
   test("should close when Cancel is clicked", async () => {
-    const { user } = render(<Default />)
+    const { user } = await renderStory(<Default />)
 
-    await user.click(screen.getByRole("button", { name: /create payment/i }))
-    await screen.findByRole("dialog", { name: /create payment/i })
+    await openCreatePaymentModal()
 
     await user.click(screen.getByRole("button", { name: /cancel/i }))
 
@@ -89,12 +102,10 @@ describe("CreatePaymentModal", () => {
   test("連続作成を有効にすると作成後もダイアログを開いたままにする", async () => {
     const onSuccess = vi.fn()
 
-    const { user } = render(<Default onSuccess={onSuccess} />)
+    const { user, baseElement } = await renderStory(<Default onSuccess={onSuccess} />)
 
-    await user.click(screen.getByRole("button", { name: /create payment/i }))
-
-    const body = within(document.body)
-    const dialog = await body.findByRole("dialog", { name: /create payment/i })
+    const body = within(baseElement)
+    const dialog = await openCreatePaymentModal()
     await within(dialog).findByLabelText(/amount/i)
 
     const checkbox = within(dialog).getByRole("checkbox", { name: /continue creating/i })
@@ -128,12 +139,10 @@ describe("CreatePaymentModal", () => {
   test("連続作成が未選択なら作成後に onSuccess が呼ばれる", async () => {
     const onSuccess = vi.fn()
 
-    const { user } = render(<Default onSuccess={onSuccess} />)
+    const { user, baseElement } = await renderStory(<Default onSuccess={onSuccess} />)
 
-    await user.click(screen.getByRole("button", { name: /create payment/i }))
-
-    const body = within(document.body)
-    const dialog = await body.findByRole("dialog", { name: /create payment/i })
+    const body = within(baseElement)
+    const dialog = await openCreatePaymentModal()
     await within(dialog).findByLabelText(/amount/i)
 
     const checkbox = within(dialog).getByRole("checkbox", { name: /continue creating/i })

--- a/apps/web/tsconfig.storybook.json
+++ b/apps/web/tsconfig.storybook.json
@@ -3,5 +3,10 @@
   "compilerOptions": {
     "types": ["vite/client", "vitest/globals"]
   },
-  "include": [".storybook/**/*.ts", ".storybook/**/*.tsx"]
+  "include": [
+    ".storybook/**/*.ts",
+    ".storybook/**/*.tsx",
+    ".storybook-test/**/*.ts",
+    ".storybook-test/**/*.tsx"
+  ]
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -41,12 +41,12 @@ export default defineConfig({
           // The plugin will run tests for the stories defined in your Storybook config
           // See options at: https://storybook.js.org/docs/writing-tests/test-addon#storybooktest
           storybookTest({
-            configDir: path.join(dirname, ".storybook"),
+            configDir: path.join(dirname, ".storybook-test"),
             tags: {
               include: ["browser-test"],
               skip: ["skip"],
             },
-            storybookScript: "pnpm storybook --ci",
+            storybookScript: "pnpm storybook --ci -c .storybook-test",
             storybookUrl: process.env.SB_URL,
           }),
         ],
@@ -58,7 +58,7 @@ export default defineConfig({
             provider: playwright(),
             instances: [{ browser: "chromium" }],
           },
-          setupFiles: [".storybook/vitest.setup.ts"],
+          setupFiles: [".storybook-test/vitest.setup.ts"],
         },
       },
     ],

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -43,6 +43,7 @@ export default defineConfig({
           storybookTest({
             configDir: path.join(dirname, ".storybook"),
             tags: {
+              include: ["browser-test"],
               skip: ["skip"],
             },
             storybookScript: "pnpm storybook --ci",

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -25,6 +25,8 @@ if (!Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = () => {}
 }
 
+window.scrollTo = () => {}
+
 if (!window.matchMedia) {
   window.matchMedia = () => ({
     matches: false,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,19 @@
+---
+title: Architecture Overview
+doc_type: overview
+status: accepted
+area: repository
+applies_to:
+  - .
+topics:
+  - architecture
+  - monorepo
+  - project-structure
+when_to_read:
+  - リポジトリ全体の構成を確認するとき
+  - アプリ間の役割分担を確認するとき
+---
+
 # Architecture Overview
 
 このリポジトリはモノリポジトリ形式で、フロントエンド、バックエンド、運用用スクリプトを分離して管理しています。ここでは高レベルなディレクトリ構成と各領域の役割を簡潔に説明します。詳細な操作手順や実装の細かい説明は各サブプロジェクトの README を参照してください。

--- a/docs/documentation-policy.md
+++ b/docs/documentation-policy.md
@@ -1,0 +1,63 @@
+---
+title: Documentation Policy
+doc_type: policy
+status: accepted
+area: repository
+applies_to:
+  - docs
+  - apps/web/docs
+  - apps/api/docs
+topics:
+  - documentation
+  - front-matter
+  - agent-guidance
+when_to_read:
+  - ドキュメントを追加または更新するとき
+  - Codexが参照するドキュメントを判断するとき
+  - AGENTS.mdのドキュメント参照方針を変更するとき
+---
+
+# Documentation Policy
+
+このリポジトリの恒常的なドキュメントは、front matter を使って対象領域と参照タイミングを明示します。
+
+`AGENTS.md` は強制ルールとドキュメント探索の入口を定義します。各ドキュメントの front matter は、Codex や他の AI agent が現在の作業セッションで読むべき文書を選ぶための探索用メタデータとして扱います。
+
+## 対象
+
+front matter を付ける対象は、`docs/` と `apps/*/docs/` 配下の恒常ドキュメントです。
+
+README、`AGENTS.md`、ローカルメモ、作業途中の一時ファイルは対象外です。
+
+## 標準項目
+
+```yaml
+---
+title: Document Title
+doc_type: overview
+status: accepted
+area: repository
+applies_to:
+  - docs
+topics:
+  - documentation
+when_to_read:
+  - ドキュメントを追加または更新するとき
+---
+```
+
+- `title`: ドキュメント名。
+- `doc_type`: `overview`, `adr`, `policy` などの文書種別。
+- `status`: `accepted`, `draft`, `deprecated` などの状態。
+- `area`: 主な対象領域。例: `repository`, `web`, `api`, `infrastructure`。
+- `applies_to`: 関連するディレクトリ、アプリ、設定面。
+- `topics`: 検索や関連判断に使う技術・概念。
+- `when_to_read`: その文書を読むべき作業状況。
+
+## 参照ルール
+
+作業開始時に関連しそうな恒常ドキュメントがある場合は、`docs/` と `apps/*/docs/` 配下を確認し、front matter の `area`, `applies_to`, `topics`, `when_to_read`, `status` を見て読む文書を選びます。
+
+`status: deprecated` の文書は、廃止済みの挙動や移行経緯を調べる場合を除き、現在の実装方針の根拠にしません。
+
+front matter は探索用メタデータであり、強制ルールではありません。必ず守るべきルールは `AGENTS.md` に置きます。

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -1,3 +1,21 @@
+---
+title: インフラ構成
+doc_type: overview
+status: accepted
+area: infrastructure
+applies_to:
+  - apps/web
+  - apps/api
+topics:
+  - cloudflare
+  - supabase
+  - hosting
+  - database
+when_to_read:
+  - ホスティングまたはDNS構成を確認するとき
+  - Supabase AuthまたはPostgreSQLの利用前提を確認するとき
+---
+
 # インフラ構成
 
 本プロジェクトの Web アプリケーションは、以下のクラウドサービスを利用して構築・運用されています。

--- a/docs/storybook-browser-tests.md
+++ b/docs/storybook-browser-tests.md
@@ -1,0 +1,32 @@
+# Storybook Browser Tests
+
+Storybook のブラウザテストは opt-in で運用します。
+
+`task web:test-storybook` は `browser-test` tag が付いた story だけを対象にします。ブラウザ実行はコストが高いため、Storybook 上の全 story を網羅するのではなく、ページ単位または統合境界をまたぐ story に絞ります。
+
+## 対象にする story
+
+- Page コンポーネントの story
+- Router、QueryClient、MSW、Theme など複数 provider をまたぐ story
+- Dialog、Popover、Portal、focus trap などブラウザ寄りの挙動を含むページ級 story
+- ブラウザ上での表示または操作確認に明確な価値がある story
+
+## 対象にしない story
+
+- Button、Field、Input、Card などの leaf component のカタログ用途 story
+- 同名の `.test.tsx` で挙動を十分確認している component story
+- props の見た目違いを並べるだけの story
+
+## 追加ルール
+
+新しい Page story を追加するときは、meta の `tags` に `browser-test` を付けます。
+
+```ts
+const meta = {
+  title: "Pages/ExamplePage",
+  component: ExamplePage,
+  tags: ["autodocs", "browser-test"],
+} satisfies Meta<typeof ExamplePage>
+```
+
+Page 以外の story に `browser-test` を付ける場合は、ブラウザテスト対象にする理由が story の責務から読み取れるようにしてください。


### PR DESCRIPTION
## 関連Issue

- Closes #1156

## 変更内容

- 支払いカテゴリ選択で空値を常に None として扱うよう修正し、関連テストを更新
- Web 検証コマンドを個別実行前提へ整理し、テスト警告が見えるように test タスクを調整
- Storybook ブラウザテストを Page story ディレクトリと browser-test tag の opt-in にし、ドキュメント方針と front matter を整備

## 動作確認

- [x] task web:lint
- [x] task web:format-check
- [x] task web:typecheck
- [x] task web:test-unit
- [x] task web:test-storybook