### PR TITLE
予算設定にカテゴリ別予算一覧を追加

### DIFF
--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -6,7 +6,7 @@ import {
   redirect,
 } from "@tanstack/react-router"
 
-import { LatestMonthlyBudget } from "../features/budgets/latestMonthlyBudget"
+import { BudgetSettings } from "../features/budgets/budgetSettings/BudgetSettings"
 import { paymentsSearchSchema } from "../features/payments/listPayment/paymentsSearchSchema"
 import type { AuthStatus } from "../providers/supabase/SupabaseSessionProvider"
 import { AppLayout } from "./AppLayout"
@@ -82,7 +82,7 @@ const settingsRoute = createRoute({
 const settingsBudgetsRoute = createRoute({
   getParentRoute: () => settingsRoute,
   path: "budgets",
-  component: LatestMonthlyBudget,
+  component: BudgetSettings,
 })
 
 const budgetsRoute = createRoute({

--- a/apps/web/src/app/routes/SettingsPage/SettingsPage.stories.tsx
+++ b/apps/web/src/app/routes/SettingsPage/SettingsPage.stories.tsx
@@ -2,9 +2,10 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 import { createRoute } from "@tanstack/react-router"
 import { expect, within } from "storybook/test"
 
-import { LatestMonthlyBudget } from "../../../features/budgets/latestMonthlyBudget"
+import { BudgetSettings } from "../../../features/budgets/budgetSettings/BudgetSettings"
 import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
 import { createStoryRouter } from "../../../test/helpers/routerDecorator"
+import { createCategoryBudgetHandlers } from "../../../test/msw/handlers/categoryBudgets"
 import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
 import { SettingsPage } from "./SettingsPage"
 
@@ -43,7 +44,7 @@ export const BudgetManagement: Story = {
       const settingsBudgetsRoute = createRoute({
         getParentRoute: () => settingsRoute,
         path: "budgets",
-        component: LatestMonthlyBudget,
+        component: BudgetSettings,
       })
 
       return [settingsRoute.addChildren([settingsBudgetsRoute])]
@@ -55,6 +56,7 @@ export const BudgetManagement: Story = {
         ...createMonthlyBudgetHandlers({
           list: { response: [monthlyBudgets[3]] },
         }),
+        ...createCategoryBudgetHandlers(),
       ],
     },
   },
@@ -62,41 +64,6 @@ export const BudgetManagement: Story = {
     const canvas = within(canvasElement)
 
     expect(await canvas.findByText("Monthly Budgets")).toBeInTheDocument()
-    expect(await canvas.findByText("￥75,000")).toBeInTheDocument()
-  },
-}
-
-export const EmptyBudgetSettings: Story = {
-  decorators: [
-    createStoryRouter("/settings/budgets", (root, Story) => {
-      const settingsRoute = createRoute({
-        getParentRoute: () => root,
-        path: "/settings",
-        component: Story,
-      })
-
-      const settingsBudgetsRoute = createRoute({
-        getParentRoute: () => settingsRoute,
-        path: "budgets",
-        component: LatestMonthlyBudget,
-      })
-
-      return [settingsRoute.addChildren([settingsBudgetsRoute])]
-    }),
-  ],
-  parameters: {
-    msw: {
-      handlers: [
-        ...createMonthlyBudgetHandlers({
-          list: { response: [] },
-        }),
-      ],
-    },
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement)
-
-    expect(await canvas.findByText("Monthly Budgets")).toBeInTheDocument()
-    expect(await canvas.findByRole("button", { name: "Create budget" })).toBeInTheDocument()
+    expect(await canvas.findByText("Category Budgets")).toBeInTheDocument()
   },
 }

--- a/apps/web/src/app/routes/SettingsPage/SettingsPage.test.tsx
+++ b/apps/web/src/app/routes/SettingsPage/SettingsPage.test.tsx
@@ -2,10 +2,12 @@ import { createRoute, redirect } from "@tanstack/react-router"
 import type { ReactNode } from "react"
 import { afterEach, describe, expect, test, vi } from "vite-plus/test"
 
+import { BudgetSettings } from "../../../features/budgets/budgetSettings/BudgetSettings"
 import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../features/budgets/createMonthlyBudget/monthlyBudgetCreateError"
-import { LatestMonthlyBudget } from "../../../features/budgets/latestMonthlyBudget"
+import { categoryBudgets } from "../../../test/data/categoryBudgets"
 import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
 import { renderWithRouter } from "../../../test/helpers/renderWithRouter"
+import { createCategoryBudgetHandlers } from "../../../test/msw/handlers/categoryBudgets"
 import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
 import { server } from "../../../test/msw/server"
 import { screen, waitFor, within } from "../../../test/test-utils"
@@ -21,7 +23,7 @@ function renderSettingsPage(
   initialEntry = "/settings",
   options: { settingsBudgetsComponent?: SettingsBudgetsComponentType } = {},
 ) {
-  const SettingsBudgetsComponent = options.settingsBudgetsComponent ?? LatestMonthlyBudget
+  const SettingsBudgetsComponent = options.settingsBudgetsComponent ?? BudgetSettings
 
   return renderWithRouter(initialEntry, (root) => {
     const authenticatedRoute = createRoute({
@@ -108,6 +110,20 @@ describe("SettingsPage", () => {
       ...createMonthlyBudgetHandlers({
         list: { response: [monthlyBudgets[3], monthlyBudgets[2]] },
       }),
+      ...createCategoryBudgetHandlers({
+        get: {
+          response: [
+            {
+              ...categoryBudgets[2],
+              category: { id: 10, name: "Food" },
+            },
+            {
+              ...categoryBudgets[3],
+              category: { id: 20, name: "Daily Necessities" },
+            },
+          ],
+        },
+      }),
     )
 
     renderSettingsPage("/settings/budgets")
@@ -115,6 +131,9 @@ describe("SettingsPage", () => {
     expect(await screen.findByText("Monthly Budgets")).toBeInTheDocument()
     expect(await screen.findByText("￥75,000")).toBeInTheDocument()
     expect(screen.queryByText("￥62,000")).not.toBeInTheDocument()
+    expect(await screen.findByText("Category Budgets")).toBeInTheDocument()
+    expect(await screen.findByText("Food ￥50,000")).toBeInTheDocument()
+    expect(await screen.findByText("Daily Necessities ￥12,000")).toBeInTheDocument()
   })
 
   test("月予算が未登録の場合は予算登録ボタンを表示する", async () => {
@@ -122,6 +141,7 @@ describe("SettingsPage", () => {
       ...createMonthlyBudgetHandlers({
         list: { response: [] },
       }),
+      ...createCategoryBudgetHandlers(),
     )
 
     renderSettingsPage("/settings/budgets")
@@ -135,6 +155,7 @@ describe("SettingsPage", () => {
       ...createMonthlyBudgetHandlers({
         list: { response: [] },
       }),
+      ...createCategoryBudgetHandlers(),
     )
 
     const { user, baseElement } = renderSettingsPage("/settings/budgets")
@@ -167,6 +188,7 @@ describe("SettingsPage", () => {
           },
         },
       }),
+      ...createCategoryBudgetHandlers(),
     )
 
     const { user, baseElement } = renderSettingsPage("/settings/budgets")

--- a/apps/web/src/features/budgets/budgetSettings/BudgetSettings/BudgetSettings.stories.tsx
+++ b/apps/web/src/features/budgets/budgetSettings/BudgetSettings/BudgetSettings.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { QueryClientProvider } from "@tanstack/react-query"
+
+import { createQueryClient } from "../../../../lib/queryClient"
+import { ThemeProvider } from "../../../../providers/theme/ThemeProvider"
+import { createCategoryBudgetHandlers } from "../../../../test/msw/handlers/categoryBudgets"
+import { createMonthlyBudgetHandlers } from "../../../../test/msw/handlers/monthlyBudgets"
+import { BudgetSettings } from "./BudgetSettings"
+
+const meta = {
+  title: "Features/Budgets/BudgetSettings",
+  component: BudgetSettings,
+  parameters: {
+    msw: {
+      handlers: [...createMonthlyBudgetHandlers(), ...createCategoryBudgetHandlers()],
+    },
+  },
+  tags: ["autodocs"],
+  decorators: (Story) => {
+    const queryClient = createQueryClient()
+
+    return (
+      <ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      </ThemeProvider>
+    )
+  },
+} satisfies Meta<typeof BudgetSettings>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/apps/web/src/features/budgets/budgetSettings/BudgetSettings/BudgetSettings.test.tsx
+++ b/apps/web/src/features/budgets/budgetSettings/BudgetSettings/BudgetSettings.test.tsx
@@ -1,0 +1,28 @@
+import { composeStories } from "@storybook/react-vite"
+import type { ReactElement } from "react"
+import { describe, expect, test } from "vite-plus/test"
+
+import { createCategoryBudgetHandlers } from "../../../../test/msw/handlers/categoryBudgets"
+import { createMonthlyBudgetHandlers } from "../../../../test/msw/handlers/monthlyBudgets"
+import { server } from "../../../../test/msw/server"
+import { act, render, screen } from "../../../../test/test-utils"
+import * as stories from "./BudgetSettings.stories"
+
+const { Default } = composeStories(stories)
+
+async function renderBudgetSettings(story: ReactElement) {
+  return await act(async () => {
+    return render(story)
+  })
+}
+
+describe("BudgetSettings", () => {
+  test("月予算とカテゴリ別予算を表示する", async () => {
+    server.resetHandlers(...createMonthlyBudgetHandlers(), ...createCategoryBudgetHandlers())
+
+    await renderBudgetSettings(<Default />)
+
+    expect(await screen.findByText("Monthly Budgets")).toBeInTheDocument()
+    expect(await screen.findByText("Category Budgets")).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/budgets/budgetSettings/BudgetSettings/BudgetSettings.tsx
+++ b/apps/web/src/features/budgets/budgetSettings/BudgetSettings/BudgetSettings.tsx
@@ -1,0 +1,13 @@
+import { Flex } from "@radix-ui/themes"
+
+import { LatestMonthlyBudget } from "../../latestMonthlyBudget"
+import { CategoryBudgetList } from "../../listCategoryBudget/CategoryBudgetList"
+
+export function BudgetSettings() {
+  return (
+    <Flex direction="column" gap="5">
+      <LatestMonthlyBudget />
+      <CategoryBudgetList />
+    </Flex>
+  )
+}

--- a/apps/web/src/features/budgets/budgetSettings/BudgetSettings/index.ts
+++ b/apps/web/src/features/budgets/budgetSettings/BudgetSettings/index.ts
@@ -1,0 +1,1 @@
+export { BudgetSettings } from "./BudgetSettings"

--- a/apps/web/src/features/budgets/listCategoryBudget/CategoryBudgetList/CategoryBudgetList.stories.tsx
+++ b/apps/web/src/features/budgets/listCategoryBudget/CategoryBudgetList/CategoryBudgetList.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { QueryClientProvider } from "@tanstack/react-query"
+
+import { createQueryClient } from "../../../../lib/queryClient"
+import { ThemeProvider } from "../../../../providers/theme/ThemeProvider"
+import { categoryBudgets } from "../../../../test/data/categoryBudgets"
+import { createCategoryBudgetHandlers } from "../../../../test/msw/handlers/categoryBudgets"
+import { CategoryBudgetList } from "./CategoryBudgetList"
+
+const meta = {
+  title: "Features/Budgets/CategoryBudgetList",
+  component: CategoryBudgetList,
+  parameters: {
+    msw: {
+      handlers: createCategoryBudgetHandlers(),
+    },
+  },
+  tags: ["autodocs"],
+  decorators: (Story) => {
+    const queryClient = createQueryClient()
+
+    return (
+      <ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      </ThemeProvider>
+    )
+  },
+} satisfies Meta<typeof CategoryBudgetList>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Empty: Story = {
+  parameters: {
+    msw: {
+      handlers: createCategoryBudgetHandlers({
+        get: { response: [] },
+      }),
+    },
+  },
+}
+
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: createCategoryBudgetHandlers({
+        get: { response: [], durationOrMode: "infinite" },
+      }),
+    },
+  },
+}
+
+export const FetchError: Story = {
+  parameters: {
+    msw: {
+      handlers: createCategoryBudgetHandlers({
+        get: { error: true },
+      }),
+    },
+  },
+}
+
+export const DuplicateCategory: Story = {
+  parameters: {
+    msw: {
+      handlers: createCategoryBudgetHandlers({
+        get: {
+          response: [
+            {
+              ...categoryBudgets[0],
+              category: { id: 10, name: "Food" },
+            },
+            {
+              ...categoryBudgets[2],
+              category: { id: 10, name: "Food" },
+            },
+          ],
+        },
+      }),
+    },
+  },
+}

--- a/apps/web/src/features/budgets/listCategoryBudget/CategoryBudgetList/CategoryBudgetList.test.tsx
+++ b/apps/web/src/features/budgets/listCategoryBudget/CategoryBudgetList/CategoryBudgetList.test.tsx
@@ -1,0 +1,98 @@
+import { composeStories } from "@storybook/react-vite"
+import type { ReactElement } from "react"
+import { afterEach, describe, expect, test, vi } from "vite-plus/test"
+
+import { categoryBudgets } from "../../../../test/data/categoryBudgets"
+import { createCategoryBudgetHandlers } from "../../../../test/msw/handlers/categoryBudgets"
+import { server } from "../../../../test/msw/server"
+import { act, render, screen } from "../../../../test/test-utils"
+import * as stories from "./CategoryBudgetList.stories"
+
+const { Default, DuplicateCategory, Empty, FetchError, Loading } = composeStories(stories)
+
+async function renderCategoryBudgetList(story: ReactElement) {
+  return await act(async () => {
+    return render(story)
+  })
+}
+
+describe("CategoryBudgetList", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test("登録済みカテゴリ別予算をカテゴリ名と金額で表示する", async () => {
+    server.resetHandlers(...createCategoryBudgetHandlers())
+
+    await renderCategoryBudgetList(<Default />)
+
+    expect(await screen.findByText("Category Budgets")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Add category budget" })).toBeDisabled()
+    expect(await screen.findByText("Food ￥50,000")).toBeInTheDocument()
+    expect(await screen.findByText("Daily Necessities ￥12,000")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Food category budget menu" })).toBeDisabled()
+  })
+
+  test("登録済みカテゴリ別予算がない場合は登録導線を表示する", async () => {
+    server.resetHandlers(
+      ...createCategoryBudgetHandlers({
+        get: { response: [] },
+      }),
+    )
+
+    await renderCategoryBudgetList(<Empty />)
+
+    expect(await screen.findByRole("button", { name: "Create category budget" })).toBeDisabled()
+  })
+
+  test("取得中はスケルトンを表示する", async () => {
+    server.resetHandlers(
+      ...createCategoryBudgetHandlers({
+        get: { response: [], durationOrMode: "infinite" },
+      }),
+    )
+
+    await renderCategoryBudgetList(<Loading />)
+
+    expect(await screen.findByLabelText("loading category budgets")).toBeInTheDocument()
+  })
+
+  test("取得に失敗した場合はエラー状態を表示する", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    server.resetHandlers(
+      ...createCategoryBudgetHandlers({
+        get: { error: true },
+      }),
+    )
+
+    await renderCategoryBudgetList(<FetchError />)
+
+    expect(await screen.findByRole("alert", {}, { timeout: 3000 })).toHaveTextContent(
+      "Could not load category budgets.",
+    )
+  })
+
+  test("同じカテゴリの予算が複数ある場合は最新の1件だけを表示する", async () => {
+    server.resetHandlers(
+      ...createCategoryBudgetHandlers({
+        get: {
+          response: [
+            {
+              ...categoryBudgets[0],
+              category: { id: 10, name: "Food" },
+            },
+            {
+              ...categoryBudgets[2],
+              category: { id: 10, name: "Food" },
+            },
+          ],
+        },
+      }),
+    )
+
+    await renderCategoryBudgetList(<DuplicateCategory />)
+
+    expect(await screen.findByText("Food ￥50,000")).toBeInTheDocument()
+    expect(screen.queryByText("Food ￥30,000")).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/budgets/listCategoryBudget/CategoryBudgetList/CategoryBudgetList.tsx
+++ b/apps/web/src/features/budgets/listCategoryBudget/CategoryBudgetList/CategoryBudgetList.tsx
@@ -1,0 +1,96 @@
+import { DotsVerticalIcon, PlusIcon } from "@radix-ui/react-icons"
+import { Button, Flex, IconButton, Skeleton, Text } from "@radix-ui/themes"
+import { Suspense, use } from "react"
+import { ErrorBoundary } from "react-error-boundary"
+
+import { toCurrency } from "../../../../utils/toCurrency"
+import type { CategoryBudget } from "../../types"
+import { useCategoryBudgets } from "../useCategoryBudgets"
+
+export function CategoryBudgetList() {
+  const { promise } = useCategoryBudgets()
+
+  return (
+    <Flex direction="column" gap="3">
+      <Flex align="center" justify="between" gap="3">
+        <Text as="p" size="4" weight="medium">
+          Category Budgets
+        </Text>
+        <Button aria-label="Add category budget" disabled size="2" variant="ghost">
+          <PlusIcon />
+        </Button>
+      </Flex>
+      <ErrorBoundary
+        fallback={
+          <Text color="red" role="alert">
+            Could not load category budgets.
+          </Text>
+        }
+      >
+        <Suspense fallback={<CategoryBudgetListLoading />}>
+          <CategoryBudgetListContent promise={promise} />
+        </Suspense>
+      </ErrorBoundary>
+    </Flex>
+  )
+}
+
+function CategoryBudgetListContent({ promise }: { promise: Promise<CategoryBudget[]> }) {
+  const categoryBudgets = use(promise)
+
+  if (categoryBudgets.length === 0) {
+    return (
+      <Button disabled variant="soft">
+        <PlusIcon /> Create category budget
+      </Button>
+    )
+  }
+
+  return (
+    <Flex direction="column" gap="2">
+      {categoryBudgets.map((categoryBudget) => (
+        <CategoryBudgetRow key={categoryBudget.id} categoryBudget={categoryBudget} />
+      ))}
+    </Flex>
+  )
+}
+
+function CategoryBudgetListLoading() {
+  return (
+    <Flex aria-label="loading category budgets" direction="column" gap="2">
+      <CategoryBudgetLoadingRow />
+      <CategoryBudgetLoadingRow />
+    </Flex>
+  )
+}
+
+function CategoryBudgetLoadingRow() {
+  return (
+    <Flex align="center" justify="between" gap="3">
+      <Skeleton loading>
+        <Text>Category name</Text>
+      </Skeleton>
+      <Skeleton loading>
+        <Text>￥000,000</Text>
+      </Skeleton>
+    </Flex>
+  )
+}
+
+function CategoryBudgetRow({ categoryBudget }: { categoryBudget: CategoryBudget }) {
+  return (
+    <Flex align="center" justify="between" gap="3">
+      <Text>
+        {categoryBudget.categoryName} {toCurrency(categoryBudget.amount)}
+      </Text>
+      <IconButton
+        aria-label={`${categoryBudget.categoryName} category budget menu`}
+        disabled
+        size="2"
+        variant="ghost"
+      >
+        <DotsVerticalIcon />
+      </IconButton>
+    </Flex>
+  )
+}

--- a/apps/web/src/features/budgets/listCategoryBudget/CategoryBudgetList/index.ts
+++ b/apps/web/src/features/budgets/listCategoryBudget/CategoryBudgetList/index.ts
@@ -1,0 +1,1 @@
+export { CategoryBudgetList } from "./CategoryBudgetList"


### PR DESCRIPTION
## 関連Issue

- closes #1197

## 変更内容

- 予算設定画面にカテゴリ別予算一覧セクションを追加
- loading / error / empty / registered の表示を Story と unit test で確認

## 動作確認

- [x] task web:lint
- [x] task web:format-check
- [x] task web:typecheck
- [x] task web:test-unit
- [x] task web:test-storybook