### PR TITLE
カテゴリ別予算のDBスキーマを追加する

### DIFF
--- a/apps/api/supabase/migrations/20260425022905_create_category_budgets_table.sql
+++ b/apps/api/supabase/migrations/20260425022905_create_category_budgets_table.sql
@@ -1,0 +1,43 @@
+create table category_budgets (
+    id bigint generated always as identity primary key,
+    category_id bigint not null references categories(id) on delete restrict,
+    effective_from date not null,
+    effective_year integer generated always as (extract(year from effective_from)::integer) stored not null,
+    effective_month integer generated always as (extract(month from effective_from)::integer) stored not null,
+    amount numeric(10, 2) not null,
+    created_at timestamp with time zone default current_timestamp,
+    updated_at timestamp with time zone default current_timestamp,
+
+    user_id bigint not null default get_authenticated_user_id() references users(id) on delete cascade,
+
+    constraint category_budgets_user_category_effective_year_month_key
+        unique (user_id, category_id, effective_year, effective_month)
+);
+
+create index idx_category_budgets_user_category_effective_from
+    on category_budgets (user_id, category_id, effective_from desc);
+
+alter table category_budgets enable row level security;
+
+create policy "Users can read own category budgets"
+  on category_budgets for select
+  to authenticated
+  using (user_id in (select id from users where external_id = auth.uid()::text));
+
+create policy "Users can insert own category budgets"
+  on category_budgets for insert
+  to authenticated
+  with check (user_id in (select id from users where external_id = auth.uid()::text));
+
+create or replace function set_category_budget_user_id()
+returns trigger as $$
+begin
+  new.user_id := get_authenticated_user_id();
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_set_category_budget_user_id
+  before insert on category_budgets
+  for each row
+  execute function set_category_budget_user_id();

--- a/apps/web/src/types/database.types.ts
+++ b/apps/web/src/types/database.types.ts
@@ -49,6 +49,57 @@ export type Database = {
         }
         Relationships: []
       }
+      category_budgets: {
+        Row: {
+          amount: number
+          category_id: number
+          created_at: string | null
+          effective_from: string
+          effective_month: number
+          effective_year: number
+          id: number
+          updated_at: string | null
+          user_id: number
+        }
+        Insert: {
+          amount: number
+          category_id: number
+          created_at?: string | null
+          effective_from: string
+          effective_month?: number
+          effective_year?: number
+          id?: never
+          updated_at?: string | null
+          user_id?: number
+        }
+        Update: {
+          amount?: number
+          category_id?: number
+          created_at?: string | null
+          effective_from?: string
+          effective_month?: number
+          effective_year?: number
+          id?: never
+          updated_at?: string | null
+          user_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "category_budgets_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "category_budgets_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       monthly_budgets: {
         Row: {
           amount: number


### PR DESCRIPTION
## 関連Issue

- closes #1195

## 変更内容

- カテゴリ別予算を履歴形式で保存する `category_budgets` テーブルの migration を追加
- カテゴリ参照、ユーザー紐づけ、RLS、insert 時の user_id 設定 trigger を追加
- Supabase 型定義に `category_budgets` を反映

## 動作確認

- [x] `task web:lint`
- [x] `task web:format-check`
- [x] `task web:typecheck`
- [x] `task web:test-unit`
- [x] `task web:test-storybook`
- [x] `task api:up:migrations`

## 補足

