### PR TITLE
デプロイワークフローをproduction向けに整理

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  deployments: write
 
 jobs:
   # --- Backend (Supabase) のデプロイ ---

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -39,9 +39,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Supabase CLI
-        uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1.6.0
+        uses: supabase/setup-cli@2eca1b4d35d9016e560c763c9159a350aa80c370 # v2
         with:
-          version: latest
+          version: 2.89.1
 
       - name: Link Supabase Project
         run: supabase link --project-ref ${{ secrets.SUPABASE_PROJECT_ID }}

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -1,12 +1,8 @@
-name: Deploy Services
+name: Deploy Production
 
 on:
   workflow_dispatch:
     inputs:
-      environment:
-        description: "Deployment environment"
-        type: environment
-        required: true
       skip_web:
         description: "Skip Web Deployment"
         type: boolean
@@ -25,7 +21,7 @@ jobs:
   deploy-api:
     if: ${{ github.event.inputs.skip_api != 'true' }} # skip_api が true の場合はこのジョブをスキップ
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: production
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       AUTH_SITE_URL: ${{ secrets.AUTH_SITE_URL }}
@@ -57,7 +53,7 @@ jobs:
     if: ${{ github.event.inputs.skip_web != 'true' && (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') }}
     needs: deploy-api
     runs-on: ubuntu-latest
-    environment: ${{ github.event.inputs.environment }}
+    environment: production
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -83,7 +79,7 @@ jobs:
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
           VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
-          VITE_SENTRY_ENVIRONMENT: ${{ github.event.inputs.environment }}
+          VITE_SENTRY_ENVIRONMENT: production
           VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
           VITE_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.VITE_SUPABASE_PUBLISHABLE_KEY }}
 

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -2,15 +2,6 @@ name: Deploy Production
 
 on:
   workflow_dispatch:
-    inputs:
-      skip_web:
-        description: "Skip Web Deployment"
-        type: boolean
-        default: false
-      skip_api:
-        description: "Skip API Deployment"
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -19,7 +10,6 @@ permissions:
 jobs:
   # --- Backend (Supabase) のデプロイ ---
   deploy-api:
-    if: ${{ github.event.inputs.skip_api != 'true' }} # skip_api が true の場合はこのジョブをスキップ
     runs-on: ubuntu-latest
     environment: production
     env:
@@ -50,7 +40,6 @@ jobs:
 
   # --- Frontend (React + Vite) のデプロイ ---
   deploy-web:
-    if: ${{ github.event.inputs.skip_web != 'true' && (needs.deploy-api.result == 'success' || needs.deploy-api.result == 'skipped') }}
     needs: deploy-api
     runs-on: ubuntu-latest
     environment: production

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -128,7 +128,7 @@ task dev
 task build
 ```
 
-Cloudflare Pages へデプロイする場合は、GitHub Actions (`deploy.yaml`) を参照してください。手動デプロイは Wrangler CLI を利用します。
+Cloudflare Pages へデプロイする場合は、GitHub Actions (`deploy_production.yaml`) を参照してください。手動デプロイは Wrangler CLI を利用します。
 
 ## 環境変数
 


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- production専用のデプロイワークフローとしてファイル名とworkflow名を整理
- GitHub Deployment作成用の権限を追加
- Supabase CLI setupをv2相当の指定SHAに固定し、CLI versionを2.89.1に固定
- production deployはAPIからWebの固定順で実行するように整理

## 動作確認

- [x] `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color .github/workflows/deploy_production.yaml`

## 補足

アプリケーションコード、build/type設定、DB migrationは変更していません。