### PR TITLE
Oxlintで型アサーションの利用を制限する

### DIFF
--- a/apps/web/.oxlintrc.json
+++ b/apps/web/.oxlintrc.json
@@ -1,5 +1,5 @@
 {
-  "plugins": ["react", "jsx-a11y"],
+  "plugins": ["react", "jsx-a11y", "typescript"],
   "jsPlugins": [{ "name": "react-hooks-js", "specifier": "eslint-plugin-react-hooks" }],
   "categories": {
     "correctness": "error"

--- a/apps/web/.oxlintrc.json
+++ b/apps/web/.oxlintrc.json
@@ -34,7 +34,12 @@
       }
     ],
     "typescript/no-import-type-side-effects": "error",
-    "typescript/consistent-type-assertions": "error",
+    "typescript/consistent-type-assertions": [
+      "error",
+      {
+        "assertionStyle": "never"
+      }
+    ],
     "typescript/no-non-null-assertion": "error"
   },
   "settings": {

--- a/apps/web/src/features/payments/components/AmountInput/AmountInput.tsx
+++ b/apps/web/src/features/payments/components/AmountInput/AmountInput.tsx
@@ -1,5 +1,5 @@
 import { TextField } from "@radix-ui/themes"
-import { type ChangeEvent } from "react"
+import type { ChangeEvent } from "react"
 
 interface AmountInputProps {
   id?: string

--- a/apps/web/src/features/payments/components/CategorySelect/CategorySelect.tsx
+++ b/apps/web/src/features/payments/components/CategorySelect/CategorySelect.tsx
@@ -1,7 +1,7 @@
 import { Select } from "@radix-ui/themes"
 import { type ReactNode, useCallback } from "react"
 
-import { Category } from "../../../../types/category"
+import type { Category } from "../../../../types/category"
 
 interface CategorySelectProps {
   autoFocus?: boolean

--- a/apps/web/src/features/payments/createPayment/CategoryField/CategoryField.tsx
+++ b/apps/web/src/features/payments/createPayment/CategoryField/CategoryField.tsx
@@ -2,7 +2,7 @@ import { memo, Suspense, use, useId } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 
 import { BaseField, FieldLabel, FieldMessages } from "../../../../components/inputs/BaseField"
-import { Category } from "../../../../types/category"
+import type { Category } from "../../../../types/category"
 import { useCategories } from "../../../categories/listCategory/useCategories"
 import {
   CategoryOption,

--- a/apps/web/src/features/payments/createPayment/useCreatePayment.ts
+++ b/apps/web/src/features/payments/createPayment/useCreatePayment.ts
@@ -14,6 +14,7 @@ async function postPayment(value: PaymentWriteInput): Promise<void> {
   const { error } = await supabase
     .from("payments")
     // FIXME: database.types.ts で user_id が必須だが、DB デフォルト値で設定されるため除外している。型定義の再生成で解消したらアサーションを削除する
+    // oxlint-disable-next-line typescript/consistent-type-assertions
     .insert(row as TablesInsert<"payments">)
 
   if (error) {

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.stories.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.stories.tsx
@@ -11,7 +11,7 @@ import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
 import { mapPaymentToRow } from "../../../../test/utils/mapPaymentToRow"
 import { PaymentDetailsOverlay } from "./PaymentDetailsOverlay"
 
-const paymentId = payments[0].id!
+const paymentId = payments[0].id
 
 const meta = {
   title: "Features/PaymentDetails/PaymentDetailsOverlay",

--- a/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.test.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.test.tsx
@@ -1,7 +1,7 @@
 import { createRoute } from "@tanstack/react-router"
 import { describe, expect, test } from "vitest"
 
-import { type SupabaseSessionState } from "../../../providers/supabase/SupabaseSessionProvider"
+import type { SupabaseSessionState } from "../../../providers/supabase/SupabaseSessionProvider"
 import { mockSession } from "../../../test/data/supabaseSession"
 import { renderWithRouter as renderWithTestRouter } from "../../../test/helpers/renderWithRouter"
 import { screen, waitFor } from "../../../test/test-utils"

--- a/apps/web/src/lib/queryClient.ts
+++ b/apps/web/src/lib/queryClient.ts
@@ -7,8 +7,8 @@ function isPostgrestUnauthorized(error: unknown): boolean {
     typeof error === "object" &&
     error !== null &&
     "code" in error &&
-    typeof (error as { code: unknown }).code === "string" &&
-    (error as { code: string }).code.startsWith("PGRST3")
+    typeof error.code === "string" &&
+    error.code.startsWith("PGRST3")
   )
 }
 

--- a/apps/web/src/providers/theme/types.ts
+++ b/apps/web/src/providers/theme/types.ts
@@ -1,1 +1,5 @@
 export type TTheme = "light" | "dark"
+
+export function isTheme(value: unknown): value is TTheme {
+  return value === "light" || value === "dark"
+}

--- a/apps/web/src/providers/theme/usePreferredTheme.tsx
+++ b/apps/web/src/providers/theme/usePreferredTheme.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useState } from "react"
 
-import type { TTheme } from "./types"
+import { isTheme, type TTheme } from "./types"
 
 export function usePreferredTheme() {
   const [theme, setTheme] = useState<TTheme>(() => {
-    const stored = localStorage.getItem("theme") as TTheme | null
-    if (stored) return stored
+    const stored = localStorage.getItem("theme")
+    if (isTheme(stored)) return stored
     // システム設定を反映
     const prefersDark = window?.matchMedia("(prefers-color-scheme: dark)").matches ?? false
     return prefersDark ? "dark" : "light"

--- a/apps/web/src/test/msw/handlers/monthlyBudgets.ts
+++ b/apps/web/src/test/msw/handlers/monthlyBudgets.ts
@@ -1,4 +1,4 @@
-import { DelayMode, HttpResponse, delay, http } from "msw"
+import { type DelayMode, HttpResponse, delay, http } from "msw"
 
 import type { MonthlyBudgetRow } from "../../../features/budgets/types"
 import { monthlyBudgets } from "../../data/monthlyBudgets"

--- a/apps/web/src/test/msw/handlers/payments.ts
+++ b/apps/web/src/test/msw/handlers/payments.ts
@@ -1,4 +1,4 @@
-import { DelayMode, HttpResponse, delay, http } from "msw"
+import { type DelayMode, HttpResponse, delay, http } from "msw"
 
 import type { CategoryRow } from "../../../types/category"
 import type { PaymentRow } from "../../../types/payment"

--- a/apps/web/src/test/msw/handlers/payments.ts
+++ b/apps/web/src/test/msw/handlers/payments.ts
@@ -1,4 +1,5 @@
 import { type DelayMode, HttpResponse, delay, http } from "msw"
+import z from "zod"
 
 import type { CategoryRow } from "../../../types/category"
 import type { PaymentRow } from "../../../types/payment"
@@ -121,18 +122,37 @@ function toPaymentDetailsRow(row: PaymentRow, categoryRows: CategoryRow[]): Paym
   }
 }
 
-function buildPaymentRow(body: Record<string, unknown>, paymentRows: PaymentRow[]): PaymentRow {
+const createPaymentBodySchema = z.object({
+  amount: z.number(),
+  date: z.string(),
+  note: z.string().nullable(),
+  category_id: z.number().nullable(),
+})
+
+type CreatePaymentBody = z.infer<typeof createPaymentBodySchema>
+
+const updatePaymentBodySchema = z.object({
+  amount: z.number().optional(),
+  date: z.string().optional(),
+  note: z.string().nullable().optional(),
+  category_id: z.number().nullable().optional(),
+})
+
+const getMonthlyTotalAmountRequestBodySchema = z.object({
+  p_month: z.string().optional(),
+})
+
+function buildPaymentRow(body: CreatePaymentBody, paymentRows: PaymentRow[]): PaymentRow {
   const now = new Date().toISOString()
 
   return {
     id: Math.max(0, ...paymentRows.map((row) => row.id)) + 1,
-    note: (body.note as string) ?? null,
-    amount: body.amount as number,
-    date: body.date as string,
+    note: body.note,
+    amount: body.amount,
+    date: body.date,
     created_at: now,
     updated_at: now,
-    category_id:
-      body.category_id !== null && body.category_id !== undefined ? Number(body.category_id) : null,
+    category_id: body.category_id,
     user_id: 100,
   }
 }
@@ -208,8 +228,9 @@ export function createPaymentHandlers({
       return HttpResponse.json([create.response], { status: 201 })
     }
 
-    const body = (await request.json()) as Record<string, unknown>
-    const newRow = buildPaymentRow(body, paymentRows)
+    const body = await request.json()
+    const parsedBody = createPaymentBodySchema.parse(body)
+    const newRow = buildPaymentRow(parsedBody, paymentRows)
     paymentRows = [...paymentRows, newRow]
 
     return HttpResponse.json([newRow], { status: 201 })
@@ -223,7 +244,8 @@ export function createPaymentHandlers({
     }
 
     const id = extractPaymentId(request)
-    const body = (await request.json()) as Partial<PaymentRow>
+    const body = await request.json()
+    const parsedBody = updatePaymentBodySchema.parse(body)
 
     paymentRows = paymentRows.map((row) => {
       if (String(row.id) !== id) {
@@ -232,7 +254,7 @@ export function createPaymentHandlers({
 
       return {
         ...row,
-        ...body,
+        ...parsedBody,
         updated_at: new Date().toISOString(),
       }
     })
@@ -269,8 +291,9 @@ export function createPaymentHandlers({
         return HttpResponse.json(getMonthlyTotalAmount.response)
       }
 
-      const body = (await request.json()) as { p_month?: string }
-      return HttpResponse.json(calculateMonthlyTotalAmount(paymentRows, body.p_month))
+      const body = await request.json()
+      const parsedBody = getMonthlyTotalAmountRequestBodySchema.parse(body)
+      return HttpResponse.json(calculateMonthlyTotalAmount(paymentRows, parsedBody.p_month))
     },
   )
 


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- Oxlint の TypeScript plugin を有効化し、TypeScript 系ルールが設定どおり適用されるようにした
- `typescript/consistent-type-assertions` を `assertionStyle: "never"` に変更し、型アサーションを原則禁止した
- 既存の型アサーションを型ガードや Zod parse に置き換えた
- DB 型生成との差分で残る支払い作成時の型アサーションは、理由コメントと `oxlint-disable-next-line` で局所的に許可した
- 型専用 import を `import type` に整理した

## 動作確認

- [x] ローカルでの動作確認
  - `task web:lint`
  - `task web:format-check`
- [ ] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

- 現状の `task web:lint` では `0 warnings / 0 errors` で、ルール違反はありません。
- UI 変更は含まないため、UI確認は未実施です。
