### PR TITLE
Frontend CI を高速化する

### DIFF
--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Install deps and build
         run: |
           pnpm install --frozen-lockfile
-          pnpm --dir apps/web build
+          pnpm --filter web build
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}

--- a/.github/workflows/frontend_ci.yaml
+++ b/.github/workflows/frontend_ci.yaml
@@ -58,7 +58,11 @@ jobs:
         run: pnpm --dir apps/web typecheck
 
   unit-test:
+    name: unit-test (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: ["1/2", "2/2"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -78,7 +82,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Unit and integration tests
-        run: pnpm --dir apps/web test:unit --reporter=dot --silent
+        run: pnpm --dir apps/web test:unit --shard=${{ matrix.shard }} --reporter=dot --silent
         env:
           VITE_SUPABASE_PUBLISHABLE_KEY: test-dummy-key
 

--- a/.github/workflows/frontend_ci.yaml
+++ b/.github/workflows/frontend_ci.yaml
@@ -6,8 +6,9 @@ on:
       - ".github/workflows/frontend_ci.yaml"
       - "apps/web/**"
     types: [opened, synchronize]
+
 jobs:
-  check:
+  lint-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -33,17 +34,80 @@ jobs:
       - name: Oxc format check
         run: pnpm --dir apps/web format --check
 
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm --dir apps/web typecheck
+
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Unit and integration tests
+        run: pnpm --dir apps/web test:unit -- --reporter=dot --silent
+        env:
+          VITE_SUPABASE_PUBLISHABLE_KEY: test-dummy-key
+
+  storybook-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@078e9d416474b29c0c387560859308974f7e9c53 # v6.0.1
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: "package.json"
+          cache: "pnpm"
+          cache-dependency-path: "pnpm-lock.yaml"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Setup Playwright (with cache)
         uses: ./.github/actions/setup-playwright
         with:
           project-directory: apps/web
 
-      - name: Test
-        run: pnpm --dir apps/web test -- --reporter=dot --silent
-        env:
-          VITE_SUPABASE_PUBLISHABLE_KEY: test-dummy-key
-
-      - name: Build
-        run: pnpm --dir apps/web build
+      - name: Storybook browser tests
+        run: pnpm --dir apps/web test:storybook -- --reporter=dot --silent
         env:
           VITE_SUPABASE_PUBLISHABLE_KEY: test-dummy-key

--- a/.github/workflows/frontend_ci.yaml
+++ b/.github/workflows/frontend_ci.yaml
@@ -78,7 +78,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Unit and integration tests
-        run: pnpm --dir apps/web test:unit -- --reporter=dot --silent
+        run: pnpm --dir apps/web test:unit --reporter=dot --silent
         env:
           VITE_SUPABASE_PUBLISHABLE_KEY: test-dummy-key
 
@@ -108,6 +108,6 @@ jobs:
           project-directory: apps/web
 
       - name: Storybook browser tests
-        run: pnpm --dir apps/web test:storybook -- --reporter=dot --silent
+        run: pnpm --dir apps/web test:storybook --reporter=dot --silent
         env:
           VITE_SUPABASE_PUBLISHABLE_KEY: test-dummy-key

--- a/.github/workflows/frontend_ci.yaml
+++ b/.github/workflows/frontend_ci.yaml
@@ -29,10 +29,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Oxc lint
-        run: pnpm --dir apps/web lint --deny-warnings
+        run: pnpm --filter web lint --deny-warnings
 
       - name: Oxc format check
-        run: pnpm --dir apps/web format --check
+        run: pnpm --filter web format --check
 
   typecheck:
     runs-on: ubuntu-latest
@@ -55,7 +55,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Typecheck
-        run: pnpm --dir apps/web typecheck
+        run: pnpm --filter web typecheck
 
   unit-test:
     name: unit-test (${{ matrix.shard }})
@@ -82,7 +82,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Unit and integration tests
-        run: pnpm --dir apps/web test:unit --shard=${{ matrix.shard }} --reporter=dot --silent
+        run: pnpm --filter web test:unit --shard=${{ matrix.shard }} --reporter=dot --silent
         env:
           VITE_SUPABASE_PUBLISHABLE_KEY: test-dummy-key
 
@@ -112,6 +112,6 @@ jobs:
           project-directory: apps/web
 
       - name: Storybook browser tests
-        run: pnpm --dir apps/web test:storybook --reporter=dot --silent
+        run: pnpm --filter web test:storybook --reporter=dot --silent
         env:
           VITE_SUPABASE_PUBLISHABLE_KEY: test-dummy-key

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "savings",
+  "name": "web",
   "version": "0.0.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## 関連Issue

- closes #1230

## 変更内容

- Frontend CIをlint/format、typecheck、unit test、storybook testの並列ジョブに分割
- buildの代わりにtypecheckを実行
- Playwright setupをstorybook testジョブだけに限定

## 動作確認

- [x] `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color .github/workflows/frontend_ci.yaml`
- [x] `git diff --check`

## 補足

- 必須チェックが旧`check`ジョブ名に依存している場合は、GitHub側のbranch protection更新が必要です。
