### PR TITLE
設定画面に予算設定導線を追加

### DIFF
--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -11,7 +11,6 @@ import type { AuthStatus } from "../providers/supabase/SupabaseSessionProvider"
 import { AppLayout } from "./AppLayout"
 import { AggregatesPage } from "./routes/AggregatesPage"
 import { AuthPage } from "./routes/AuthPage"
-import { BudgetsPage } from "./routes/BudgetsPage"
 import { ErrorPage } from "./routes/ErrorPage"
 import { PaymentsPage } from "./routes/PaymentsPage"
 import { SettingsPage } from "./routes/SettingsPage"
@@ -79,16 +78,30 @@ const settingsRoute = createRoute({
   component: SettingsPage,
 })
 
+const settingsBudgetsRoute = createRoute({
+  getParentRoute: () => authenticatedRoute,
+  path: "/settings/budgets",
+  component: SettingsPage,
+})
+
 const budgetsRoute = createRoute({
   getParentRoute: () => authenticatedRoute,
   path: "/budgets",
-  component: BudgetsPage,
+  beforeLoad: () => {
+    throw redirect({ to: "/settings/budgets" })
+  },
 })
 
 const routeTree = rootRoute.addChildren([
   indexRoute,
   authRoute,
-  authenticatedRoute.addChildren([paymentsRoute, aggregatesRoute, settingsRoute, budgetsRoute]),
+  authenticatedRoute.addChildren([
+    paymentsRoute,
+    aggregatesRoute,
+    settingsRoute,
+    settingsBudgetsRoute,
+    budgetsRoute,
+  ]),
 ])
 
 export const router = createRouter({

--- a/apps/web/src/app/routes/SettingsPage/SettingsPage.module.css
+++ b/apps/web/src/app/routes/SettingsPage/SettingsPage.module.css
@@ -1,0 +1,16 @@
+.menu-link {
+  width: 100%;
+  cursor: pointer;
+  text-decoration: none;
+
+  justify-content: flex-start;
+}
+
+.heading-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.heading-link:hover {
+  text-decoration: underline;
+}

--- a/apps/web/src/app/routes/SettingsPage/SettingsPage.stories.tsx
+++ b/apps/web/src/app/routes/SettingsPage/SettingsPage.stories.tsx
@@ -19,5 +19,10 @@ export const Default: Story = {
     const canvas = within(canvasElement)
 
     expect(await canvas.findByRole("heading", { name: "Settings" })).toBeInTheDocument()
+    expect(canvas.getByRole("link", { name: "Settings" })).toHaveAttribute("href", "/settings")
+    expect(canvas.getByRole("link", { name: "Budgets" })).toHaveAttribute(
+      "href",
+      "/settings/budgets",
+    )
   },
 }

--- a/apps/web/src/app/routes/SettingsPage/SettingsPage.test.tsx
+++ b/apps/web/src/app/routes/SettingsPage/SettingsPage.test.tsx
@@ -1,12 +1,73 @@
+import { createRoute, redirect } from "@tanstack/react-router"
 import { describe, expect, test } from "vite-plus/test"
 
-import { render, screen } from "../../../test/test-utils"
+import { renderWithRouter } from "../../../test/helpers/renderWithRouter"
+import { screen, waitFor } from "../../../test/test-utils"
 import { SettingsPage } from "./SettingsPage"
 
-describe("SettingsPage", () => {
-  test("Settings 見出しを表示する", () => {
-    render(<SettingsPage />)
+function renderSettingsPage(initialEntry = "/settings") {
+  return renderWithRouter(initialEntry, (root) => {
+    const authenticatedRoute = createRoute({
+      getParentRoute: () => root,
+      id: "authenticated",
+    })
 
-    expect(screen.getByRole("heading", { name: "Settings" })).toBeInTheDocument()
+    const settingsRoute = createRoute({
+      getParentRoute: () => authenticatedRoute,
+      path: "/settings",
+      component: SettingsPage,
+    })
+
+    const settingsBudgetsRoute = createRoute({
+      getParentRoute: () => authenticatedRoute,
+      path: "/settings/budgets",
+      component: SettingsPage,
+    })
+
+    const legacyBudgetsRoute = createRoute({
+      getParentRoute: () => authenticatedRoute,
+      path: "/budgets",
+      beforeLoad: () => {
+        throw redirect({ to: "/settings/budgets" })
+      },
+    })
+
+    return [
+      authenticatedRoute.addChildren([settingsRoute, settingsBudgetsRoute, legacyBudgetsRoute]),
+    ]
+  })
+}
+
+describe("SettingsPage", () => {
+  test("Settings 見出しと Budgets への導線を表示する", async () => {
+    renderSettingsPage()
+
+    expect(await screen.findByRole("heading", { name: "Settings" })).toBeInTheDocument()
+
+    const settingsLink = await screen.findByRole("link", { name: "Settings" })
+    expect(settingsLink).toHaveAttribute("href", "/settings")
+
+    const budgetsLink = await screen.findByRole("link", { name: "Budgets" })
+    expect(budgetsLink).toHaveAttribute("href", "/settings/budgets")
+  })
+
+  test("Budgets 導線から予算設定へ遷移する", async () => {
+    const { router, user } = renderSettingsPage()
+
+    await user.click(await screen.findByRole("link", { name: "Budgets" }))
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/settings/budgets")
+    })
+    expect(await screen.findByRole("heading", { name: "Settings" })).toBeInTheDocument()
+  })
+
+  test("/budgets から予算設定へ到達できる", async () => {
+    const { router } = renderSettingsPage("/budgets")
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/settings/budgets")
+    })
+    expect(await screen.findByRole("heading", { name: "Settings" })).toBeInTheDocument()
   })
 })

--- a/apps/web/src/app/routes/SettingsPage/SettingsPage.tsx
+++ b/apps/web/src/app/routes/SettingsPage/SettingsPage.tsx
@@ -1,12 +1,37 @@
-import { Container, Flex, Heading } from "@radix-ui/themes"
+import { Box, Button, Container, Flex, Grid, Heading, Section, Separator } from "@radix-ui/themes"
+import { Link } from "@tanstack/react-router"
+
+import styles from "./SettingsPage.module.css"
 
 export function SettingsPage() {
   return (
     <Container size="4">
       <Flex direction="column" gap="4">
         <Heading as="h1" size="6">
-          Settings
+          <Link to="/settings" className={styles.headingLink}>
+            Settings
+          </Link>
         </Heading>
+        <Grid
+          columns={{ initial: "1", sm: "minmax(160px, 220px) auto minmax(0, 1fr)" }}
+          gap="4"
+          align="stretch"
+          minHeight="calc(100vh - 9rem)"
+        >
+          <nav aria-label="Settings sections">
+            <Flex direction="column" gap="2" align="stretch">
+              <Button asChild variant="ghost" size="3">
+                <Link to="/settings/budgets" className={styles.menuLink}>
+                  Budgets
+                </Link>
+              </Button>
+            </Flex>
+          </nav>
+          <Box display={{ initial: "none", sm: "block" }}>
+            <Separator decorative orientation="vertical" size="4" />
+          </Box>
+          <Section size="1" minWidth="0" />
+        </Grid>
       </Flex>
     </Container>
   )


### PR DESCRIPTION
## 関連Issue

- closes #1190

## 変更内容

- Settings画面にBudgetsへの導線を追加
- /settings/budgets ルートを追加し、既存 /budgets からredirect
- SettingsPageの導線テストとPage storyを更新

## 動作確認

- [x] task web:lint
- [x] task web:format-check
- [x] task web:typecheck
- [x] task web:test-unit
- [x] task web:test-storybook