### PR TITLE
カテゴリ別予算の作成ロジックを追加する

### DIFF
--- a/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetCreateError.test.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetCreateError.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vite-plus/test"
+
+import {
+  POSTGRES_UNIQUE_VIOLATION_CODE,
+  toCategoryBudgetCreateErrorMessage,
+} from "./categoryBudgetCreateError"
+
+describe("toCategoryBudgetCreateErrorMessage", () => {
+  test("PostgreSQL unique_violationは重複カテゴリ年月メッセージに変換する", () => {
+    expect(
+      toCategoryBudgetCreateErrorMessage({
+        code: POSTGRES_UNIQUE_VIOLATION_CODE,
+        message: "duplicate key value violates unique constraint",
+      }),
+    ).toBe("A category budget for this category and month already exists.")
+  })
+
+  test("それ以外のエラーは汎用メッセージに変換する", () => {
+    expect(toCategoryBudgetCreateErrorMessage({ message: "network error" })).toBe(
+      "Failed to create category budget.",
+    )
+    expect(toCategoryBudgetCreateErrorMessage(undefined)).toBe("Failed to create category budget.")
+  })
+})

--- a/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetCreateError.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetCreateError.ts
@@ -1,0 +1,22 @@
+// PostgreSQL SQLSTATE 23505 means unique_violation.
+export const POSTGRES_UNIQUE_VIOLATION_CODE = "23505"
+
+const DUPLICATE_CATEGORY_BUDGET_MESSAGE =
+  "A category budget for this category and month already exists."
+const GENERIC_CREATE_CATEGORY_BUDGET_MESSAGE = "Failed to create category budget."
+
+export function toCategoryBudgetCreateErrorMessage(error: unknown): string {
+  if (isPostgresUniqueViolationError(error)) {
+    return DUPLICATE_CATEGORY_BUDGET_MESSAGE
+  }
+
+  return GENERIC_CREATE_CATEGORY_BUDGET_MESSAGE
+}
+
+function isPostgresUniqueViolationError(error: unknown): boolean {
+  if (!error || typeof error !== "object" || !("code" in error)) {
+    return false
+  }
+
+  return error.code === POSTGRES_UNIQUE_VIOLATION_CODE
+}

--- a/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormMappers.test.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormMappers.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "vite-plus/test"
+
+import { toCategoryBudgetInsert } from "./categoryBudgetFormMappers"
+
+describe("toCategoryBudgetInsert", () => {
+  test("カテゴリ別予算作成用の値をcategory_budgets insert payloadに変換する", () => {
+    expect(
+      toCategoryBudgetInsert({
+        categoryId: 10,
+        targetMonth: new Date(2026, 2, 20),
+        amount: 50000,
+      }),
+    ).toEqual({
+      amount: 50000,
+      category_id: 10,
+      effective_from: "2026-03-01",
+    })
+  })
+
+  test("選択日の年月を使い、日付は月初日に丸める", () => {
+    expect(
+      toCategoryBudgetInsert({
+        categoryId: 20,
+        targetMonth: new Date(2025, 6, 31),
+        amount: 12000,
+      }),
+    ).toEqual({
+      amount: 12000,
+      category_id: 20,
+      effective_from: "2025-07-01",
+    })
+  })
+})

--- a/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormMappers.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormMappers.ts
@@ -1,0 +1,27 @@
+import { format } from "date-fns"
+
+import type { TablesInsert } from "../../../types/database.types"
+
+export interface CategoryBudgetWriteInput {
+  categoryId: number
+  targetMonth: Date
+  amount: number
+}
+
+// user_id は DB のデフォルト値（auth.uid()）で自動設定されるため FE から渡さない
+export type CategoryBudgetInsert = Omit<
+  TablesInsert<"category_budgets">,
+  "user_id" | "effective_year" | "effective_month"
+>
+
+export function toCategoryBudgetInsert(value: CategoryBudgetWriteInput): CategoryBudgetInsert {
+  return {
+    amount: value.amount,
+    category_id: value.categoryId,
+    effective_from: format(toMonthStartDate(value.targetMonth), "yyyy-MM-dd"),
+  }
+}
+
+function toMonthStartDate(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1)
+}

--- a/apps/web/src/features/budgets/createCategoryBudget/createCategoryBudget.test.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/createCategoryBudget.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vite-plus/test"
+
+import { createCategoryBudget } from "./createCategoryBudget"
+
+const mockInsert = vi.fn()
+const mockFrom = vi.fn(() => ({ insert: mockInsert }))
+
+vi.mock("../../../lib/supabase", () => ({
+  getSupabaseClient: () => ({ from: mockFrom }),
+}))
+
+describe("createCategoryBudget", () => {
+  it("category_budgetsにカテゴリID、月初日のeffective_from、amountをinsertする", async () => {
+    mockInsert.mockResolvedValue({ error: null })
+
+    await createCategoryBudget({
+      categoryId: 10,
+      targetMonth: new Date(2026, 2, 20),
+      amount: 50000,
+    })
+
+    expect(mockFrom).toHaveBeenCalledWith("category_budgets")
+    expect(mockInsert).toHaveBeenCalledWith({
+      amount: 50000,
+      category_id: 10,
+      effective_from: "2026-03-01",
+    })
+  })
+
+  it("Supabaseがエラーを返した場合にthrowする", async () => {
+    const supabaseError = { message: "重複しています", code: "23505" }
+    mockInsert.mockResolvedValue({ error: supabaseError })
+
+    await expect(
+      createCategoryBudget({
+        categoryId: 10,
+        targetMonth: new Date(2026, 2, 1),
+        amount: 50000,
+      }),
+    ).rejects.toEqual(supabaseError)
+  })
+})

--- a/apps/web/src/features/budgets/createCategoryBudget/createCategoryBudget.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/createCategoryBudget.ts
@@ -1,0 +1,12 @@
+import { getSupabaseClient } from "../../../lib/supabase"
+import { type CategoryBudgetWriteInput, toCategoryBudgetInsert } from "./categoryBudgetFormMappers"
+
+export async function createCategoryBudget(value: CategoryBudgetWriteInput): Promise<void> {
+  const supabase = getSupabaseClient()
+  const row = toCategoryBudgetInsert(value)
+  const { error } = await supabase.from("category_budgets").insert(row)
+
+  if (error) {
+    throw error
+  }
+}

--- a/apps/web/src/features/budgets/createCategoryBudget/useCreateCategoryBudget.test.tsx
+++ b/apps/web/src/features/budgets/createCategoryBudget/useCreateCategoryBudget.test.tsx
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { createQueryClient } from "../../../lib/queryClient"
+import { act, renderHook } from "../../../test/test-utils"
+import type { CategoryBudgetWriteInput } from "./categoryBudgetFormMappers"
+import { useCreateCategoryBudget } from "./useCreateCategoryBudget"
+
+const { mockCreateCategoryBudget } = vi.hoisted(() => ({
+  mockCreateCategoryBudget: vi.fn(),
+}))
+
+vi.mock("./createCategoryBudget", () => ({
+  createCategoryBudget: mockCreateCategoryBudget,
+}))
+
+describe("useCreateCategoryBudget", () => {
+  beforeEach(() => {
+    mockCreateCategoryBudget.mockReset()
+  })
+
+  it("成功時に関連queryをinvalidateしてresolveする", async () => {
+    const queryClient = createQueryClient()
+    const invalidateQueries = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined)
+    const input: CategoryBudgetWriteInput = {
+      categoryId: 10,
+      targetMonth: new Date(2026, 2, 1),
+      amount: 50000,
+    }
+    mockCreateCategoryBudget.mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useCreateCategoryBudget(), {
+      queryClient,
+    })
+
+    await act(async () => {
+      const promise = result.current.createCategoryBudget(input)
+
+      expect(promise).toBeInstanceOf(Promise)
+      await promise
+    })
+
+    expect(mockCreateCategoryBudget).toHaveBeenCalledTimes(1)
+    expect(mockCreateCategoryBudget.mock.calls[0]?.[0]).toBe(input)
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["categoryBudgets"] })
+    expect(invalidateQueries).toHaveBeenCalledTimes(1)
+  })
+
+  it("失敗時に関連queryをinvalidateせずrejectする", async () => {
+    const queryClient = createQueryClient()
+    const invalidateQueries = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined)
+    const error = { message: "重複しています", code: "23505" }
+    mockCreateCategoryBudget.mockRejectedValue(error)
+
+    const { result } = renderHook(() => useCreateCategoryBudget(), {
+      queryClient,
+    })
+
+    await act(async () => {
+      await expect(
+        result.current.createCategoryBudget({
+          categoryId: 10,
+          targetMonth: new Date(2026, 2, 1),
+          amount: 50000,
+        }),
+      ).rejects.toEqual(error)
+    })
+
+    expect(invalidateQueries).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/budgets/createCategoryBudget/useCreateCategoryBudget.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/useCreateCategoryBudget.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useCallback } from "react"
+
+import type { CategoryBudgetWriteInput } from "./categoryBudgetFormMappers"
+import { createCategoryBudget as createCategoryBudgetRecord } from "./createCategoryBudget"
+
+interface UseCreateCategoryBudgetReturn {
+  createCategoryBudget: (value: CategoryBudgetWriteInput) => Promise<void>
+  isPending: boolean
+}
+
+export function useCreateCategoryBudget(): UseCreateCategoryBudgetReturn {
+  const queryClient = useQueryClient()
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: createCategoryBudgetRecord,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["categoryBudgets"] })
+    },
+  })
+
+  const createCategoryBudget = useCallback(
+    async (value: CategoryBudgetWriteInput) => {
+      return mutateAsync(value)
+    },
+    [mutateAsync],
+  )
+
+  return { createCategoryBudget, isPending }
+}


### PR DESCRIPTION
## 関連Issue

- closes #1198

## 変更内容

- カテゴリ別予算作成用の insert payload mapper と Supabase insert 処理を追加
- 作成用 mutation hook で成功時にカテゴリ別予算一覧 query を invalidate
- 重複エラーを UI 側で扱えるメッセージへ変換し、作成 API 境界と hook の unit test を追加

## 動作確認

- [x] `task web:lint`
- [x] `task web:format-check`
- [x] `task web:typecheck`
- [x] `task web:test-unit`
- [x] `task web:test-storybook`
