### PR TITLE
カテゴリ別予算の一覧取得ロジックを追加する

### DIFF
--- a/apps/web/src/features/budgets/categoryBudgetMappers.ts
+++ b/apps/web/src/features/budgets/categoryBudgetMappers.ts
@@ -1,0 +1,74 @@
+import * as z from "zod"
+
+import type { CategoryBudget } from "./types"
+import { parseIsoDateOnlyToLocalDate } from "./utils/month"
+
+const categoryBudgetRowSchema = z.object({
+  id: z.number(),
+  category_id: z.number(),
+  amount: z.number(),
+  effective_from: z.string(),
+  effective_year: z.number(),
+  effective_month: z.number(),
+  user_id: z.number(),
+  created_at: z.string().nullable(),
+  updated_at: z.string().nullable(),
+  category: z.object({
+    id: z.number(),
+    name: z.string(),
+  }),
+})
+
+type NormalizedCategoryBudgetRow = z.infer<typeof categoryBudgetRowSchema>
+
+export function normalizeCategoryBudgetRows(value: unknown): NormalizedCategoryBudgetRow[] {
+  const result = z.array(categoryBudgetRowSchema).safeParse(value)
+
+  if (!result.success) {
+    throw new Error("Invalid category budget response")
+  }
+
+  return result.data
+}
+
+export function toCategoryBudget(row: NormalizedCategoryBudgetRow): CategoryBudget {
+  return {
+    id: row.id,
+    categoryId: row.category_id,
+    categoryName: row.category.name,
+    amount: row.amount,
+    effectiveFrom: parseIsoDateOnlyToLocalDate(row.effective_from),
+    effectiveYear: row.effective_year,
+    effectiveMonth: row.effective_month,
+    userId: row.user_id,
+    createdDate: row.created_at ? new Date(row.created_at) : new Date(),
+    updatedDate: row.updated_at ? new Date(row.updated_at) : new Date(),
+  }
+}
+
+export function pickLatestCategoryBudgetRows(
+  rows: NormalizedCategoryBudgetRow[],
+): NormalizedCategoryBudgetRow[] {
+  const latestRows = new Map<number, NormalizedCategoryBudgetRow>()
+
+  for (const row of rows) {
+    const current = latestRows.get(row.category_id)
+
+    if (!current || isNewerCategoryBudgetRow(row, current)) {
+      latestRows.set(row.category_id, row)
+    }
+  }
+
+  return Array.from(latestRows.values())
+}
+
+function isNewerCategoryBudgetRow(
+  candidate: NormalizedCategoryBudgetRow,
+  current: NormalizedCategoryBudgetRow,
+): boolean {
+  if (candidate.effective_from !== current.effective_from) {
+    return candidate.effective_from > current.effective_from
+  }
+
+  return candidate.id > current.id
+}

--- a/apps/web/src/features/budgets/listCategoryBudget/fetchCategoryBudgets.test.ts
+++ b/apps/web/src/features/budgets/listCategoryBudget/fetchCategoryBudgets.test.ts
@@ -62,11 +62,11 @@ const dailyNecessitiesFutureBudget = {
   id: 4,
   amount: 12000,
   category_id: 20,
-  created_at: "2026-04-01T00:00:00.000Z",
-  effective_from: "2026-04-01",
+  created_at: "2099-04-01T00:00:00.000Z",
+  effective_from: "2099-04-01",
   effective_month: 4,
-  effective_year: 2026,
-  updated_at: "2026-04-01T00:00:00.000Z",
+  effective_year: 2099,
+  updated_at: "2099-04-01T00:00:00.000Z",
   user_id: 100,
   category: {
     id: 20,
@@ -132,7 +132,7 @@ describe("fetchCategoryBudgets", () => {
     expect(budgets[0]).toMatchObject({
       id: 4,
       categoryId: 20,
-      effectiveYear: 2026,
+      effectiveYear: 2099,
       effectiveMonth: 4,
     })
   })

--- a/apps/web/src/features/budgets/listCategoryBudget/fetchCategoryBudgets.test.ts
+++ b/apps/web/src/features/budgets/listCategoryBudget/fetchCategoryBudgets.test.ts
@@ -1,0 +1,228 @@
+import { HttpResponse, http } from "msw"
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { createCategoryBudgetHandlers } from "../../../test/msw/handlers/categoryBudgets"
+import { server } from "../../../test/msw/server"
+import { supabaseTestClient } from "../../../test/utils/createSupabaseTestClient"
+import { fetchCategoryBudgets } from "./fetchCategoryBudgets"
+
+vi.mock("../../../lib/supabase", () => ({
+  getSupabaseClient: () => supabaseTestClient,
+}))
+
+const foodBudgetOld = {
+  id: 1,
+  amount: 30000,
+  category_id: 10,
+  created_at: "2025-01-01T00:00:00.000Z",
+  effective_from: "2025-01-01",
+  effective_month: 1,
+  effective_year: 2025,
+  updated_at: "2025-01-01T00:00:00.000Z",
+  user_id: 100,
+  category: {
+    id: 10,
+    name: "Food",
+  },
+}
+
+const foodBudgetLatestSameDay = {
+  id: 3,
+  amount: 50000,
+  category_id: 10,
+  created_at: "2025-03-02T00:00:00.000Z",
+  effective_from: "2025-03-01",
+  effective_month: 3,
+  effective_year: 2025,
+  updated_at: "2025-03-02T00:00:00.000Z",
+  user_id: 100,
+  category: {
+    id: 10,
+    name: "Food",
+  },
+}
+
+const foodBudgetOlderSameDay = {
+  id: 2,
+  amount: 45000,
+  category_id: 10,
+  created_at: "2025-03-01T00:00:00.000Z",
+  effective_from: "2025-03-01",
+  effective_month: 3,
+  effective_year: 2025,
+  updated_at: "2025-03-01T00:00:00.000Z",
+  user_id: 100,
+  category: {
+    id: 10,
+    name: "Food",
+  },
+}
+
+const dailyNecessitiesFutureBudget = {
+  id: 4,
+  amount: 12000,
+  category_id: 20,
+  created_at: "2026-04-01T00:00:00.000Z",
+  effective_from: "2026-04-01",
+  effective_month: 4,
+  effective_year: 2026,
+  updated_at: "2026-04-01T00:00:00.000Z",
+  user_id: 100,
+  category: {
+    id: 20,
+    name: "Daily Necessities",
+  },
+}
+
+describe("fetchCategoryBudgets", () => {
+  beforeEach(() => {
+    server.resetHandlers(...createCategoryBudgetHandlers())
+  })
+
+  it("カテゴリ別予算一覧を取得してカテゴリ名つきの domain model に変換する", async () => {
+    server.resetHandlers(
+      ...createCategoryBudgetHandlers({
+        get: {
+          response: [foodBudgetLatestSameDay, dailyNecessitiesFutureBudget],
+        },
+      }),
+    )
+
+    const budgets = await fetchCategoryBudgets()
+
+    expect(budgets).toHaveLength(2)
+    expect(budgets[0]).toMatchObject({
+      id: 3,
+      amount: 50000,
+      categoryId: 10,
+      categoryName: "Food",
+      effectiveYear: 2025,
+      effectiveMonth: 3,
+      userId: 100,
+    })
+    expect(budgets[0]?.effectiveFrom).toEqual(new Date(2025, 2, 1))
+    expect(budgets[0]?.createdDate).toBeInstanceOf(Date)
+    expect(budgets[0]?.updatedDate).toBeInstanceOf(Date)
+  })
+
+  it("登録済みカテゴリ別予算がない場合は空配列を返す", async () => {
+    server.resetHandlers(
+      ...createCategoryBudgetHandlers({
+        get: {
+          response: [],
+        },
+      }),
+    )
+
+    await expect(fetchCategoryBudgets()).resolves.toEqual([])
+  })
+
+  it("未来日付のカテゴリ別予算も取得対象に含める", async () => {
+    server.resetHandlers(
+      ...createCategoryBudgetHandlers({
+        get: {
+          response: [dailyNecessitiesFutureBudget],
+        },
+      }),
+    )
+
+    const budgets = await fetchCategoryBudgets()
+
+    expect(budgets).toHaveLength(1)
+    expect(budgets[0]).toMatchObject({
+      id: 4,
+      categoryId: 20,
+      effectiveYear: 2026,
+      effectiveMonth: 4,
+    })
+  })
+
+  it("同じカテゴリに複数予算がある場合は最新の1件だけを返す", async () => {
+    server.resetHandlers(
+      ...createCategoryBudgetHandlers({
+        get: {
+          response: [
+            foodBudgetOld,
+            foodBudgetOlderSameDay,
+            foodBudgetLatestSameDay,
+            dailyNecessitiesFutureBudget,
+          ],
+        },
+      }),
+    )
+
+    const budgets = await fetchCategoryBudgets()
+
+    expect(budgets).toHaveLength(2)
+    expect(budgets.find((budget) => budget.categoryId === 10)?.id).toBe(3)
+    expect(budgets.find((budget) => budget.categoryId === 20)?.id).toBe(4)
+  })
+
+  it("カテゴリ別予算とカテゴリ名を取得する query を送る", async () => {
+    const requestCapture: { url: URL | null } = { url: null }
+
+    server.use(
+      http.get("*/rest/v1/category_budgets*", ({ request }) => {
+        requestCapture.url = new URL(request.url)
+
+        return HttpResponse.json([foodBudgetLatestSameDay])
+      }),
+    )
+
+    await fetchCategoryBudgets()
+
+    const select = requestCapture.url?.searchParams.get("select")
+    expect(select).toContain("id")
+    expect(select).toContain("category_id")
+    expect(select).toContain("amount")
+    expect(select).toContain("effective_from")
+    expect(select).toContain("effective_year")
+    expect(select).toContain("effective_month")
+    expect(select).toContain("user_id")
+    expect(select).toContain("created_at")
+    expect(select).toContain("updated_at")
+    expect(select).toContain("category:categories!category_budgets_category_id_fkey")
+    expect(requestCapture.url?.searchParams.get("order")).toBe(
+      "category_id.asc,effective_from.desc,id.desc",
+    )
+    expect(requestCapture.url?.searchParams.has("effective_from")).toBe(false)
+  })
+
+  it("Supabase がエラーを返した場合に throw する", async () => {
+    server.resetHandlers(
+      ...createCategoryBudgetHandlers({
+        get: {
+          error: true,
+        },
+      }),
+    )
+
+    await expect(fetchCategoryBudgets()).rejects.toThrow("Failed to fetch category budgets.")
+  })
+
+  it("レスポンス shape が不正ならエラーにする", async () => {
+    server.use(
+      http.get("*/rest/v1/category_budgets*", () => {
+        return HttpResponse.json([
+          {
+            id: "invalid",
+            amount: 50000,
+            category_id: 10,
+            effective_from: "2025-03-01",
+            effective_year: 2025,
+            effective_month: 3,
+            user_id: 100,
+            created_at: "2025-03-02T00:00:00.000Z",
+            updated_at: "2025-03-02T00:00:00.000Z",
+            category: {
+              id: 10,
+              name: "Food",
+            },
+          },
+        ])
+      }),
+    )
+
+    await expect(fetchCategoryBudgets()).rejects.toThrow("Invalid category budget response")
+  })
+})

--- a/apps/web/src/features/budgets/listCategoryBudget/fetchCategoryBudgets.ts
+++ b/apps/web/src/features/budgets/listCategoryBudget/fetchCategoryBudgets.ts
@@ -1,0 +1,39 @@
+import { getSupabaseClient } from "../../../lib/supabase"
+import {
+  normalizeCategoryBudgetRows,
+  pickLatestCategoryBudgetRows,
+  toCategoryBudget,
+} from "../categoryBudgetMappers"
+import type { CategoryBudget } from "../types"
+
+const categoryBudgetColumns = `
+  id,
+  category_id,
+  amount,
+  effective_from,
+  effective_year,
+  effective_month,
+  user_id,
+  created_at,
+  updated_at,
+  category:categories!category_budgets_category_id_fkey (
+    id,
+    name
+  )
+`
+
+export async function fetchCategoryBudgets(): Promise<CategoryBudget[]> {
+  const supabase = getSupabaseClient()
+  const { data, error } = await supabase
+    .from("category_budgets")
+    .select(categoryBudgetColumns)
+    .order("category_id", { ascending: true })
+    .order("effective_from", { ascending: false })
+    .order("id", { ascending: false })
+
+  if (error) {
+    throw error
+  }
+
+  return pickLatestCategoryBudgetRows(normalizeCategoryBudgetRows(data ?? [])).map(toCategoryBudget)
+}

--- a/apps/web/src/features/budgets/listCategoryBudget/index.ts
+++ b/apps/web/src/features/budgets/listCategoryBudget/index.ts
@@ -1,0 +1,2 @@
+export * from "./fetchCategoryBudgets"
+export * from "./useCategoryBudgets"

--- a/apps/web/src/features/budgets/listCategoryBudget/useCategoryBudgets.test.tsx
+++ b/apps/web/src/features/budgets/listCategoryBudget/useCategoryBudgets.test.tsx
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { renderHook, waitFor } from "../../../test/test-utils"
+import type { CategoryBudget } from "../types"
+import { useCategoryBudgets } from "./useCategoryBudgets"
+
+const { mockFetchCategoryBudgets } = vi.hoisted(() => ({
+  mockFetchCategoryBudgets: vi.fn(),
+}))
+
+vi.mock("./fetchCategoryBudgets", () => ({
+  fetchCategoryBudgets: mockFetchCategoryBudgets,
+}))
+
+function buildCategoryBudget(id: number): CategoryBudget {
+  return {
+    id,
+    amount: 50000 + id,
+    categoryId: 10 + id,
+    categoryName: `Category ${id}`,
+    effectiveFrom: new Date(2025, id, 1),
+    effectiveYear: 2025,
+    effectiveMonth: id + 1,
+    userId: 100,
+    createdDate: new Date("2025-01-01T00:00:00.000Z"),
+    updatedDate: new Date("2025-01-01T00:00:00.000Z"),
+  }
+}
+
+describe("useCategoryBudgets", () => {
+  beforeEach(() => {
+    mockFetchCategoryBudgets.mockReset()
+  })
+
+  it("カテゴリ別予算一覧を取得する", async () => {
+    const budgets = [buildCategoryBudget(1), buildCategoryBudget(2)]
+    mockFetchCategoryBudgets.mockResolvedValue(budgets)
+
+    const { result } = renderHook(() => useCategoryBudgets())
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(budgets)
+    })
+    expect(mockFetchCategoryBudgets).toHaveBeenCalledTimes(1)
+    expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  it("取得に失敗した場合は error を返す", async () => {
+    const error = new Error("failed")
+    mockFetchCategoryBudgets.mockRejectedValue(error)
+
+    const { result } = renderHook(() => useCategoryBudgets())
+
+    await waitFor(
+      () => {
+        expect(result.current.error).toBe(error)
+      },
+      { timeout: 3000 },
+    )
+    expect(result.current.data).toEqual([])
+    expect(result.current.loading).toBe(false)
+  })
+})

--- a/apps/web/src/features/budgets/listCategoryBudget/useCategoryBudgets.ts
+++ b/apps/web/src/features/budgets/listCategoryBudget/useCategoryBudgets.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query"
+
+import type { CategoryBudget } from "../types"
+import { fetchCategoryBudgets } from "./fetchCategoryBudgets"
+
+interface UseCategoryBudgetsReturn {
+  data: CategoryBudget[]
+  loading: boolean
+  error: Error | null
+  promise: Promise<CategoryBudget[]>
+}
+
+export function useCategoryBudgets(): UseCategoryBudgetsReturn {
+  const query = useQuery({
+    queryKey: ["categoryBudgets"],
+    queryFn: async () => fetchCategoryBudgets(),
+    staleTime: 3000, // 3秒
+  })
+
+  return {
+    data: query.data ?? [],
+    loading: query.isLoading,
+    error: query.error,
+    promise: query.promise,
+  }
+}

--- a/apps/web/src/features/budgets/types/index.ts
+++ b/apps/web/src/features/budgets/types/index.ts
@@ -1,9 +1,23 @@
 import type { Tables } from "../../../types/database.types"
 
 export type MonthlyBudgetRow = Tables<"monthly_budgets">
+export type CategoryBudgetRow = Tables<"category_budgets">
 
 export interface MonthlyBudget {
   id: number
+  amount: number
+  effectiveFrom: Date
+  effectiveYear: number
+  effectiveMonth: number
+  userId: number
+  createdDate: Date
+  updatedDate: Date
+}
+
+export interface CategoryBudget {
+  id: number
+  categoryId: number
+  categoryName: string
   amount: number
   effectiveFrom: Date
   effectiveYear: number

--- a/apps/web/src/test/data/categoryBudgets.ts
+++ b/apps/web/src/test/data/categoryBudgets.ts
@@ -1,0 +1,48 @@
+import type { CategoryBudgetRow } from "../../features/budgets/types"
+
+export const categoryBudgets: CategoryBudgetRow[] = [
+  {
+    id: 1,
+    amount: 30000,
+    category_id: 10,
+    created_at: "2025-01-01T00:00:00.000Z",
+    effective_from: "2025-01-01",
+    effective_month: 1,
+    effective_year: 2025,
+    updated_at: "2025-01-01T00:00:00.000Z",
+    user_id: 100,
+  },
+  {
+    id: 2,
+    amount: 45000,
+    category_id: 10,
+    created_at: "2025-03-01T00:00:00.000Z",
+    effective_from: "2025-03-01",
+    effective_month: 3,
+    effective_year: 2025,
+    updated_at: "2025-03-01T00:00:00.000Z",
+    user_id: 100,
+  },
+  {
+    id: 3,
+    amount: 50000,
+    category_id: 10,
+    created_at: "2025-03-02T00:00:00.000Z",
+    effective_from: "2025-03-01",
+    effective_month: 3,
+    effective_year: 2025,
+    updated_at: "2025-03-02T00:00:00.000Z",
+    user_id: 100,
+  },
+  {
+    id: 4,
+    amount: 12000,
+    category_id: 20,
+    created_at: "2026-04-01T00:00:00.000Z",
+    effective_from: "2026-04-01",
+    effective_month: 4,
+    effective_year: 2026,
+    updated_at: "2026-04-01T00:00:00.000Z",
+    user_id: 100,
+  },
+]

--- a/apps/web/src/test/msw/handlers/categoryBudgets.ts
+++ b/apps/web/src/test/msw/handlers/categoryBudgets.ts
@@ -1,0 +1,54 @@
+import { type DelayMode, HttpResponse, delay, http } from "msw"
+
+import type { CategoryBudgetRow } from "../../../features/budgets/types"
+import { categories } from "../../data/categories"
+import { categoryBudgets } from "../../data/categoryBudgets"
+
+const REST_URL = "*/rest/v1/category_budgets*"
+
+interface CategoryBudgetResponseRow extends CategoryBudgetRow {
+  category: {
+    id: number
+    name: string
+  }
+}
+
+interface GetCategoryBudgetsOptions {
+  response?: CategoryBudgetResponseRow[]
+  error?: boolean
+  durationOrMode?: number | DelayMode | undefined
+}
+
+interface CreateCategoryBudgetHandlersOptions {
+  get?: GetCategoryBudgetsOptions
+}
+
+const defaultCategoryBudgetRows: CategoryBudgetResponseRow[] = categoryBudgets.map((row) => {
+  const category = categories.find((candidate) => candidate.id === row.category_id)
+
+  return {
+    ...row,
+    category: {
+      id: row.category_id,
+      name: category?.name ?? "Unknown",
+    },
+  }
+})
+
+export function createCategoryBudgetHandlers({
+  get = {},
+}: CreateCategoryBudgetHandlersOptions = {}) {
+  const categoryBudgetsHandler = http.get(REST_URL, async () => {
+    await delay(get.durationOrMode)
+
+    if (get.error) {
+      return HttpResponse.json({ message: "Failed to fetch category budgets." }, { status: 500 })
+    }
+
+    return HttpResponse.json(get.response ?? defaultCategoryBudgetRows)
+  })
+
+  return [categoryBudgetsHandler]
+}
+
+export const categoryBudgetHandlers = createCategoryBudgetHandlers()

--- a/apps/web/src/test/msw/handlers/index.ts
+++ b/apps/web/src/test/msw/handlers/index.ts
@@ -1,5 +1,6 @@
 import { authHandlers } from "./auth"
 import { categoryHandlers } from "./categories"
+import { categoryBudgetHandlers } from "./categoryBudgets"
 import { monthlyBudgetHandlers } from "./monthlyBudgets"
 import { paymentHandlers } from "./payments"
 
@@ -7,5 +8,6 @@ export const handlers = [
   ...authHandlers,
   ...paymentHandlers,
   ...categoryHandlers,
+  ...categoryBudgetHandlers,
   ...monthlyBudgetHandlers,
 ]


### PR DESCRIPTION
## 関連Issue

- closes #1196

## 変更内容

- カテゴリ別予算をカテゴリ名つきで取得する fetch / mapper / hook を追加
- カテゴリごとの最新予算を `effective_from` と `id` で選ぶ変換処理を追加
- 薄い MSW handler と unit test を追加

## 動作確認

- [x] `task web:lint`
- [x] `task web:format-check`
- [x] `task web:typecheck`
- [x] `task web:test-unit`
- [x] `task web:test-storybook`
