### PR TITLE
Settingsページを追加して管理画面導線を切り出す

### DIFF
--- a/apps/web/src/app/AppLayout/AppLayout.test.tsx
+++ b/apps/web/src/app/AppLayout/AppLayout.test.tsx
@@ -19,13 +19,13 @@ function renderAppLayout(initialEntry = "/payments") {
       component: () => <div>Payments page</div>,
     })
 
-    const budgetsRoute = createRoute({
+    const settingsRoute = createRoute({
       getParentRoute: () => authenticatedRoute,
-      path: "/budgets",
-      component: () => <div>Budgets page</div>,
+      path: "/settings",
+      component: () => <div>Settings page</div>,
     })
 
-    return [authenticatedRoute.addChildren([paymentsRoute, budgetsRoute])]
+    return [authenticatedRoute.addChildren([paymentsRoute, settingsRoute])]
   })
 }
 
@@ -34,21 +34,21 @@ describe("AppLayout", () => {
     window.localStorage.clear()
   })
 
-  test("Sidebar に Payments と Budgets への導線を表示する", async () => {
+  test("Sidebar に Payments と Settings への導線を表示する", async () => {
     const { router, user } = renderAppLayout()
 
     expect(
       await screen.findByRole("link", { name: "Navigate to Payments page" }),
     ).toBeInTheDocument()
 
-    const budgetsLink = await screen.findByRole("link", { name: "Navigate to Budgets page" })
-    expect(budgetsLink).toHaveAttribute("href", "/budgets")
+    const settingsLink = await screen.findByRole("link", { name: "Navigate to Settings page" })
+    expect(settingsLink).toHaveAttribute("href", "/settings")
 
-    await user.click(budgetsLink)
+    await user.click(settingsLink)
 
     await waitFor(() => {
-      expect(router.state.location.pathname).toBe("/budgets")
+      expect(router.state.location.pathname).toBe("/settings")
     })
-    expect(await screen.findByText("Budgets page")).toBeInTheDocument()
+    expect(await screen.findByText("Settings page")).toBeInTheDocument()
   })
 })

--- a/apps/web/src/app/AppLayout/AppLayout.tsx
+++ b/apps/web/src/app/AppLayout/AppLayout.tsx
@@ -20,7 +20,7 @@ export function AppLayout() {
           label="Payments"
           onClick={closeSidebar}
         />
-        <Separator orientation="horizontal" size="4" />
+        <Separator orientation="horizontal" size="4" decorative />
         <SidebarButton
           to="/settings"
           ariaLabel="Navigate to Settings page"

--- a/apps/web/src/app/AppLayout/AppLayout.tsx
+++ b/apps/web/src/app/AppLayout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@radix-ui/themes"
+import { Flex, Separator } from "@radix-ui/themes"
 import { Outlet } from "@tanstack/react-router"
 
 import { Header } from "../Header"
@@ -20,10 +20,11 @@ export function AppLayout() {
           label="Payments"
           onClick={closeSidebar}
         />
+        <Separator orientation="horizontal" size="4" />
         <SidebarButton
-          to="/budgets"
-          ariaLabel="Navigate to Budgets page"
-          label="Budgets"
+          to="/settings"
+          ariaLabel="Navigate to Settings page"
+          label="Settings"
           onClick={closeSidebar}
         />
       </Sidebar>

--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -14,6 +14,7 @@ import { AuthPage } from "./routes/AuthPage"
 import { BudgetsPage } from "./routes/BudgetsPage"
 import { ErrorPage } from "./routes/ErrorPage"
 import { PaymentsPage } from "./routes/PaymentsPage"
+import { SettingsPage } from "./routes/SettingsPage"
 import { TopPage } from "./routes/TopPage"
 
 export interface RouterContext {
@@ -72,6 +73,12 @@ const aggregatesRoute = createRoute({
   component: AggregatesPage,
 })
 
+const settingsRoute = createRoute({
+  getParentRoute: () => authenticatedRoute,
+  path: "/settings",
+  component: SettingsPage,
+})
+
 const budgetsRoute = createRoute({
   getParentRoute: () => authenticatedRoute,
   path: "/budgets",
@@ -81,7 +88,7 @@ const budgetsRoute = createRoute({
 const routeTree = rootRoute.addChildren([
   indexRoute,
   authRoute,
-  authenticatedRoute.addChildren([paymentsRoute, aggregatesRoute, budgetsRoute]),
+  authenticatedRoute.addChildren([paymentsRoute, aggregatesRoute, settingsRoute, budgetsRoute]),
 ])
 
 export const router = createRouter({

--- a/apps/web/src/app/routes/SettingsPage/SettingsPage.stories.tsx
+++ b/apps/web/src/app/routes/SettingsPage/SettingsPage.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { expect, within } from "storybook/test"
+
+import { createStoryRouter } from "../../../test/helpers/routerDecorator"
+import { SettingsPage } from "./SettingsPage"
+
+const meta = {
+  title: "Pages/SettingsPage",
+  component: SettingsPage,
+  decorators: [createStoryRouter("/settings")],
+  tags: ["autodocs", "browser-test"],
+} satisfies Meta<typeof SettingsPage>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    expect(await canvas.findByRole("heading", { name: "Settings" })).toBeInTheDocument()
+  },
+}

--- a/apps/web/src/app/routes/SettingsPage/SettingsPage.test.tsx
+++ b/apps/web/src/app/routes/SettingsPage/SettingsPage.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "vitest"
+
+import { render, screen } from "../../../test/test-utils"
+import { SettingsPage } from "./SettingsPage"
+
+describe("SettingsPage", () => {
+  test("Settings 見出しを表示する", () => {
+    render(<SettingsPage />)
+
+    expect(screen.getByRole("heading", { name: "Settings" })).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/app/routes/SettingsPage/SettingsPage.tsx
+++ b/apps/web/src/app/routes/SettingsPage/SettingsPage.tsx
@@ -1,0 +1,13 @@
+import { Container, Flex, Heading } from "@radix-ui/themes"
+
+export function SettingsPage() {
+  return (
+    <Container size="4">
+      <Flex direction="column" gap="4">
+        <Heading as="h1" size="6">
+          Settings
+        </Heading>
+      </Flex>
+    </Container>
+  )
+}

--- a/apps/web/src/app/routes/SettingsPage/index.ts
+++ b/apps/web/src/app/routes/SettingsPage/index.ts
@@ -1,0 +1,1 @@
+export * from "./SettingsPage"


### PR DESCRIPTION
## 関連Issue

- #1190

## 変更内容

- サイドバーの `Budgets` 導線を `Settings` に差し替え
- `/settings` ルートと最小の `SettingsPage` を追加
- `SettingsPage` の unit test と page story を追加

## 動作確認

- [x] ローカルでの動作確認
- [x] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

- Issue #1190 の完了条件はまだ満たしていないため、管理画面の中身は最小構成です
