### PR TITLE
支払い一覧に月予算利用状況を表示

### DIFF
--- a/apps/web/src/app/routes/PaymentsPage/PaymentPage.stories.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentPage.stories.tsx
@@ -1,9 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { expect, within } from "storybook/test"
 
+import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
 import { payments } from "../../../test/data/payments"
 import { createStoryRouter, paymentsRouteBuilder } from "../../../test/helpers/routerDecorator"
 import { createCategoryHandlers } from "../../../test/msw/handlers/categories"
+import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
 import { createPaymentHandlers } from "../../../test/msw/handlers/payments"
 import { mapPaymentToRow } from "../../../test/utils/mapPaymentToRow"
 import { PaymentsPage } from "./PaymentsPage"
@@ -19,6 +21,9 @@ const meta = {
           initialRows: payments.map(mapPaymentToRow),
         }),
         ...createCategoryHandlers(),
+        ...createMonthlyBudgetHandlers({
+          get: { response: { ...monthlyBudgets[2], amount: 25000 } },
+        }),
       ],
     },
   },
@@ -45,6 +50,7 @@ export const Default: Story = {
     expect(await canvas.findByText("2025/06/03")).toBeInTheDocument()
     expect(await canvas.findByText("￥1,000")).toBeInTheDocument()
     expect(await canvas.findByText("￥4,000")).toBeInTheDocument()
+    expect(await canvas.findByText("￥20,000 left")).toBeInTheDocument()
   },
 }
 

--- a/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
@@ -3,8 +3,10 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
 import { createQueryClient } from "../../../lib/queryClient"
 import { entertainmentCat } from "../../../test/data/categories"
+import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
 import { payments } from "../../../test/data/payments"
 import { createCategoryHandlers } from "../../../test/msw/handlers/categories"
+import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
 import { createPaymentHandlers } from "../../../test/msw/handlers/payments"
 import { server } from "../../../test/msw/server"
 import { render, screen, waitFor, within } from "../../../test/test-utils"
@@ -56,6 +58,9 @@ describe("PaymentsPage", () => {
         },
       }),
       ...createCategoryHandlers(),
+      ...createMonthlyBudgetHandlers({
+        get: { response: { ...monthlyBudgets[2], amount: 25000 } },
+      }),
     )
   })
 

--- a/apps/web/src/features/budgets/components/MonthlyBudgetUsage/MonthlyBudgetUsage.stories.tsx
+++ b/apps/web/src/features/budgets/components/MonthlyBudgetUsage/MonthlyBudgetUsage.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { monthlyBudgets } from "../../../../test/data/monthlyBudgets"
+import { createMonthlyBudgetHandlers } from "../../../../test/msw/handlers/monthlyBudgets"
+import { MonthlyBudgetUsage } from "./MonthlyBudgetUsage"
+
+const targetDate = new Date(2025, 2, 1)
+const monthlyBudget = { ...monthlyBudgets[2], amount: 30000 }
+
+const meta = {
+  title: "Features/Budgets/MonthlyBudgetUsage",
+  component: MonthlyBudgetUsage,
+  tags: ["autodocs"],
+  parameters: {
+    msw: {
+      handlers: createMonthlyBudgetHandlers({
+        get: { response: monthlyBudget },
+      }),
+    },
+  },
+  args: {
+    targetDate,
+    totalExpenditures: 10000,
+    totalExpendituresError: null,
+    totalExpendituresLoading: false,
+  },
+} satisfies Meta<typeof MonthlyBudgetUsage>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Remaining: Story = {}
+
+export const Over: Story = {
+  args: {
+    totalExpenditures: 45000,
+  },
+}
+
+export const NoBudget: Story = {
+  parameters: {
+    msw: {
+      handlers: createMonthlyBudgetHandlers({
+        get: { response: null },
+      }),
+    },
+  },
+}
+
+export const FetchError: Story = {
+  parameters: {
+    msw: {
+      handlers: createMonthlyBudgetHandlers({
+        get: { error: true },
+      }),
+    },
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    totalExpenditures: null,
+    totalExpendituresLoading: true,
+  },
+}

--- a/apps/web/src/features/budgets/components/MonthlyBudgetUsage/MonthlyBudgetUsage.test.tsx
+++ b/apps/web/src/features/budgets/components/MonthlyBudgetUsage/MonthlyBudgetUsage.test.tsx
@@ -1,0 +1,77 @@
+import { composeStories } from "@storybook/react-vite"
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+import { monthlyBudgets } from "../../../../test/data/monthlyBudgets"
+import { createMonthlyBudgetHandlers } from "../../../../test/msw/handlers/monthlyBudgets"
+import { server } from "../../../../test/msw/server"
+import { render, screen, waitFor } from "../../../../test/test-utils"
+import * as stories from "./MonthlyBudgetUsage.stories"
+
+const { FetchError, Loading, NoBudget, Over, Remaining } = composeStories(stories)
+const monthlyBudget = { ...monthlyBudgets[2], amount: 30000 }
+
+describe("MonthlyBudgetUsage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test("月予算に対する残額を表示する", async () => {
+    server.resetHandlers(
+      ...createMonthlyBudgetHandlers({
+        get: { response: monthlyBudget },
+      }),
+    )
+    render(<Remaining />)
+
+    expect(await screen.findByText("￥20,000 left")).toBeInTheDocument()
+  })
+
+  test("月予算を超えたら超過額を表示する", async () => {
+    server.resetHandlers(
+      ...createMonthlyBudgetHandlers({
+        get: { response: monthlyBudget },
+      }),
+    )
+    render(<Over />)
+
+    expect(await screen.findByText("￥15,000 over")).toBeInTheDocument()
+  })
+
+  test("月予算がない場合は利用状況を表示しない", async () => {
+    server.resetHandlers(
+      ...createMonthlyBudgetHandlers({
+        get: { response: null },
+      }),
+    )
+    render(<NoBudget />)
+
+    await waitFor(() => {
+      expect(screen.queryByText(/left|over|Could not get the budget/)).not.toBeInTheDocument()
+    })
+  })
+
+  test("月予算の取得に失敗した場合はエラー状態を表示する", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    server.resetHandlers(
+      ...createMonthlyBudgetHandlers({
+        get: { error: true },
+      }),
+    )
+    render(<FetchError />)
+
+    expect(await screen.findByRole("status", {}, { timeout: 3000 })).toHaveTextContent(
+      "Could not get the budget",
+    )
+  })
+
+  test("読み込み中はスケルトンを表示する", async () => {
+    server.resetHandlers(
+      ...createMonthlyBudgetHandlers({
+        get: { response: monthlyBudget },
+      }),
+    )
+    render(<Loading />)
+
+    expect(await screen.findByTestId("budget-difference-skeleton")).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/budgets/components/MonthlyBudgetUsage/MonthlyBudgetUsage.tsx
+++ b/apps/web/src/features/budgets/components/MonthlyBudgetUsage/MonthlyBudgetUsage.tsx
@@ -1,0 +1,95 @@
+import { Skeleton, Text } from "@radix-ui/themes"
+import { memo } from "react"
+
+import { useEffectiveMonthlyBudget } from "../../getMonthlyBudget/useEffectiveMonthlyBudget"
+import {
+  getMonthlyBudgetUsageDisplay,
+  type MonthlyBudgetUsageStatus,
+} from "../../utils/monthlyBudgetUsage"
+
+export interface MonthlyBudgetUsageProps {
+  targetDate: Date | null
+  totalExpenditures: number | null
+  totalExpendituresError: Error | null
+  totalExpendituresLoading: boolean
+}
+
+export function MonthlyBudgetUsage({
+  targetDate,
+  totalExpenditures,
+  totalExpendituresError,
+  totalExpendituresLoading,
+}: MonthlyBudgetUsageProps) {
+  const {
+    data: monthlyBudget,
+    error: monthlyBudgetError,
+    loading: monthlyBudgetLoading,
+  } = useEffectiveMonthlyBudget(targetDate)
+
+  if (totalExpendituresLoading || monthlyBudgetLoading) {
+    return <MonthlyBudgetUsageText loading />
+  }
+
+  if (totalExpendituresError || targetDate === null || totalExpenditures === null) {
+    return null
+  }
+
+  if (monthlyBudgetError) {
+    return <MonthlyBudgetUsageText error />
+  }
+
+  const display = getMonthlyBudgetUsageDisplay(totalExpenditures, monthlyBudget?.amount ?? null)
+
+  if (display === null) {
+    return null
+  }
+
+  return <MonthlyBudgetUsageText status={display.status} text={display.text} />
+}
+
+interface MonthlyBudgetUsageTextProps {
+  error?: boolean
+  loading?: boolean
+  status?: MonthlyBudgetUsageStatus
+  text?: string
+}
+
+const MonthlyBudgetUsageText = memo(function MonthlyBudgetUsageText({
+  error = false,
+  loading = false,
+  status,
+  text,
+}: MonthlyBudgetUsageTextProps) {
+  const content = error ? "Could not get the budget" : (text ?? "\u00A0")
+
+  return (
+    <Skeleton loading={loading} data-testid={loading ? "budget-difference-skeleton" : undefined}>
+      <Text
+        align="right"
+        aria-hidden={loading}
+        color={getTextColor(error, status)}
+        role={error ? "status" : undefined}
+        size="2"
+        style={{ display: "inline-block", minHeight: "20px", minWidth: "12ch" }}
+      >
+        {content}
+      </Text>
+    </Skeleton>
+  )
+})
+
+function getTextColor(error: boolean, status?: MonthlyBudgetUsageStatus): "green" | "red" | "gray" {
+  if (error) {
+    return "gray"
+  }
+
+  if (status === "remaining") {
+    return "green"
+  }
+
+  if (status === "over") {
+    return "red"
+  }
+
+  return "gray"
+}

--- a/apps/web/src/features/budgets/components/MonthlyBudgetUsage/index.ts
+++ b/apps/web/src/features/budgets/components/MonthlyBudgetUsage/index.ts
@@ -1,0 +1,1 @@
+export * from "./MonthlyBudgetUsage"

--- a/apps/web/src/features/budgets/utils/monthlyBudgetUsage.test.ts
+++ b/apps/web/src/features/budgets/utils/monthlyBudgetUsage.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "vitest"
+
+import { getMonthlyBudgetUsageDisplay } from "./monthlyBudgetUsage"
+
+describe("getMonthlyBudgetUsageDisplay", () => {
+  test("支出が月予算以下なら残額を表示する", () => {
+    expect(getMonthlyBudgetUsageDisplay(10000, 30000)).toEqual({
+      text: "￥20,000 left",
+      status: "remaining",
+    })
+  })
+
+  test("支出が月予算と同額なら ￥0 left を表示する", () => {
+    expect(getMonthlyBudgetUsageDisplay(30000, 30000)).toEqual({
+      text: "￥0 left",
+      status: "remaining",
+    })
+  })
+
+  test("支出が月予算を超えたら超過額を表示する", () => {
+    expect(getMonthlyBudgetUsageDisplay(45000, 30000)).toEqual({
+      text: "￥15,000 over",
+      status: "over",
+    })
+  })
+
+  test("支出または月予算がない場合は表示しない", () => {
+    expect(getMonthlyBudgetUsageDisplay(null, 30000)).toBeNull()
+    expect(getMonthlyBudgetUsageDisplay(10000, null)).toBeNull()
+  })
+})

--- a/apps/web/src/features/budgets/utils/monthlyBudgetUsage.ts
+++ b/apps/web/src/features/budgets/utils/monthlyBudgetUsage.ts
@@ -1,0 +1,31 @@
+import { toCurrency } from "../../../utils/toCurrency"
+
+export type MonthlyBudgetUsageStatus = "remaining" | "over"
+
+export interface MonthlyBudgetUsageDisplay {
+  text: string
+  status: MonthlyBudgetUsageStatus
+}
+
+export function getMonthlyBudgetUsageDisplay(
+  totalExpenditures: number | null,
+  monthlyBudgetAmount: number | null,
+): MonthlyBudgetUsageDisplay | null {
+  if (totalExpenditures === null || monthlyBudgetAmount === null) {
+    return null
+  }
+
+  const difference = monthlyBudgetAmount - totalExpenditures
+
+  if (difference >= 0) {
+    return {
+      text: `${toCurrency(difference)} left`,
+      status: "remaining",
+    }
+  }
+
+  return {
+    text: `${toCurrency(Math.abs(difference))} over`,
+    status: "over",
+  }
+}

--- a/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.stories.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
+import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
 import { createStoryRouter, paymentsRouteBuilder } from "../../../test/helpers/routerDecorator"
+import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
 import { createPaymentHandlers } from "../../../test/msw/handlers/payments"
 import { MonthlyTotals } from "./MonthlyTotals"
 
@@ -10,9 +12,14 @@ const meta = {
   tags: ["autodocs"],
   parameters: {
     msw: {
-      handlers: createPaymentHandlers({
-        getMonthlyTotalAmount: { response: 10000 },
-      }),
+      handlers: [
+        ...createPaymentHandlers({
+          getMonthlyTotalAmount: { response: 10000 },
+        }),
+        ...createMonthlyBudgetHandlers({
+          get: { response: { ...monthlyBudgets[2], amount: 30000 } },
+        }),
+      ],
     },
   },
   decorators: [createStoryRouter("/payments?year=2025&month=06", paymentsRouteBuilder)],

--- a/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.test.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.test.tsx
@@ -1,9 +1,11 @@
 import { composeStories } from "@storybook/react-vite"
-import { describe, expect, test } from "vitest"
+import { afterEach, describe, expect, test, vi } from "vitest"
 
+import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
+import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
 import { createPaymentHandlers } from "../../../test/msw/handlers/payments"
 import { server } from "../../../test/msw/server"
-import { render, screen } from "../../../test/test-utils"
+import { render, screen, waitFor } from "../../../test/test-utils"
 import * as stories from "./MonthlyTotals.stories"
 
 const { Default } = composeStories(stories)
@@ -13,15 +15,74 @@ function renderStory() {
 }
 
 describe("MonthlyTotals", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   test("月次合計を表示する", async () => {
     server.resetHandlers(
       ...createPaymentHandlers({
         getMonthlyTotalAmount: { response: 10000 },
+      }),
+      ...createMonthlyBudgetHandlers({
+        get: { response: { ...monthlyBudgets[2], amount: 30000 } },
       }),
     )
     renderStory()
 
     expect(await screen.findByText("Total spending")).toBeInTheDocument()
     expect(await screen.findByText("￥10,000")).toBeInTheDocument()
+    expect(await screen.findByText("￥20,000 left")).toBeInTheDocument()
+  })
+
+  test("月次合計が月予算を超えたら超過額を表示する", async () => {
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        getMonthlyTotalAmount: { response: 45000 },
+      }),
+      ...createMonthlyBudgetHandlers({
+        get: { response: { ...monthlyBudgets[2], amount: 30000 } },
+      }),
+    )
+    renderStory()
+
+    expect(await screen.findByText("￥45,000")).toBeInTheDocument()
+    expect(await screen.findByText("￥15,000 over")).toBeInTheDocument()
+  })
+
+  test("月予算がない場合は差額を表示しない", async () => {
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        getMonthlyTotalAmount: { response: 10000 },
+      }),
+      ...createMonthlyBudgetHandlers({
+        get: { response: null },
+      }),
+    )
+    renderStory()
+
+    expect(await screen.findByText("￥10,000")).toBeInTheDocument()
+
+    await waitFor(() => {
+      expect(screen.queryByText(/left|over|Could not get the budget/)).not.toBeInTheDocument()
+    })
+  })
+
+  test("月予算の取得に失敗した場合は支出合計を残してエラーを表示する", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        getMonthlyTotalAmount: { response: 10000 },
+      }),
+      ...createMonthlyBudgetHandlers({
+        get: { error: true },
+      }),
+    )
+    renderStory()
+
+    expect(await screen.findByText("￥10,000")).toBeInTheDocument()
+    expect(
+      await screen.findByText("Could not get the budget", {}, { timeout: 3000 }),
+    ).toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.tsx
@@ -3,10 +3,13 @@ import { memo, Suspense, use } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 
 import { toCurrency } from "../../../utils/toCurrency"
+import { useDateRange } from "../../../utils/useDateRange"
+import { MonthlyBudgetUsage } from "../../budgets/components/MonthlyBudgetUsage"
 import { useTotalExpenditures } from "../useTotalExpenditures"
 
 function MonthlyTotals() {
-  const { promise } = useTotalExpenditures()
+  const totalExpenditures = useTotalExpenditures()
+  const { date } = useDateRange()
 
   return (
     <Flex gap="1" direction="column">
@@ -16,9 +19,17 @@ function MonthlyTotals() {
       <Flex justify="end" align="center">
         <ErrorBoundary fallback={<Text color="red">An unexpected error has occurred.</Text>}>
           <Suspense fallback={<MoneyText loading />}>
-            <MoneyText getValue={promise} />
+            <MoneyText getValue={totalExpenditures.promise} />
           </Suspense>
         </ErrorBoundary>
+      </Flex>
+      <Flex justify="end" align="center">
+        <MonthlyBudgetUsage
+          targetDate={date}
+          totalExpenditures={totalExpenditures.data}
+          totalExpendituresError={totalExpenditures.error}
+          totalExpendituresLoading={totalExpenditures.loading}
+        />
       </Flex>
     </Flex>
   )

--- a/apps/web/src/features/summaryByMonth/Summary/Summary.stories.tsx
+++ b/apps/web/src/features/summaryByMonth/Summary/Summary.stories.tsx
@@ -1,8 +1,10 @@
 import { Container } from "@radix-ui/themes"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
+import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
 import { createStoryRouter, paymentsRouteBuilder } from "../../../test/helpers/routerDecorator"
 import { createCategoryHandlers } from "../../../test/msw/handlers/categories"
+import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
 import { createPaymentHandlers } from "../../../test/msw/handlers/payments"
 import { Summary } from "./Summary"
 
@@ -12,7 +14,13 @@ const meta = {
   parameters: {
     layout: "centered",
     msw: {
-      handlers: [...createPaymentHandlers(), ...createCategoryHandlers()],
+      handlers: [
+        ...createPaymentHandlers(),
+        ...createCategoryHandlers(),
+        ...createMonthlyBudgetHandlers({
+          get: { response: { ...monthlyBudgets[2], amount: 25000 } },
+        }),
+      ],
     },
   },
   tags: ["autodocs"],

--- a/apps/web/src/features/summaryByMonth/Summary/Summary.test.tsx
+++ b/apps/web/src/features/summaryByMonth/Summary/Summary.test.tsx
@@ -1,7 +1,9 @@
 import { composeStories } from "@storybook/react-vite"
 import { describe, expect, test } from "vitest"
 
+import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
 import { createCategoryHandlers } from "../../../test/msw/handlers/categories"
+import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
 import { createPaymentHandlers } from "../../../test/msw/handlers/payments"
 import { server } from "../../../test/msw/server"
 import { render, screen } from "../../../test/test-utils"
@@ -15,11 +17,18 @@ function renderStory() {
 
 describe("Summary", () => {
   test("月次合計とカテゴリ別合計を表示できる", async () => {
-    server.resetHandlers(...createPaymentHandlers(), ...createCategoryHandlers())
+    server.resetHandlers(
+      ...createPaymentHandlers(),
+      ...createCategoryHandlers(),
+      ...createMonthlyBudgetHandlers({
+        get: { response: { ...monthlyBudgets[2], amount: 25000 } },
+      }),
+    )
     const { user } = renderStory()
 
     expect(await screen.findByText("Total spending")).toBeInTheDocument()
     expect(await screen.findByText("￥5,000")).toBeInTheDocument()
+    expect(await screen.findByText("￥20,000 left")).toBeInTheDocument()
 
     const accordionTrigger = screen.getByRole("button", {
       name: /by category/i,


### PR DESCRIPTION
## 関連Issue

- closes #1116

## 変更内容

- 支払い一覧の月次サマリーに、月予算に対する残額または超過額を表示
- 月予算利用状況の計算と表示を budgets feature に追加
- 予算あり、超過、未設定、取得エラー、読み込み中の story/test を追加

## 動作確認

- [x] task web:lint
- [x] task web:format-check
- [x] task web:typecheck
- [x] task web:test-unit
- [x] task web:test-storybook