### PR TITLE
月予算一覧を表示する

### DIFF
--- a/apps/web/src/app/AppLayout/AppLayout.test.tsx
+++ b/apps/web/src/app/AppLayout/AppLayout.test.tsx
@@ -1,0 +1,54 @@
+import { createRoute } from "@tanstack/react-router"
+import { beforeEach, describe, expect, test } from "vitest"
+
+import { renderWithRouter } from "../../test/helpers/renderWithRouter"
+import { screen, waitFor } from "../../test/test-utils"
+import { AppLayout } from "./AppLayout"
+
+function renderAppLayout(initialEntry = "/payments") {
+  return renderWithRouter(initialEntry, (root) => {
+    const authenticatedRoute = createRoute({
+      getParentRoute: () => root,
+      id: "authenticated",
+      component: AppLayout,
+    })
+
+    const paymentsRoute = createRoute({
+      getParentRoute: () => authenticatedRoute,
+      path: "/payments",
+      component: () => <div>Payments page</div>,
+    })
+
+    const budgetsRoute = createRoute({
+      getParentRoute: () => authenticatedRoute,
+      path: "/budgets",
+      component: () => <div>Budgets page</div>,
+    })
+
+    return [authenticatedRoute.addChildren([paymentsRoute, budgetsRoute])]
+  })
+}
+
+describe("AppLayout", () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  test("Sidebar に Payments と Budgets への導線を表示する", async () => {
+    const { router, user } = renderAppLayout()
+
+    expect(
+      await screen.findByRole("link", { name: "Navigate to Payments page" }),
+    ).toBeInTheDocument()
+
+    const budgetsLink = await screen.findByRole("link", { name: "Navigate to Budgets page" })
+    expect(budgetsLink).toHaveAttribute("href", "/budgets")
+
+    await user.click(budgetsLink)
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/budgets")
+    })
+    expect(await screen.findByText("Budgets page")).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/app/AppLayout/AppLayout.tsx
+++ b/apps/web/src/app/AppLayout/AppLayout.tsx
@@ -1,4 +1,3 @@
-import { CalendarIcon } from "@radix-ui/react-icons"
 import { Flex } from "@radix-ui/themes"
 import { Outlet } from "@tanstack/react-router"
 
@@ -18,11 +17,7 @@ export function AppLayout() {
         <SidebarButton
           to="/payments"
           ariaLabel="Navigate to Payments page"
-          label={
-            <>
-              <CalendarIcon /> Payments
-            </>
-          }
+          label="Payments"
           onClick={closeSidebar}
         />
         <SidebarButton

--- a/apps/web/src/app/AppLayout/AppLayout.tsx
+++ b/apps/web/src/app/AppLayout/AppLayout.tsx
@@ -17,11 +17,18 @@ export function AppLayout() {
       <Sidebar open={open} onClose={closeSidebar}>
         <SidebarButton
           to="/payments"
+          ariaLabel="Navigate to Payments page"
           label={
             <>
               <CalendarIcon /> Payments
             </>
           }
+          onClick={closeSidebar}
+        />
+        <SidebarButton
+          to="/budgets"
+          ariaLabel="Navigate to Budgets page"
+          label="Budgets"
           onClick={closeSidebar}
         />
       </Sidebar>

--- a/apps/web/src/app/Sidebar/Sidebar.tsx
+++ b/apps/web/src/app/Sidebar/Sidebar.tsx
@@ -44,7 +44,7 @@ export function Sidebar({ children, open, onClose }: SidebarProps) {
       </Flex>
       <Separator size="4" />
       {/* Sidebar Contents */}
-      <Flex className={styles.sidebarContents} align="start" gap="2" p="4">
+      <Flex className={styles.sidebarContents} align="start" direction={"column"} gap="4" p="4">
         {children}
       </Flex>
       <Separator size="4" />

--- a/apps/web/src/app/Sidebar/Sidebar.tsx
+++ b/apps/web/src/app/Sidebar/Sidebar.tsx
@@ -44,7 +44,7 @@ export function Sidebar({ children, open, onClose }: SidebarProps) {
       </Flex>
       <Separator size="4" />
       {/* Sidebar Contents */}
-      <Flex className={styles.sidebarContents} align="start" direction={"column"} gap="4" p="4">
+      <Flex className={styles.sidebarContents} align="start" direction="column" gap="4" p="4">
         {children}
       </Flex>
       <Separator size="4" />

--- a/apps/web/src/app/Sidebar/SidebarButton.tsx
+++ b/apps/web/src/app/Sidebar/SidebarButton.tsx
@@ -7,14 +7,15 @@ import styles from "./SidebarButton.module.css"
 interface SidebarButtonProps {
   to: string
   label: ReactNode
+  ariaLabel: string
   onClick?: () => void
 }
 
-export function SidebarButton({ to, label, onClick }: SidebarButtonProps) {
+export function SidebarButton({ to, label, ariaLabel, onClick }: SidebarButtonProps) {
   return (
     <Button
       asChild
-      aria-label={`Navigate to ${label} page`}
+      aria-label={ariaLabel}
       className={styles.sidebarButton}
       variant="ghost"
       size="3"

--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -11,6 +11,7 @@ import type { AuthStatus } from "../providers/supabase/SupabaseSessionProvider"
 import { AppLayout } from "./AppLayout"
 import { AggregatesPage } from "./routes/AggregatesPage"
 import { AuthPage } from "./routes/AuthPage"
+import { BudgetsPage } from "./routes/BudgetsPage"
 import { ErrorPage } from "./routes/ErrorPage"
 import { PaymentsPage } from "./routes/PaymentsPage"
 import { TopPage } from "./routes/TopPage"
@@ -71,10 +72,16 @@ const aggregatesRoute = createRoute({
   component: AggregatesPage,
 })
 
+const budgetsRoute = createRoute({
+  getParentRoute: () => authenticatedRoute,
+  path: "/budgets",
+  component: BudgetsPage,
+})
+
 const routeTree = rootRoute.addChildren([
   indexRoute,
   authRoute,
-  authenticatedRoute.addChildren([paymentsRoute, aggregatesRoute]),
+  authenticatedRoute.addChildren([paymentsRoute, aggregatesRoute, budgetsRoute]),
 ])
 
 export const router = createRouter({

--- a/apps/web/src/app/routes/BudgetsPage/BudgetsPage.stories.tsx
+++ b/apps/web/src/app/routes/BudgetsPage/BudgetsPage.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { expect, within } from "storybook/test"
+
+import { createStoryRouter } from "../../../test/helpers/routerDecorator"
+import { BudgetsPage } from "./BudgetsPage"
+
+const meta = {
+  title: "Pages/BudgetsPage",
+  component: BudgetsPage,
+  parameters: {},
+  tags: ["autodocs", "browser-test"],
+  decorators: [createStoryRouter("/budgets")],
+  argTypes: {},
+  args: {},
+} satisfies Meta<typeof BudgetsPage>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {},
+  play: ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    expect(canvas.getByRole("heading", { name: "Budgets" })).toBeInTheDocument()
+  },
+}

--- a/apps/web/src/app/routes/BudgetsPage/BudgetsPage.stories.tsx
+++ b/apps/web/src/app/routes/BudgetsPage/BudgetsPage.stories.tsx
@@ -1,13 +1,23 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { expect, within } from "storybook/test"
 
+import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
 import { createStoryRouter } from "../../../test/helpers/routerDecorator"
+import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
 import { BudgetsPage } from "./BudgetsPage"
 
 const meta = {
   title: "Pages/BudgetsPage",
   component: BudgetsPage,
-  parameters: {},
+  parameters: {
+    msw: {
+      handlers: [
+        ...createMonthlyBudgetHandlers({
+          list: { response: [monthlyBudgets[3], monthlyBudgets[2], monthlyBudgets[1]] },
+        }),
+      ],
+    },
+  },
   tags: ["autodocs", "browser-test"],
   decorators: [createStoryRouter("/budgets")],
   argTypes: {},
@@ -19,9 +29,65 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {},
-  play: ({ canvasElement }) => {
+  play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
     expect(canvas.getByRole("heading", { name: "Budgets" })).toBeInTheDocument()
+    const table = await canvas.findByRole("table")
+    expect(await within(table).findByText("2025/07")).toBeInTheDocument()
+    expect(await within(table).findByText("￥75,000")).toBeInTheDocument()
+  },
+}
+
+export const Empty: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...createMonthlyBudgetHandlers({
+          list: { response: [] },
+        }),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    expect(await canvas.findByText("No monthly budgets yet.")).toBeInTheDocument()
+  },
+}
+
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...createMonthlyBudgetHandlers({
+          list: { response: [], durationOrMode: "infinite" },
+        }),
+      ],
+    },
+  },
+  play: ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    expect(canvas.getAllByLabelText("loading monthly budget")).toHaveLength(3)
+  },
+}
+
+export const FetchError: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...createMonthlyBudgetHandlers({
+          list: { error: true },
+        }),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    expect(
+      await canvas.findByText("Could not load monthly budgets.", {}, { timeout: 3000 }),
+    ).toBeInTheDocument()
   },
 }

--- a/apps/web/src/app/routes/BudgetsPage/BudgetsPage.test.tsx
+++ b/apps/web/src/app/routes/BudgetsPage/BudgetsPage.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "vitest"
+
+import { render, screen } from "../../../test/test-utils"
+import { BudgetsPage } from "./BudgetsPage"
+
+describe("BudgetsPage", () => {
+  test("Budgets 見出しを表示する", () => {
+    render(<BudgetsPage />)
+
+    expect(screen.getByRole("heading", { name: "Budgets" })).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/app/routes/BudgetsPage/BudgetsPage.test.tsx
+++ b/apps/web/src/app/routes/BudgetsPage/BudgetsPage.test.tsx
@@ -1,12 +1,29 @@
 import { describe, expect, test } from "vitest"
 
-import { render, screen } from "../../../test/test-utils"
+import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
+import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
+import { server } from "../../../test/msw/server"
+import { act, render, screen } from "../../../test/test-utils"
 import { BudgetsPage } from "./BudgetsPage"
 
+async function renderBudgetsPage() {
+  return await act(async () => {
+    return render(<BudgetsPage />)
+  })
+}
+
 describe("BudgetsPage", () => {
-  test("Budgets 見出しを表示する", () => {
-    render(<BudgetsPage />)
+  test("Budgets 見出しと月予算一覧を表示する", async () => {
+    server.resetHandlers(
+      ...createMonthlyBudgetHandlers({
+        list: { response: [monthlyBudgets[3]] },
+      }),
+    )
+
+    await renderBudgetsPage()
 
     expect(screen.getByRole("heading", { name: "Budgets" })).toBeInTheDocument()
+    expect(await screen.findByRole("table")).toBeInTheDocument()
+    expect(await screen.findByText("2025/07")).toBeInTheDocument()
   })
 })

--- a/apps/web/src/app/routes/BudgetsPage/BudgetsPage.tsx
+++ b/apps/web/src/app/routes/BudgetsPage/BudgetsPage.tsx
@@ -1,12 +1,15 @@
 import { Container, Flex, Heading } from "@radix-ui/themes"
 
+import { MonthlyBudgetList } from "../../../features/budgets/listMonthlyBudget"
+
 export function BudgetsPage() {
   return (
     <Container size="4">
-      <Flex direction="column" gap="3">
+      <Flex direction="column" gap="4">
         <Heading as="h1" size="6">
           Budgets
         </Heading>
+        <MonthlyBudgetList />
       </Flex>
     </Container>
   )

--- a/apps/web/src/app/routes/BudgetsPage/BudgetsPage.tsx
+++ b/apps/web/src/app/routes/BudgetsPage/BudgetsPage.tsx
@@ -1,0 +1,13 @@
+import { Container, Flex, Heading } from "@radix-ui/themes"
+
+export function BudgetsPage() {
+  return (
+    <Container size="4">
+      <Flex direction="column" gap="3">
+        <Heading as="h1" size="6">
+          Budgets
+        </Heading>
+      </Flex>
+    </Container>
+  )
+}

--- a/apps/web/src/app/routes/BudgetsPage/index.ts
+++ b/apps/web/src/app/routes/BudgetsPage/index.ts
@@ -1,0 +1,1 @@
+export * from "./BudgetsPage"

--- a/apps/web/src/features/budgets/getMonthlyBudget/fetchEffectiveMonthlyBudget.ts
+++ b/apps/web/src/features/budgets/getMonthlyBudget/fetchEffectiveMonthlyBudget.ts
@@ -1,21 +1,7 @@
-import * as z from "zod"
-
 import { getSupabaseClient } from "../../../lib/supabase"
-import type { MonthlyBudget, MonthlyBudgetRow } from "../types"
-import { parseIsoDateOnlyToLocalDate, toMonthEndIsoDate } from "../utils/month"
-
-const monthlyBudgetRowSchema = z.object({
-  id: z.number(),
-  amount: z.number(),
-  effective_from: z.string(),
-  effective_year: z.number(),
-  effective_month: z.number(),
-  user_id: z.number(),
-  created_at: z.string().nullable(),
-  updated_at: z.string().nullable(),
-})
-
-type NormalizedMonthlyBudgetRow = z.infer<typeof monthlyBudgetRowSchema>
+import { normalizeMonthlyBudgetRow, toMonthlyBudget } from "../monthlyBudgetMappers"
+import type { MonthlyBudget } from "../types"
+import { toMonthEndIsoDate } from "../utils/month"
 
 export async function fetchEffectiveMonthlyBudget(targetDate: Date): Promise<MonthlyBudget | null> {
   const supabase = getSupabaseClient()
@@ -38,27 +24,4 @@ export async function fetchEffectiveMonthlyBudget(targetDate: Date): Promise<Mon
   }
 
   return toMonthlyBudget(normalizeMonthlyBudgetRow(data))
-}
-
-function normalizeMonthlyBudgetRow(value: unknown): NormalizedMonthlyBudgetRow {
-  const result = monthlyBudgetRowSchema.safeParse(value)
-
-  if (!result.success) {
-    throw new Error("Invalid monthly budget response")
-  }
-
-  return result.data
-}
-
-function toMonthlyBudget(row: MonthlyBudgetRow): MonthlyBudget {
-  return {
-    id: row.id,
-    amount: row.amount,
-    effectiveFrom: parseIsoDateOnlyToLocalDate(row.effective_from),
-    effectiveYear: row.effective_year,
-    effectiveMonth: row.effective_month,
-    userId: row.user_id,
-    createdDate: row.created_at ? new Date(row.created_at) : new Date(),
-    updatedDate: row.updated_at ? new Date(row.updated_at) : new Date(),
-  }
 }

--- a/apps/web/src/features/budgets/listMonthlyBudget/MonthlyBudgetList/MonthlyBudgetList.test.tsx
+++ b/apps/web/src/features/budgets/listMonthlyBudget/MonthlyBudgetList/MonthlyBudgetList.test.tsx
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+import { monthlyBudgets } from "../../../../test/data/monthlyBudgets"
+import { createMonthlyBudgetHandlers } from "../../../../test/msw/handlers/monthlyBudgets"
+import { server } from "../../../../test/msw/server"
+import { act, render, screen, within } from "../../../../test/test-utils"
+import { MonthlyBudgetList } from "./MonthlyBudgetList"
+
+async function renderMonthlyBudgetList() {
+  return await act(async () => {
+    return render(<MonthlyBudgetList />)
+  })
+}
+
+describe("MonthlyBudgetList", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test("月予算の年月と金額を一覧表示する", async () => {
+    server.resetHandlers(
+      ...createMonthlyBudgetHandlers({
+        list: {
+          response: [monthlyBudgets[3], monthlyBudgets[2]],
+        },
+      }),
+    )
+
+    await renderMonthlyBudgetList()
+
+    const table = await screen.findByRole("table")
+    expect(within(table).getByText("Month")).toBeInTheDocument()
+    expect(within(table).getByText("Amount")).toBeInTheDocument()
+    expect(await within(table).findByText("2025/07")).toBeInTheDocument()
+    expect(await within(table).findByText("￥75,000")).toBeInTheDocument()
+    expect(await within(table).findByText("2025/03")).toBeInTheDocument()
+    expect(await within(table).findByText("￥62,000")).toBeInTheDocument()
+  })
+
+  test("月予算がない場合は空状態を表示する", async () => {
+    server.resetHandlers(
+      ...createMonthlyBudgetHandlers({
+        list: { response: [] },
+      }),
+    )
+
+    await renderMonthlyBudgetList()
+
+    expect(await screen.findByText("No monthly budgets yet.")).toBeInTheDocument()
+  })
+
+  test("取得中はスケルトン行を表示する", async () => {
+    server.resetHandlers(
+      ...createMonthlyBudgetHandlers({
+        list: { response: [], durationOrMode: "infinite" },
+      }),
+    )
+
+    await renderMonthlyBudgetList()
+
+    expect(screen.getAllByLabelText("loading monthly budget")).toHaveLength(3)
+  })
+
+  test("取得に失敗した場合はエラー状態を表示する", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    server.resetHandlers(
+      ...createMonthlyBudgetHandlers({
+        list: { error: true },
+      }),
+    )
+
+    render(<MonthlyBudgetList />)
+
+    expect(
+      await screen.findByText("Could not load monthly budgets.", {}, { timeout: 3000 }),
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/budgets/listMonthlyBudget/MonthlyBudgetList/MonthlyBudgetList.test.tsx
+++ b/apps/web/src/features/budgets/listMonthlyBudget/MonthlyBudgetList/MonthlyBudgetList.test.tsx
@@ -69,7 +69,7 @@ describe("MonthlyBudgetList", () => {
       }),
     )
 
-    render(<MonthlyBudgetList />)
+    await renderMonthlyBudgetList()
 
     expect(
       await screen.findByText("Could not load monthly budgets.", {}, { timeout: 3000 }),

--- a/apps/web/src/features/budgets/listMonthlyBudget/MonthlyBudgetList/MonthlyBudgetList.tsx
+++ b/apps/web/src/features/budgets/listMonthlyBudget/MonthlyBudgetList/MonthlyBudgetList.tsx
@@ -1,0 +1,100 @@
+import { Flex, Skeleton, Table, Text } from "@radix-ui/themes"
+import { Suspense, use } from "react"
+import { ErrorBoundary } from "react-error-boundary"
+
+import { toCurrency } from "../../../../utils/toCurrency"
+import type { MonthlyBudget } from "../../types"
+import { useMonthlyBudgets } from "../useMonthlyBudgets"
+
+const monthlyBudgetListLimit = 10
+
+export function MonthlyBudgetList() {
+  const { promise } = useMonthlyBudgets(monthlyBudgetListLimit)
+
+  return (
+    <Flex direction="column" gap="3">
+      <Text as="p" size="4" weight="medium">
+        Monthly budgets
+      </Text>
+      <Table.Root aria-label="monthly budgets">
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeaderCell>Month</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell align="right">Amount</Table.ColumnHeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          <ErrorBoundary
+            fallback={<StatusRow color="red" text="Could not load monthly budgets." />}
+          >
+            <Suspense fallback={<LoadingRows />}>
+              <MonthlyBudgetRows promise={promise} />
+            </Suspense>
+          </ErrorBoundary>
+        </Table.Body>
+      </Table.Root>
+    </Flex>
+  )
+}
+
+function MonthlyBudgetRows({ promise }: { promise: Promise<MonthlyBudget[]> }) {
+  const monthlyBudgets = use(promise)
+
+  if (monthlyBudgets.length === 0) {
+    return <StatusRow color="gray" text="No monthly budgets yet." />
+  }
+
+  return monthlyBudgets.map((monthlyBudget) => (
+    <MonthlyBudgetRow key={monthlyBudget.id} monthlyBudget={monthlyBudget} />
+  ))
+}
+
+function LoadingRows() {
+  return (
+    <>
+      <LoadingRow />
+      <LoadingRow />
+      <LoadingRow />
+    </>
+  )
+}
+
+function LoadingRow() {
+  return (
+    <Table.Row aria-label="loading monthly budget">
+      <Table.Cell>
+        <Skeleton loading>
+          <Text>0000/00</Text>
+        </Skeleton>
+      </Table.Cell>
+      <Table.Cell align="right">
+        <Skeleton loading>
+          <Text>￥000,000</Text>
+        </Skeleton>
+      </Table.Cell>
+    </Table.Row>
+  )
+}
+
+function StatusRow({ color, text }: { color: "gray" | "red"; text: string }) {
+  return (
+    <Table.Row>
+      <Table.Cell colSpan={2}>
+        <Text color={color}>{text}</Text>
+      </Table.Cell>
+    </Table.Row>
+  )
+}
+
+function MonthlyBudgetRow({ monthlyBudget }: { monthlyBudget: MonthlyBudget }) {
+  return (
+    <Table.Row>
+      <Table.RowHeaderCell>{formatMonthlyBudgetMonth(monthlyBudget)}</Table.RowHeaderCell>
+      <Table.Cell align="right">{toCurrency(monthlyBudget.amount)}</Table.Cell>
+    </Table.Row>
+  )
+}
+
+function formatMonthlyBudgetMonth(monthlyBudget: MonthlyBudget): string {
+  return `${monthlyBudget.effectiveYear}/${String(monthlyBudget.effectiveMonth).padStart(2, "0")}`
+}

--- a/apps/web/src/features/budgets/listMonthlyBudget/fetchMonthlyBudgets.test.ts
+++ b/apps/web/src/features/budgets/listMonthlyBudget/fetchMonthlyBudgets.test.ts
@@ -1,0 +1,118 @@
+import { HttpResponse, http } from "msw"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
+import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
+import { server } from "../../../test/msw/server"
+import { supabaseTestClient } from "../../../test/utils/createSupabaseTestClient"
+import { fetchMonthlyBudgets } from "./fetchMonthlyBudgets"
+
+vi.mock("../../../lib/supabase", () => ({
+  getSupabaseClient: () => supabaseTestClient,
+}))
+
+describe("fetchMonthlyBudgets", () => {
+  beforeEach(() => {
+    server.resetHandlers(...createMonthlyBudgetHandlers())
+  })
+
+  it("月予算一覧を取得して domain model に変換する", async () => {
+    server.resetHandlers(
+      ...createMonthlyBudgetHandlers({
+        list: {
+          response: [monthlyBudgets[3], monthlyBudgets[2]],
+        },
+      }),
+    )
+
+    const budgets = await fetchMonthlyBudgets(2)
+
+    expect(budgets).toHaveLength(2)
+    expect(budgets[0]).toMatchObject({
+      id: 3,
+      amount: 75000,
+      effectiveYear: 2025,
+      effectiveMonth: 7,
+      userId: 100,
+    })
+    expect(budgets[0]?.effectiveFrom).toEqual(new Date(2025, 6, 1))
+    expect(budgets[0]?.createdDate).toBeInstanceOf(Date)
+    expect(budgets[0]?.updatedDate).toBeInstanceOf(Date)
+  })
+
+  it("登録済み月予算がない場合は空配列を返す", async () => {
+    server.resetHandlers(
+      ...createMonthlyBudgetHandlers({
+        list: {
+          response: [],
+        },
+      }),
+    )
+
+    await expect(fetchMonthlyBudgets(10)).resolves.toEqual([])
+  })
+
+  it("直近順・指定件数で monthly_budgets を問い合わせる", async () => {
+    const requestCapture: { url: URL | null } = { url: null }
+
+    server.use(
+      http.get("*/rest/v1/monthly_budgets*", ({ request }) => {
+        requestCapture.url = new URL(request.url)
+
+        return HttpResponse.json([monthlyBudgets[3], monthlyBudgets[2]])
+      }),
+    )
+
+    await fetchMonthlyBudgets(2)
+
+    const select = requestCapture.url?.searchParams.get("select")
+    expect(select).toContain("id")
+    expect(select).toContain("amount")
+    expect(select).toContain("effective_from")
+    expect(select).toContain("effective_year")
+    expect(select).toContain("effective_month")
+    expect(select).toContain("user_id")
+    expect(select).toContain("created_at")
+    expect(select).toContain("updated_at")
+    expect(requestCapture.url?.searchParams.get("order")).toBe("effective_from.desc")
+    expect(requestCapture.url?.searchParams.get("limit")).toBe("2")
+  })
+
+  it("レスポンス shape が不正ならエラーにする", async () => {
+    server.use(
+      http.get("*/rest/v1/monthly_budgets*", () => {
+        return HttpResponse.json([
+          {
+            id: "invalid",
+            amount: 62000,
+            effective_from: "2025-03-30",
+            effective_year: 2025,
+            effective_month: 3,
+            user_id: 100,
+            created_at: "2025-03-30T00:00:00.000Z",
+            updated_at: "2025-03-30T00:00:00.000Z",
+          },
+        ])
+      }),
+    )
+
+    await expect(fetchMonthlyBudgets(10)).rejects.toThrow("Invalid monthly budget response")
+  })
+
+  it("取得件数が正の整数でない場合は問い合わせ前にエラーにする", async () => {
+    const requestSpy = vi.fn()
+
+    server.use(
+      http.get("*/rest/v1/monthly_budgets*", () => {
+        requestSpy()
+
+        return HttpResponse.json([])
+      }),
+    )
+
+    for (const limit of [0, -1, 1.5, Number.NaN]) {
+      await expect(fetchMonthlyBudgets(limit)).rejects.toThrow(RangeError)
+    }
+    expect(requestSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/budgets/listMonthlyBudget/fetchMonthlyBudgets.ts
+++ b/apps/web/src/features/budgets/listMonthlyBudget/fetchMonthlyBudgets.ts
@@ -1,0 +1,34 @@
+import * as z from "zod"
+
+import { getSupabaseClient } from "../../../lib/supabase"
+import { normalizeMonthlyBudgetRows, toMonthlyBudget } from "../monthlyBudgetMappers"
+import type { MonthlyBudget } from "../types"
+
+const monthlyBudgetColumns =
+  "id, amount, effective_from, effective_year, effective_month, user_id, created_at, updated_at"
+const monthlyBudgetLimitSchema = z.number().int().positive()
+
+export async function fetchMonthlyBudgets(limit: number): Promise<MonthlyBudget[]> {
+  assertPositiveInteger(limit)
+
+  const supabase = getSupabaseClient()
+  const { data, error } = await supabase
+    .from("monthly_budgets")
+    .select(monthlyBudgetColumns)
+    .order("effective_from", { ascending: false })
+    .limit(limit)
+
+  if (error) {
+    throw error
+  }
+
+  return normalizeMonthlyBudgetRows(data).map(toMonthlyBudget)
+}
+
+function assertPositiveInteger(value: number): void {
+  const result = monthlyBudgetLimitSchema.safeParse(value)
+
+  if (!result.success) {
+    throw new RangeError("Monthly budget limit must be a positive integer")
+  }
+}

--- a/apps/web/src/features/budgets/listMonthlyBudget/index.ts
+++ b/apps/web/src/features/budgets/listMonthlyBudget/index.ts
@@ -1,0 +1,1 @@
+export * from "./MonthlyBudgetList/MonthlyBudgetList"

--- a/apps/web/src/features/budgets/listMonthlyBudget/useMonthlyBudgets.test.tsx
+++ b/apps/web/src/features/budgets/listMonthlyBudget/useMonthlyBudgets.test.tsx
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { renderHook, waitFor } from "../../../test/test-utils"
+import type { MonthlyBudget } from "../types"
+import { useMonthlyBudgets } from "./useMonthlyBudgets"
+
+const { mockFetchMonthlyBudgets } = vi.hoisted(() => ({
+  mockFetchMonthlyBudgets: vi.fn(),
+}))
+
+vi.mock("./fetchMonthlyBudgets", () => ({
+  fetchMonthlyBudgets: mockFetchMonthlyBudgets,
+}))
+
+function buildMonthlyBudget(id: number): MonthlyBudget {
+  return {
+    id,
+    amount: 50000 + id,
+    effectiveFrom: new Date(2025, id, 1),
+    effectiveYear: 2025,
+    effectiveMonth: id + 1,
+    userId: 100,
+    createdDate: new Date("2025-01-01T00:00:00.000Z"),
+    updatedDate: new Date("2025-01-01T00:00:00.000Z"),
+  }
+}
+
+describe("useMonthlyBudgets", () => {
+  beforeEach(() => {
+    mockFetchMonthlyBudgets.mockReset()
+  })
+
+  it("指定した件数で月予算一覧を取得する", async () => {
+    const budgets = [buildMonthlyBudget(1), buildMonthlyBudget(2)]
+    mockFetchMonthlyBudgets.mockResolvedValue(budgets)
+
+    const { result } = renderHook(() => useMonthlyBudgets(10))
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(budgets)
+    })
+    expect(mockFetchMonthlyBudgets).toHaveBeenCalledWith(10)
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  it("取得件数が変わると別 query として取得し直す", async () => {
+    const firstBudget = buildMonthlyBudget(1)
+    const secondBudget = buildMonthlyBudget(2)
+    mockFetchMonthlyBudgets
+      .mockResolvedValueOnce([firstBudget])
+      .mockResolvedValueOnce([secondBudget])
+
+    const { result, rerender } = renderHook(
+      ({ limit }: { limit: number }) => useMonthlyBudgets(limit),
+      {
+        initialProps: { limit: 10 },
+      },
+    )
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([firstBudget])
+    })
+
+    rerender({ limit: 3 })
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([secondBudget])
+    })
+    expect(mockFetchMonthlyBudgets).toHaveBeenNthCalledWith(1, 10)
+    expect(mockFetchMonthlyBudgets).toHaveBeenNthCalledWith(2, 3)
+  })
+
+  it("取得に失敗した場合は error を返す", async () => {
+    const error = new Error("failed")
+    mockFetchMonthlyBudgets.mockRejectedValue(error)
+
+    const { result } = renderHook(() => useMonthlyBudgets(10))
+
+    await waitFor(
+      () => {
+        expect(result.current.error).toBe(error)
+      },
+      { timeout: 3000 },
+    )
+    expect(result.current.data).toEqual([])
+    expect(result.current.loading).toBe(false)
+  })
+})

--- a/apps/web/src/features/budgets/listMonthlyBudget/useMonthlyBudgets.ts
+++ b/apps/web/src/features/budgets/listMonthlyBudget/useMonthlyBudgets.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query"
+
+import type { MonthlyBudget } from "../types"
+import { fetchMonthlyBudgets } from "./fetchMonthlyBudgets"
+
+interface UseMonthlyBudgetsReturn {
+  data: MonthlyBudget[]
+  loading: boolean
+  error: Error | null
+  promise: Promise<MonthlyBudget[]>
+}
+
+export function useMonthlyBudgets(limit: number): UseMonthlyBudgetsReturn {
+  const query = useQuery({
+    queryKey: ["monthlyBudgets", limit],
+    queryFn: () => fetchMonthlyBudgets(limit),
+    staleTime: 3000, // 3秒
+  })
+
+  return {
+    data: query.data ?? [],
+    loading: query.isLoading,
+    error: query.error,
+    promise: query.promise,
+  }
+}

--- a/apps/web/src/features/budgets/monthlyBudgetMappers.ts
+++ b/apps/web/src/features/budgets/monthlyBudgetMappers.ts
@@ -1,0 +1,50 @@
+import * as z from "zod"
+
+import type { MonthlyBudget } from "./types"
+import { parseIsoDateOnlyToLocalDate } from "./utils/month"
+
+const monthlyBudgetRowSchema = z.object({
+  id: z.number(),
+  amount: z.number(),
+  effective_from: z.string(),
+  effective_year: z.number(),
+  effective_month: z.number(),
+  user_id: z.number(),
+  created_at: z.string().nullable(),
+  updated_at: z.string().nullable(),
+})
+
+type NormalizedMonthlyBudgetRow = z.infer<typeof monthlyBudgetRowSchema>
+
+export function normalizeMonthlyBudgetRow(value: unknown): NormalizedMonthlyBudgetRow {
+  const result = monthlyBudgetRowSchema.safeParse(value)
+
+  if (!result.success) {
+    throw new Error("Invalid monthly budget response")
+  }
+
+  return result.data
+}
+
+export function normalizeMonthlyBudgetRows(value: unknown): NormalizedMonthlyBudgetRow[] {
+  const result = z.array(monthlyBudgetRowSchema).safeParse(value)
+
+  if (!result.success) {
+    throw new Error("Invalid monthly budget response")
+  }
+
+  return result.data
+}
+
+export function toMonthlyBudget(row: NormalizedMonthlyBudgetRow): MonthlyBudget {
+  return {
+    id: row.id,
+    amount: row.amount,
+    effectiveFrom: parseIsoDateOnlyToLocalDate(row.effective_from),
+    effectiveYear: row.effective_year,
+    effectiveMonth: row.effective_month,
+    userId: row.user_id,
+    createdDate: row.created_at ? new Date(row.created_at) : new Date(),
+    updatedDate: row.updated_at ? new Date(row.updated_at) : new Date(),
+  }
+}

--- a/apps/web/src/test/msw/handlers/monthlyBudgets.ts
+++ b/apps/web/src/test/msw/handlers/monthlyBudgets.ts
@@ -18,26 +18,18 @@ interface ListMonthlyBudgetOptions extends BaseOptions {
   response?: MonthlyBudgetRow[]
 }
 
-type CreateMonthlyBudgetHandlersOptions =
-  | {
-      get?: GetMonthlyBudgetOptions
-      list?: never
-    }
-  | {
-      get?: never
-      list: ListMonthlyBudgetOptions
-    }
+interface CreateMonthlyBudgetHandlersOptions {
+  get?: GetMonthlyBudgetOptions
+  list?: ListMonthlyBudgetOptions
+}
 
 export function createMonthlyBudgetHandlers(options: CreateMonthlyBudgetHandlersOptions = {}) {
-  if (options.get !== undefined && options.list !== undefined) {
-    throw new Error("get and list monthly budget handler options cannot be used together")
-  }
-
   const get = options.get ?? {}
-  const list = options.list
+  const list = options.list ?? {}
 
-  const getMonthlyBudgetHandler = http.get(REST_URL, async () => {
-    const handlerOptions = list ?? get
+  const monthlyBudgetsHandler = http.get(REST_URL, async ({ request }) => {
+    const shouldReturnSingle = shouldReturnSingleObject(request)
+    const handlerOptions = shouldReturnSingle ? get : list
 
     await delay(handlerOptions.durationOrMode)
 
@@ -45,19 +37,24 @@ export function createMonthlyBudgetHandlers(options: CreateMonthlyBudgetHandlers
       return HttpResponse.json({ message: "Failed to fetch monthly budgets." }, { status: 500 })
     }
 
-    const response =
-      list === undefined
-        ? get.response === undefined
-          ? monthlyBudgets[2]
-          : get.response
-        : list.response === undefined
-          ? monthlyBudgets
-          : list.response
+    const response = shouldReturnSingle
+      ? get.response === undefined
+        ? monthlyBudgets[2]
+        : get.response
+      : list.response === undefined
+        ? monthlyBudgets
+        : list.response
 
     return HttpResponse.json(response)
   })
 
-  return [getMonthlyBudgetHandler]
+  return [monthlyBudgetsHandler]
+}
+
+function shouldReturnSingleObject(request: Request): boolean {
+  const url = new URL(request.url)
+
+  return url.searchParams.has("effective_from") && url.searchParams.get("limit") === "1"
 }
 
 export const monthlyBudgetHandlers = createMonthlyBudgetHandlers()

--- a/apps/web/src/test/msw/handlers/monthlyBudgets.ts
+++ b/apps/web/src/test/msw/handlers/monthlyBudgets.ts
@@ -14,19 +14,45 @@ interface GetMonthlyBudgetOptions extends BaseOptions {
   response?: MonthlyBudgetRow | null
 }
 
-interface CreateMonthlyBudgetHandlersOptions {
-  get?: GetMonthlyBudgetOptions
+interface ListMonthlyBudgetOptions extends BaseOptions {
+  response?: MonthlyBudgetRow[]
 }
 
-export function createMonthlyBudgetHandlers({ get = {} }: CreateMonthlyBudgetHandlersOptions = {}) {
-  const getMonthlyBudgetHandler = http.get(REST_URL, async () => {
-    await delay(get.durationOrMode)
+type CreateMonthlyBudgetHandlersOptions =
+  | {
+      get?: GetMonthlyBudgetOptions
+      list?: never
+    }
+  | {
+      get?: never
+      list: ListMonthlyBudgetOptions
+    }
 
-    if (get.error) {
+export function createMonthlyBudgetHandlers(options: CreateMonthlyBudgetHandlersOptions = {}) {
+  if (options.get !== undefined && options.list !== undefined) {
+    throw new Error("get and list monthly budget handler options cannot be used together")
+  }
+
+  const get = options.get ?? {}
+  const list = options.list
+
+  const getMonthlyBudgetHandler = http.get(REST_URL, async () => {
+    const handlerOptions = list ?? get
+
+    await delay(handlerOptions.durationOrMode)
+
+    if (handlerOptions.error) {
       return HttpResponse.json({ message: "Failed to fetch monthly budgets." }, { status: 500 })
     }
 
-    const response = get.response === undefined ? monthlyBudgets[2] : get.response
+    const response =
+      list === undefined
+        ? get.response === undefined
+          ? monthlyBudgets[2]
+          : get.response
+        : list.response === undefined
+          ? monthlyBudgets
+          : list.response
 
     return HttpResponse.json(response)
   })


### PR DESCRIPTION
## 関連Issue

- closes #1178

## 変更内容

- 予算管理ページとサイドバー導線を追加した
- 登録済み月予算の直近10件取得と一覧表示を追加した
- 一覧のローディング・エラー・空状態を扱う Storybook とテストを追加した

## 動作確認

- [x] task web:lint
- [x] task web:format-check
- [x] task web:typecheck
- [x] task web:test-unit
- [x] task web:test-storybook