### PR TITLE
支払い詳細でカテゴリをインライン編集できるようにする

### DIFF
--- a/apps/web/src/features/payments/components/CategorySelect/CategorySelect.test.tsx
+++ b/apps/web/src/features/payments/components/CategorySelect/CategorySelect.test.tsx
@@ -43,12 +43,21 @@ describe("CategorySelect", () => {
     expect(screen.getByRole("combobox")).toHaveTextContent("Daily Necessities")
   })
 
+  test("disabled prop で combobox を操作不可にする", () => {
+    renderWithTheme(<Default disabled />)
+
+    expect(screen.getByRole("combobox")).toBeDisabled()
+  })
+
   test("Loading story では loading option を表示する", async () => {
     const { user } = renderWithTheme(<Loading />)
 
     await user.click(screen.getByRole("combobox"))
 
-    expect(screen.getByRole("option", { name: /loading/i })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: /loading/i })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    )
   })
 
   test("ErrorState story では error option を表示する", async () => {
@@ -56,6 +65,6 @@ describe("CategorySelect", () => {
 
     await user.click(screen.getByRole("combobox"))
 
-    expect(screen.getByRole("option", { name: /error/i })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: /error/i })).toHaveAttribute("aria-disabled", "true")
   })
 })

--- a/apps/web/src/features/payments/components/CategorySelect/CategorySelect.tsx
+++ b/apps/web/src/features/payments/components/CategorySelect/CategorySelect.tsx
@@ -7,6 +7,7 @@ interface CategorySelectProps {
   autoFocus?: boolean
   disabled?: boolean
   id?: string
+  width?: string
   value?: string
   children?: ReactNode
   onChange?: (category: string) => void
@@ -19,6 +20,7 @@ export function CategorySelect({
   autoFocus = false,
   disabled = false,
   id,
+  width,
   value,
   children,
   onChange,
@@ -45,7 +47,12 @@ export function CategorySelect({
       onOpenChange={onOpenChange}
       onValueChange={handleChange}
     >
-      <Select.Trigger autoFocus={autoFocus} id={id} placeholder="Pick a category" />
+      <Select.Trigger
+        autoFocus={autoFocus}
+        id={id}
+        placeholder="Pick a category"
+        style={{ width }}
+      />
       <Select.Content>
         <NoneCategoryOption />
         {children}

--- a/apps/web/src/features/payments/components/CategorySelect/CategorySelect.tsx
+++ b/apps/web/src/features/payments/components/CategorySelect/CategorySelect.tsx
@@ -1,18 +1,29 @@
 import { Select } from "@radix-ui/themes"
-import { useCallback } from "react"
+import { type ReactNode, useCallback } from "react"
 
 import { Category } from "../../../../types/category"
 
 interface CategorySelectProps {
+  autoFocus?: boolean
+  disabled?: boolean
   id?: string
   value?: string
-  children?: React.ReactNode
+  children?: ReactNode
   onChange?: (category: string) => void
+  onOpenChange?: (open: boolean) => void
 }
 
 const NONE_CATEGORY_VALUE = "none"
 
-export function CategorySelect({ id, value, children, onChange }: CategorySelectProps) {
+export function CategorySelect({
+  autoFocus = false,
+  disabled = false,
+  id,
+  value,
+  children,
+  onChange,
+  onOpenChange,
+}: CategorySelectProps) {
   const selectValue = value === undefined || value === "" ? NONE_CATEGORY_VALUE : value
 
   const handleChange = useCallback(
@@ -27,8 +38,14 @@ export function CategorySelect({ id, value, children, onChange }: CategorySelect
   )
 
   return (
-    <Select.Root name="category" value={selectValue} onValueChange={handleChange}>
-      <Select.Trigger id={id} placeholder="Pick a category" />
+    <Select.Root
+      disabled={disabled}
+      name="category"
+      value={selectValue}
+      onOpenChange={onOpenChange}
+      onValueChange={handleChange}
+    >
+      <Select.Trigger autoFocus={autoFocus} id={id} placeholder="Pick a category" />
       <Select.Content>
         <NoneCategoryOption />
         {children}
@@ -55,9 +72,17 @@ export function NoneCategoryOption() {
 }
 
 export function ErrorCategoryOption() {
-  return <Select.Item value="error">Error</Select.Item>
+  return (
+    <Select.Item disabled value="error">
+      Error
+    </Select.Item>
+  )
 }
 
 export function LoadingCategoryOption() {
-  return <Select.Item value="loading">Loading</Select.Item>
+  return (
+    <Select.Item disabled value="loading">
+      Loading
+    </Select.Item>
+  )
 }

--- a/apps/web/src/features/payments/paymentDetails/CategoryField/CategoryField.stories.tsx
+++ b/apps/web/src/features/payments/paymentDetails/CategoryField/CategoryField.stories.tsx
@@ -1,16 +1,55 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { QueryClientProvider } from "@tanstack/react-query"
+import { fn } from "storybook/test"
 
+import { createQueryClient } from "../../../../lib/queryClient"
+import { SnackbarProvider } from "../../../../providers/snackbar"
+import { ThemeProvider } from "../../../../providers/theme/ThemeProvider"
+import { categoryHandlers } from "../../../../test/msw/handlers/categories"
+import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
 import { CategoryField } from "./CategoryField"
 
 const meta = {
   title: "Features/PaymentDetails/CategoryField",
   component: CategoryField,
+  parameters: {
+    msw: {
+      handlers: [...createPaymentHandlers(), ...categoryHandlers],
+    },
+  },
   args: {
+    paymentId: 1,
+    categoryId: 10,
     categoryName: "Food",
   },
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={createQueryClient()}>
+        <ThemeProvider>
+          <SnackbarProvider>
+            <Story />
+          </SnackbarProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    ),
+  ],
 } satisfies Meta<typeof CategoryField>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  args: {
+    onEditStart: fn(),
+    onEditEnd: fn(),
+  },
+}
+
+export const Unknown: Story = {
+  args: {
+    categoryId: null,
+    categoryName: "Unknown",
+    onEditStart: fn(),
+    onEditEnd: fn(),
+  },
+}

--- a/apps/web/src/features/payments/paymentDetails/CategoryField/CategoryField.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/CategoryField/CategoryField.test.tsx
@@ -1,16 +1,175 @@
 import { composeStories } from "@storybook/react-vite"
-import { describe, expect, test } from "vitest"
+import { HttpResponse, http } from "msw"
+import { beforeEach, describe, expect, test, vi } from "vitest"
 
-import { render, screen } from "../../../../test/test-utils"
+import { categoryHandlers } from "../../../../test/msw/handlers/categories"
+import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
+import { server } from "../../../../test/msw/server"
+import { render, screen, waitFor } from "../../../../test/test-utils"
 import * as stories from "./CategoryField.stories"
 
-const { Default } = composeStories(stories)
+const { Default, Unknown } = composeStories(stories)
 
 describe("PaymentDetails CategoryField", () => {
+  beforeEach(() => {
+    server.resetHandlers(...createPaymentHandlers(), ...categoryHandlers)
+  })
+
   test("Default story ではラベルとカテゴリ名を表示する", () => {
     render(<Default />)
 
     expect(screen.getByText("Category")).toBeInTheDocument()
     expect(screen.getByText("Food")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /edit category/i })).toBeInTheDocument()
+  })
+
+  test("編集ボタンを押すと現在カテゴリを選択した combobox を表示する", async () => {
+    const { user } = render(<Default />)
+
+    await user.click(screen.getByRole("button", { name: /edit category/i }))
+
+    expect(await screen.findByRole("combobox", { name: /category/i })).toHaveTextContent("Food")
+  })
+
+  test("カテゴリを選ぶと保存して editor を閉じる", async () => {
+    const { user } = render(<Default />)
+
+    await user.click(screen.getByRole("button", { name: /edit category/i }))
+    await user.click(await screen.findByRole("combobox", { name: /category/i }))
+    await user.click(await screen.findByRole("option", { name: /daily necessities/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("combobox", { name: /category/i })).not.toBeInTheDocument()
+    })
+  })
+
+  test("None を選ぶとカテゴリ未設定として保存する", async () => {
+    let updatePayload: unknown
+
+    server.use(
+      http.patch("*/rest/v1/payments*", async ({ request }) => {
+        updatePayload = await request.json()
+        return HttpResponse.json({ message: "Updated" })
+      }),
+    )
+
+    const { user } = render(<Default />)
+
+    await user.click(screen.getByRole("button", { name: /edit category/i }))
+    await user.click(await screen.findByRole("combobox", { name: /category/i }))
+    await user.click(await screen.findByRole("option", { name: /^none$/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("combobox", { name: /category/i })).not.toBeInTheDocument()
+    })
+    expect(updatePayload).toEqual({ category_id: null })
+    expect(screen.getByText("Food")).toBeInTheDocument()
+  })
+
+  test("未設定カテゴリの編集開始時は None を選択状態にする", async () => {
+    const { user } = render(<Unknown />)
+
+    expect(screen.getByText("Unknown")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: /edit category/i }))
+
+    expect(await screen.findByRole("combobox", { name: /category/i })).toHaveTextContent("None")
+  })
+
+  test("同じカテゴリを再選択すると API は呼ばずに editor を閉じる", async () => {
+    let updateCalls = 0
+
+    server.use(
+      http.patch("*/rest/v1/payments*", () => {
+        updateCalls += 1
+        return HttpResponse.json({ message: "Updated" })
+      }),
+    )
+
+    const { user } = render(<Default />)
+
+    await user.click(screen.getByRole("button", { name: /edit category/i }))
+    await user.click(await screen.findByRole("combobox", { name: /category/i }))
+    await user.click(await screen.findByRole("option", { name: /^food$/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("combobox", { name: /category/i })).not.toBeInTheDocument()
+    })
+    expect(updateCalls).toBe(0)
+  })
+
+  test("値を変えずにカテゴリメニューを閉じると API は呼ばずに editor を閉じる", async () => {
+    let updateCalls = 0
+
+    server.use(
+      http.patch("*/rest/v1/payments*", () => {
+        updateCalls += 1
+        return HttpResponse.json({ message: "Updated" })
+      }),
+    )
+
+    const { user } = render(<Default />)
+
+    await user.click(screen.getByRole("button", { name: /edit category/i }))
+    await user.click(await screen.findByRole("combobox", { name: /category/i }))
+    await user.keyboard("{Escape}")
+
+    await waitFor(() => {
+      expect(screen.queryByRole("combobox", { name: /category/i })).not.toBeInTheDocument()
+    })
+    expect(updateCalls).toBe(0)
+  })
+
+  test("保存失敗時は編集状態を維持してエラーを表示する", async () => {
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        update: { error: true },
+      }),
+      ...categoryHandlers,
+    )
+
+    const { user } = render(<Default />)
+
+    await user.click(screen.getByRole("button", { name: /edit category/i }))
+    await user.click(await screen.findByRole("combobox", { name: /category/i }))
+    await user.click(await screen.findByRole("option", { name: /daily necessities/i }))
+
+    expect(
+      await screen.findByText("Failed to update category.", { selector: "span" }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole("combobox", { name: /category/i })).toBeInTheDocument()
+    expect(screen.getByRole("combobox", { name: /category/i })).toHaveTextContent(
+      "Daily Necessities",
+    )
+  })
+
+  test("保存中は combobox を操作不可にする", async () => {
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        update: { durationOrMode: 1000 },
+      }),
+      ...categoryHandlers,
+    )
+
+    const { user } = render(<Default />)
+
+    await user.click(screen.getByRole("button", { name: /edit category/i }))
+    await user.click(await screen.findByRole("combobox", { name: /category/i }))
+    await user.click(await screen.findByRole("option", { name: /daily necessities/i }))
+
+    expect(screen.getByRole("combobox", { name: /category/i })).toBeDisabled()
+  })
+
+  test("Escape で編集を閉じると onEditEnd を呼ぶ", async () => {
+    const onEditStart = vi.fn()
+    const onEditEnd = vi.fn()
+    const { user } = render(<Default onEditStart={onEditStart} onEditEnd={onEditEnd} />)
+
+    await user.click(screen.getByRole("button", { name: /edit category/i }))
+    await user.keyboard("{Escape}")
+
+    expect(screen.queryByRole("combobox", { name: /category/i })).not.toBeInTheDocument()
+    expect(onEditStart).toHaveBeenCalledTimes(1)
+    expect(onEditEnd).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/web/src/features/payments/paymentDetails/CategoryField/CategoryField.tsx
+++ b/apps/web/src/features/payments/paymentDetails/CategoryField/CategoryField.tsx
@@ -1,16 +1,203 @@
 import { Text } from "@radix-ui/themes"
+import {
+  type KeyboardEvent,
+  type ReactNode,
+  Suspense,
+  use,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react"
+import { ErrorBoundary } from "react-error-boundary"
 
-import { BaseField, FieldLabel } from "../../../../components/inputs/BaseField"
+import { useSnackbar } from "../../../../providers/snackbar"
+import type { Category } from "../../../../types/category"
+import type { PaymentId } from "../../../../types/payment"
+import { useCategories } from "../../../categories/listCategory/useCategories"
+import {
+  CategoryOption,
+  CategorySelect,
+  ErrorCategoryOption,
+  LoadingCategoryOption,
+} from "../../components/CategorySelect"
+import { useUpdatePayment } from "../../updatePayment/useUpdatePayment"
+import { EditableField } from "../EditableField"
 
 interface CategoryFieldProps {
+  paymentId: PaymentId
+  categoryId: number | null
   categoryName: string
+  disabled?: boolean
+  onEditStart: () => void
+  onEditEnd: () => void
 }
 
-export function CategoryField({ categoryName }: CategoryFieldProps) {
-  return (
-    <BaseField gap="2">
-      <FieldLabel>Category</FieldLabel>
-      <Text size="4">{categoryName}</Text>
-    </BaseField>
+export function CategoryField({
+  paymentId,
+  categoryId,
+  categoryName,
+  disabled = false,
+  onEditStart,
+  onEditEnd,
+}: CategoryFieldProps) {
+  const id = useId()
+  const { openSnackbar } = useSnackbar()
+  const { updatePayment, isPending } = useUpdatePayment()
+  const { promise: categoriesPromise } = useCategories()
+  const currentCategoryValue = toCategoryValue(categoryId)
+  const [editing, setEditing] = useState(false)
+  const editingRef = useRef(false)
+  const [draftCategoryId, setDraftCategoryId] = useState(currentCategoryValue)
+  const [messages, setMessages] = useState<string[] | undefined>()
+
+  useEffect(() => {
+    return () => {
+      if (editingRef.current) {
+        onEditEnd()
+      }
+    }
+  }, [onEditEnd])
+
+  const closeEditor = useCallback(() => {
+    if (!editingRef.current) return
+
+    editingRef.current = false
+    setEditing(false)
+    onEditEnd()
+  }, [onEditEnd])
+
+  const handleEdit = useCallback(() => {
+    setDraftCategoryId(currentCategoryValue)
+    setMessages(undefined)
+    editingRef.current = true
+    setEditing(true)
+    onEditStart()
+  }, [currentCategoryValue, onEditStart])
+
+  const handleCancel = useCallback(() => {
+    if (isPending) return
+
+    setDraftCategoryId(currentCategoryValue)
+    setMessages(undefined)
+    closeEditor()
+  }, [closeEditor, currentCategoryValue, isPending])
+
+  const handleChange = useCallback(
+    async (nextCategoryId: string) => {
+      if (isPending) return
+
+      setDraftCategoryId(nextCategoryId)
+
+      if (nextCategoryId === currentCategoryValue) {
+        setMessages(undefined)
+        closeEditor()
+        return
+      }
+
+      try {
+        setMessages(undefined)
+        await updatePayment({
+          paymentId,
+          patch: { categoryId: nextCategoryId },
+        })
+        closeEditor()
+      } catch {
+        const message = "Failed to update category."
+
+        setMessages([message])
+        openSnackbar("error", message)
+      }
+    },
+    [closeEditor, currentCategoryValue, isPending, openSnackbar, paymentId, updatePayment],
   )
+
+  const handleSelectOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) return
+      if (isPending) return
+      if (draftCategoryId !== currentCategoryValue) return
+
+      setMessages(undefined)
+      closeEditor()
+    },
+    [closeEditor, currentCategoryValue, draftCategoryId, isPending],
+  )
+
+  return (
+    <EditableField
+      label="Category"
+      htmlFor={id}
+      editing={editing}
+      disabled={disabled && !editing}
+      editButtonLabel="Edit category"
+      onEdit={handleEdit}
+      error={Boolean(messages?.length)}
+      messages={messages}
+      view={
+        <Text size="4" style={{ flex: 1 }}>
+          {categoryName}
+        </Text>
+      }
+      editor={
+        <InlineEditor onCancel={handleCancel} saving={isPending}>
+          <CategorySelect
+            autoFocus
+            disabled={isPending}
+            id={id}
+            value={draftCategoryId}
+            onChange={handleChange}
+            onOpenChange={handleSelectOpenChange}
+          >
+            <ErrorBoundary fallback={<ErrorCategoryOption />}>
+              <Suspense fallback={<LoadingCategoryOption />}>
+                <CategoryOptions categoriesPromise={categoriesPromise} />
+              </Suspense>
+            </ErrorBoundary>
+          </CategorySelect>
+        </InlineEditor>
+      }
+    />
+  )
+}
+
+interface CategoryOptionsProps {
+  categoriesPromise: Promise<Category[]>
+}
+
+function CategoryOptions({ categoriesPromise }: CategoryOptionsProps) {
+  const categories = use(categoriesPromise)
+
+  return (
+    <>
+      {categories.map((category) => (
+        <CategoryOption key={category.id} category={category} />
+      ))}
+    </>
+  )
+}
+
+interface InlineEditorProps {
+  children: ReactNode
+  onCancel?: () => void
+  saving?: boolean
+}
+
+function InlineEditor({ children, onCancel, saving = false }: InlineEditorProps) {
+  function handleKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "Escape") return
+
+    event.preventDefault()
+    event.stopPropagation()
+    if (!saving) {
+      onCancel?.()
+    }
+  }
+
+  return <div onKeyDownCapture={handleKeyDown}>{children}</div>
+}
+
+function toCategoryValue(categoryId: number | null): string {
+  return categoryId === null ? "" : String(categoryId)
 }

--- a/apps/web/src/features/payments/paymentDetails/CategoryField/CategoryField.tsx
+++ b/apps/web/src/features/payments/paymentDetails/CategoryField/CategoryField.tsx
@@ -147,6 +147,7 @@ export function CategoryField({
             disabled={isPending}
             id={id}
             value={draftCategoryId}
+            width="100%"
             onChange={handleChange}
             onOpenChange={handleSelectOpenChange}
           >
@@ -195,7 +196,11 @@ function InlineEditor({ children, onCancel, saving = false }: InlineEditorProps)
     }
   }
 
-  return <div onKeyDownCapture={handleKeyDown}>{children}</div>
+  return (
+    <div onKeyDownCapture={handleKeyDown} style={{ width: "100%" }}>
+      {children}
+    </div>
+  )
 }
 
 function toCategoryValue(categoryId: number | null): string {

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.stories.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.stories.tsx
@@ -6,6 +6,7 @@ import { createQueryClient } from "../../../../lib/queryClient"
 import { SnackbarProvider } from "../../../../providers/snackbar"
 import { ThemeProvider } from "../../../../providers/theme/ThemeProvider"
 import { payments } from "../../../../test/data/payments"
+import { categoryHandlers } from "../../../../test/msw/handlers/categories"
 import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
 import { mapPaymentToRow } from "../../../../test/utils/mapPaymentToRow"
 import { PaymentDetailsOverlay } from "./PaymentDetailsOverlay"
@@ -44,7 +45,7 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {
   parameters: {
     msw: {
-      handlers: createPaymentHandlers(),
+      handlers: [...createPaymentHandlers(), ...categoryHandlers],
     },
   },
 }
@@ -52,15 +53,18 @@ export const Default: Story = {
 export const EmptyNote: Story = {
   parameters: {
     msw: {
-      handlers: createPaymentHandlers({
-        initialRows: [
-          mapPaymentToRow({
-            ...payments[0],
-            note: "",
-          }),
-          ...payments.slice(1).map(mapPaymentToRow),
-        ],
-      }),
+      handlers: [
+        ...createPaymentHandlers({
+          initialRows: [
+            mapPaymentToRow({
+              ...payments[0],
+              note: "",
+            }),
+            ...payments.slice(1).map(mapPaymentToRow),
+          ],
+        }),
+        ...categoryHandlers,
+      ],
     },
   },
 }
@@ -71,7 +75,7 @@ export const MissingPayment: Story = {
   },
   parameters: {
     msw: {
-      handlers: createPaymentHandlers(),
+      handlers: [...createPaymentHandlers(), ...categoryHandlers],
     },
   },
 }
@@ -100,9 +104,12 @@ export const FetchError: Story = {
   ],
   parameters: {
     msw: {
-      handlers: createPaymentHandlers({
-        get: { error: true },
-      }),
+      handlers: [
+        ...createPaymentHandlers({
+          get: { error: true },
+        }),
+        ...categoryHandlers,
+      ],
     },
   },
 }

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
@@ -5,6 +5,7 @@ import { HttpResponse, http } from "msw"
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
 import { payments } from "../../../../test/data/payments"
+import { categoryHandlers } from "../../../../test/msw/handlers/categories"
 import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
 import { server } from "../../../../test/msw/server"
 import { render, screen, waitFor, within } from "../../../../test/test-utils"
@@ -15,7 +16,7 @@ const { Default, EmptyNote, FetchError, MissingPayment } = composeStories(storie
 
 describe("PaymentDetailsOverlay", () => {
   beforeEach(() => {
-    server.resetHandlers(...createPaymentHandlers())
+    server.resetHandlers(...createPaymentHandlers(), ...categoryHandlers)
   })
 
   test("Default story では削除ボタンと金額編集ボタンを表示する", async () => {
@@ -37,6 +38,7 @@ describe("PaymentDetailsOverlay", () => {
           ...payments.slice(1).map(mapPaymentToRow),
         ],
       }),
+      ...categoryHandlers,
     )
 
     render(<EmptyNote />)
@@ -90,6 +92,55 @@ describe("PaymentDetailsOverlay", () => {
     await user.click(await within(dialog).findByRole("button", { name: /edit note/i }))
 
     expect(within(dialog).getByRole("button", { name: /edit amount/i })).toBeDisabled()
+  })
+
+  test("category 編集中は他フィールドの編集導線を無効化する", async () => {
+    const { user } = render(<Default />)
+
+    const dialog = await screen.findByRole("dialog", { name: /payment details/i })
+    await user.click(await within(dialog).findByRole("button", { name: /edit category/i }))
+
+    expect(await within(dialog).findByRole("combobox", { name: /category/i })).toHaveTextContent(
+      "Food",
+    )
+    expect(within(dialog).getByRole("button", { name: /edit date/i })).toBeDisabled()
+    expect(within(dialog).getByRole("button", { name: /edit note/i })).toBeDisabled()
+    expect(within(dialog).getByRole("button", { name: /edit amount/i })).toBeDisabled()
+  })
+
+  test("note 編集中は category の編集導線を無効化する", async () => {
+    const { user } = render(<Default />)
+
+    const dialog = await screen.findByRole("dialog", { name: /payment details/i })
+    await user.click(await within(dialog).findByRole("button", { name: /edit note/i }))
+
+    expect(within(dialog).getByRole("button", { name: /edit category/i })).toBeDisabled()
+  })
+
+  test("category 編集中の Escape はオーバーレイを閉じずに編集だけ解除する", async () => {
+    const { user } = render(<Default />)
+
+    const dialog = await screen.findByRole("dialog", { name: /payment details/i })
+    await user.click(await within(dialog).findByRole("button", { name: /edit category/i }))
+    await user.keyboard("{Escape}")
+
+    expect(screen.getByRole("dialog", { name: /payment details/i })).toBeInTheDocument()
+    expect(within(dialog).queryByRole("combobox", { name: /category/i })).not.toBeInTheDocument()
+    expect(within(dialog).getByText("Food")).toBeInTheDocument()
+  })
+
+  test("category を None にすると未設定として保存して詳細表示は Unknown になる", async () => {
+    const { user } = render(<Default />)
+
+    const dialog = await screen.findByRole("dialog", { name: /payment details/i })
+    await user.click(await within(dialog).findByRole("button", { name: /edit category/i }))
+    await user.click(await within(dialog).findByRole("combobox", { name: /category/i }))
+    await user.click(await screen.findByRole("option", { name: /^none$/i }))
+
+    await waitFor(() => {
+      expect(within(dialog).queryByRole("combobox", { name: /category/i })).not.toBeInTheDocument()
+    })
+    expect(await within(dialog).findByText("Unknown")).toBeInTheDocument()
   })
 
   describe("Date editing", () => {

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
@@ -72,7 +72,14 @@ export function PaymentDetailsOverlay({
               onEditStart={handleEditStart}
               onEditEnd={handleEditEnd}
             />
-            <CategoryField categoryName={payment.category?.name ?? unknownCategory.name} />
+            <CategoryField
+              paymentId={payment.id}
+              categoryId={payment.category?.id ?? null}
+              categoryName={payment.category?.name ?? unknownCategory.name}
+              disabled={isEditingField}
+              onEditStart={handleEditStart}
+              onEditEnd={handleEditEnd}
+            />
             <NoteField
               paymentId={payment.id}
               note={payment.note}


### PR DESCRIPTION
## 関連Issue

- Close #1146

## 変更内容

- 支払い詳細の CategoryField をインライン編集できるようにした
- カテゴリ選択完了で更新し、None による未設定化、保存中・失敗時の表示、Escape キャンセルに対応した
- CategorySelect の disabled / autoFocus / onOpenChange 対応と関連 Story/Test を更新した

## 動作確認

- [x] ローカルでの動作確認
- [x] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

- #1146 全体のうち CategoryField を対象にした変更です
