### PR TITLE
月予算テーブルと一意制約を追加する

### DIFF
--- a/apps/api/supabase/migrations/20260412142615_create_monthly_budgets_table.sql
+++ b/apps/api/supabase/migrations/20260412142615_create_monthly_budgets_table.sql
@@ -1,0 +1,47 @@
+create table monthly_budgets (
+    id bigint generated always as identity primary key,
+    effective_from date not null,
+    amount numeric(10, 2) not null,
+    created_at timestamp with time zone default current_timestamp,
+    updated_at timestamp with time zone default current_timestamp,
+
+    user_id bigint not null references users(id) on delete cascade
+);
+
+create unique index uniq_monthly_budgets_user_effective_year_month
+    on monthly_budgets (
+        user_id,
+        extract(year from effective_from),
+        extract(month from effective_from)
+    );
+
+create index idx_monthly_budgets_user_effective_from
+    on monthly_budgets (user_id, effective_from desc);
+
+alter table monthly_budgets enable row level security;
+
+create policy "Users can read own monthly budgets"
+  on monthly_budgets for select
+  to authenticated
+  using (user_id in (select id from users where external_id = auth.uid()::text));
+
+create policy "Users can insert own monthly budgets"
+  on monthly_budgets for insert
+  to authenticated
+  with check (user_id in (select id from users where external_id = auth.uid()::text));
+
+create or replace function set_monthly_budget_user_id()
+returns trigger as $$
+begin
+  new.user_id := (select id from users where external_id = auth.uid()::text);
+  if new.user_id is null then
+    raise exception 'User not found for auth.uid: %', auth.uid();
+  end if;
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_set_monthly_budget_user_id
+  before insert on monthly_budgets
+  for each row
+  execute function set_monthly_budget_user_id();

--- a/apps/api/supabase/migrations/20260412142615_create_monthly_budgets_table.sql
+++ b/apps/api/supabase/migrations/20260412142615_create_monthly_budgets_table.sql
@@ -1,19 +1,39 @@
+create or replace function get_authenticated_user_id()
+returns bigint as $$
+declare
+  authenticated_user_id bigint;
+begin
+  select id into authenticated_user_id
+  from users
+  where external_id = auth.uid()::text;
+
+  if authenticated_user_id is null then
+    raise exception 'User not found for auth.uid: %', auth.uid();
+  end if;
+
+  return authenticated_user_id;
+end;
+$$ language plpgsql security invoker stable set search_path = public;
+
+revoke all on function public.get_authenticated_user_id() from public;
+revoke all on function public.get_authenticated_user_id() from anon;
+grant execute on function public.get_authenticated_user_id() to authenticated;
+grant execute on function public.get_authenticated_user_id() to service_role;
+
 create table monthly_budgets (
     id bigint generated always as identity primary key,
     effective_from date not null,
+    effective_year integer generated always as (extract(year from effective_from)::integer) stored not null,
+    effective_month integer generated always as (extract(month from effective_from)::integer) stored not null,
     amount numeric(10, 2) not null,
     created_at timestamp with time zone default current_timestamp,
     updated_at timestamp with time zone default current_timestamp,
 
-    user_id bigint not null references users(id) on delete cascade
-);
+    user_id bigint not null default get_authenticated_user_id() references users(id) on delete cascade,
 
-create unique index uniq_monthly_budgets_user_effective_year_month
-    on monthly_budgets (
-        user_id,
-        extract(year from effective_from),
-        extract(month from effective_from)
-    );
+    constraint monthly_budgets_user_effective_year_month_key
+        unique (user_id, effective_year, effective_month)
+);
 
 create index idx_monthly_budgets_user_effective_from
     on monthly_budgets (user_id, effective_from desc);
@@ -33,10 +53,7 @@ create policy "Users can insert own monthly budgets"
 create or replace function set_monthly_budget_user_id()
 returns trigger as $$
 begin
-  new.user_id := (select id from users where external_id = auth.uid()::text);
-  if new.user_id is null then
-    raise exception 'User not found for auth.uid: %', auth.uid();
-  end if;
+  new.user_id := get_authenticated_user_id();
   return new;
 end;
 $$ language plpgsql security invoker set search_path = public;

--- a/apps/web/src/types/database.types.ts
+++ b/apps/web/src/types/database.types.ts
@@ -49,6 +49,41 @@ export type Database = {
         }
         Relationships: []
       }
+      monthly_budgets: {
+        Row: {
+          amount: number
+          created_at: string | null
+          effective_from: string
+          id: number
+          updated_at: string | null
+          user_id: number
+        }
+        Insert: {
+          amount: number
+          created_at?: string | null
+          effective_from: string
+          id?: never
+          updated_at?: string | null
+          user_id: number
+        }
+        Update: {
+          amount?: number
+          created_at?: string | null
+          effective_from?: string
+          id?: never
+          updated_at?: string | null
+          user_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "monthly_budgets_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       payments: {
         Row: {
           amount: number

--- a/apps/web/src/types/database.types.ts
+++ b/apps/web/src/types/database.types.ts
@@ -54,6 +54,8 @@ export type Database = {
           amount: number
           created_at: string | null
           effective_from: string
+          effective_month: number
+          effective_year: number
           id: number
           updated_at: string | null
           user_id: number
@@ -62,14 +64,18 @@ export type Database = {
           amount: number
           created_at?: string | null
           effective_from: string
+          effective_month?: number
+          effective_year?: number
           id?: never
           updated_at?: string | null
-          user_id: number
+          user_id?: number
         }
         Update: {
           amount?: number
           created_at?: string | null
           effective_from?: string
+          effective_month?: number
+          effective_year?: number
           id?: never
           updated_at?: string | null
           user_id?: number
@@ -164,6 +170,7 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      get_authenticated_user_id: { Args: never; Returns: number }
       get_monthly_total_amount: { Args: { p_month: string }; Returns: number }
     }
     Enums: {


### PR DESCRIPTION
## 関連Issue

- closes #1113
- #601

## 変更内容

- 月予算を保存する `monthly_budgets` テーブルを追加した
- 同一ユーザー・同一年月の重複登録を防ぐ一意制約を追加した
- 月予算の RLS、insert 時の `user_id` 自動設定、Supabase 型を追加した

## 動作確認

- [x] ローカルでの動作確認
  - `SUPABASE_GOOGLE_SKIP_NONCE_CHECK=false task api:up:migrations`
  - `psql` で `monthly_budgets.amount` が `numeric(10,2)` であることを確認
- [x] テストの実行
  - `task web:lint`
  - `task web:format-check`
  - `task web:typecheck`
  - `task web:test-unit`
  - `task web:test-storybook`
- [ ] UIの確認（スクリーンショット等）

## 補足

- UI 変更はありません。
- 月予算の編集・削除は Issue #1113 の対象外のため、update/delete policy は追加していません。
