### PR TITLE
カテゴリ別予算の作成フォームを追加する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,13 @@ Personal savings management app. Monorepo with two apps (`apps/web/` and `apps/a
 - When changing an existing workflow, command path, or configuration surface, follow the established pattern in the same layer unless there is a clear reason to change it.
 - If you intentionally diverge from an existing pattern, explain why before applying the change.
 
+## Mandatory Web Component Structure Rules
+
+The rules in this section are mandatory and must always be followed.
+
+- Before adding, moving, or extracting Web components, read and follow `apps/web/docs/policies/component-structure.md`.
+- If a requested change or review comment conflicts with that policy, stop and clarify before editing.
+
 ## Mandatory Communication Rules
 
 The rules in this section are mandatory and must always be followed.

--- a/apps/web/docs/policies/component-structure.md
+++ b/apps/web/docs/policies/component-structure.md
@@ -1,0 +1,88 @@
+---
+title: Component Structure
+doc_type: policy
+status: accepted
+area: web
+applies_to:
+  - apps/web/src/components
+  - apps/web/src/features
+topics:
+  - component-structure
+  - frontend-architecture
+  - project-structure
+when_to_read:
+  - Webアプリにコンポーネントを追加するとき
+  - Webアプリのコンポーネントを別ファイルへ切り出すとき
+  - features配下またはcomponents配下のコンポーネント配置を変更するとき
+---
+
+# Component Structure
+
+Webアプリのコンポーネント定義は、ディレクトリ単位で管理します。
+
+単体の `Foo.tsx` をコンポーネント定義として追加せず、コンポーネント名のディレクトリを作り、その中に同名の実装ファイルと `index.ts` を置きます。
+
+```text
+Foo/
+  Foo.tsx
+  index.ts
+  Foo.test.tsx      # 必要な場合
+  Foo.stories.tsx   # 必要な場合
+```
+
+## Feature内の配置
+
+feature slice 内でフォームやフィールドなどのコンポーネントを分ける場合も、各コンポーネントは兄弟ディレクトリとして配置します。
+
+```text
+createExample/
+  ExampleField/
+    ExampleField.tsx
+    index.ts
+  CreateExampleForm/
+    CreateExampleForm.tsx
+    index.ts
+```
+
+`CreateExampleForm` から `ExampleField` を使う場合は、`../ExampleField` から import します。
+
+## 禁止する配置
+
+単体ファイルのコンポーネント定義は禁止します。
+
+```text
+createExample/
+  ExampleField.tsx
+```
+
+親コンポーネントのディレクトリ配下に、子コンポーネントを定義することも禁止します。
+
+```text
+createExample/
+  CreateExampleForm/
+    CreateExampleForm.tsx
+    ExampleField.tsx
+```
+
+```text
+createExample/
+  CreateExampleForm/
+    CreateExampleForm.tsx
+    ExampleField/
+      ExampleField.tsx
+      index.ts
+```
+
+コンポーネントを切り出すときは、親コンポーネント配下ではなく、同じ feature slice 内の兄弟コンポーネントディレクトリとして作成します。
+
+## index.ts の扱い
+
+コンポーネントディレクトリの `index.ts` は、そのコンポーネントの公開口として置きます。
+
+一方で、feature 直下の barrel export とは別の話です。コンポーネントディレクトリに `index.ts` を置くことを理由に、`features/<feature>/index.ts` や feature slice 直下の barrel export を追加してはいけません。
+
+## 対象外
+
+hooks、utilities、schema、adapter など、コンポーネントではない実装ファイルはこのルールの対象外です。既存の層の配置規約に従います。
+
+レビューコメントで「別ファイルに切り出して」と指摘された場合も、単体ファイル化ではなく、このコンポーネント構造に従って切り出します。

--- a/apps/web/src/features/budgets/createCategoryBudget/CategoryField/CategoryField.tsx
+++ b/apps/web/src/features/budgets/createCategoryBudget/CategoryField/CategoryField.tsx
@@ -1,0 +1,61 @@
+import { memo, Suspense, use, useId } from "react"
+import { ErrorBoundary } from "react-error-boundary"
+
+import { BaseField, FieldLabel, FieldMessages } from "../../../../components/inputs/BaseField"
+import type { Category } from "../../../../types/category"
+import { useCategories } from "../../../categories/listCategory/useCategories"
+import {
+  CategoryOption,
+  CategorySelect,
+  ErrorCategoryOption,
+  LoadingCategoryOption,
+} from "../../../payments/components/CategorySelect/CategorySelect"
+
+interface CategoryFieldProps {
+  error?: boolean
+  messages?: string[]
+  value?: string
+  onChange?: (category: string) => void
+}
+
+export const CategoryField = memo(function CategoryField({
+  error,
+  messages,
+  value,
+  onChange,
+}: CategoryFieldProps) {
+  const id = useId()
+  const { promise: promiseCategories } = useCategories()
+
+  return (
+    <BaseField>
+      <FieldLabel htmlFor={id} required>
+        Category
+      </FieldLabel>
+      <CategorySelect id={id} value={value} onChange={onChange}>
+        <ErrorBoundary fallback={<ErrorCategoryOption />}>
+          <Suspense fallback={<LoadingCategoryOption />}>
+            <CategoryOptions categoriesPromise={promiseCategories} />
+          </Suspense>
+        </ErrorBoundary>
+      </CategorySelect>
+      <FieldMessages error={Boolean(error)} messages={messages} />
+    </BaseField>
+  )
+})
+
+interface CategoryOptionsProps {
+  categoriesPromise: Promise<Category[]>
+}
+
+const CategoryOptions = memo(function CategoryOptions({ categoriesPromise }: CategoryOptionsProps) {
+  const categories = use(categoriesPromise)
+
+  return (
+    <>
+      {categories.map((category) => (
+        <CategoryOption key={category.id} category={category} />
+      ))}
+    </>
+  )
+})

--- a/apps/web/src/features/budgets/createCategoryBudget/CategoryField/index.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/CategoryField/index.ts
@@ -1,0 +1,1 @@
+export { CategoryField } from "./CategoryField"

--- a/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetForm/CreateCategoryBudgetForm.stories.tsx
+++ b/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetForm/CreateCategoryBudgetForm.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { QueryClientProvider } from "@tanstack/react-query"
+import { fn } from "storybook/test"
+
+import { createQueryClient } from "../../../../lib/queryClient"
+import { ThemeProvider } from "../../../../providers/theme/ThemeProvider"
+import { createCategoryHandlers } from "../../../../test/msw/handlers/categories"
+import { createCategoryBudgetHandlers } from "../../../../test/msw/handlers/categoryBudgets"
+import { CreateCategoryBudgetForm } from "./CreateCategoryBudgetForm"
+
+const meta = {
+  title: "Features/Budgets/CreateCategoryBudgetForm",
+  component: CreateCategoryBudgetForm,
+  parameters: {
+    layout: "centered",
+    msw: {
+      handlers: [...createCategoryHandlers(), ...createCategoryBudgetHandlers()],
+    },
+  },
+  tags: ["autodocs"],
+  args: {
+    onCancel: fn(),
+  },
+  decorators: (Story) => {
+    const queryClient = createQueryClient()
+
+    return (
+      <ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      </ThemeProvider>
+    )
+  },
+} satisfies Meta<typeof CreateCategoryBudgetForm>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    onSuccess: fn(),
+    onError: fn(),
+  },
+}

--- a/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetForm/CreateCategoryBudgetForm.test.tsx
+++ b/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetForm/CreateCategoryBudgetForm.test.tsx
@@ -1,0 +1,182 @@
+import { composeStories } from "@storybook/react-vite"
+import { HttpResponse, http } from "msw"
+import { describe, expect, test, vi } from "vite-plus/test"
+
+import { createCategoryHandlers } from "../../../../test/msw/handlers/categories"
+import { createCategoryBudgetHandlers } from "../../../../test/msw/handlers/categoryBudgets"
+import { server } from "../../../../test/msw/server"
+import { act, render, screen, waitFor, within } from "../../../../test/test-utils"
+import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../categoryBudgetCreateError"
+import * as stories from "./CreateCategoryBudgetForm.stories"
+
+const { Default } = composeStories(stories)
+const CATEGORY_BUDGETS_REST_URL = "*/rest/v1/category_budgets*"
+
+async function renderStory(story: React.ReactElement) {
+  return await act(async () => {
+    return render(story)
+  })
+}
+
+describe("CreateCategoryBudgetForm", () => {
+  test("カテゴリ、月、金額入力欄を表示する", async () => {
+    await renderStory(<Default />)
+
+    expect(await screen.findByRole("combobox", { name: /category/i })).toBeInTheDocument()
+    expect(screen.getByText("Month")).toBeInTheDocument()
+    expect(screen.getByRole("combobox", { name: "Year" })).toHaveTextContent("Select year")
+    expect(screen.getByRole("combobox", { name: "Month" })).toHaveTextContent("Select month")
+    expect(screen.getByRole("textbox", { name: /amount/i })).toBeInTheDocument()
+  })
+
+  test("未入力で送信するとバリデーションエラーを表示する", async () => {
+    const { user } = await renderStory(<Default />)
+
+    await user.click(screen.getByRole("button", { name: "Create" }))
+
+    expect(await screen.findByText("Category cannot be empty")).toBeInTheDocument()
+    expect(await screen.findByText("Month cannot be empty")).toBeInTheDocument()
+    expect(await screen.findByText("Amount cannot be empty")).toBeInTheDocument()
+  })
+
+  test("有効な入力で作成に成功するとonSuccessを呼ぶ", async () => {
+    const onSuccess = vi.fn()
+    const onError = vi.fn()
+
+    server.resetHandlers(...createCategoryHandlers(), ...createCategoryBudgetHandlers())
+
+    const { user } = await renderStory(<Default onSuccess={onSuccess} onError={onError} />)
+
+    await selectCategory(user, "Food")
+    await selectMonth("2026", "3", user)
+    await user.type(screen.getByRole("textbox", { name: /amount/i }), "50000")
+    await user.click(screen.getByRole("button", { name: "Create" }))
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
+
+    expect(onError).not.toHaveBeenCalled()
+  })
+
+  test("重複カテゴリ月エラー時は重複メッセージを表示する", async () => {
+    const onSuccess = vi.fn()
+    const onError = vi.fn()
+
+    server.resetHandlers(
+      ...createCategoryHandlers(),
+      ...createCategoryBudgetHandlers({
+        create: {
+          error: true,
+          errorResponse: {
+            code: POSTGRES_UNIQUE_VIOLATION_CODE,
+            message: "duplicate key value violates unique constraint",
+          },
+        },
+      }),
+    )
+
+    const { user } = await renderStory(<Default onSuccess={onSuccess} onError={onError} />)
+
+    await selectCategory(user, "Food")
+    await selectMonth("2026", "3", user)
+    await user.type(screen.getByRole("textbox", { name: /amount/i }), "50000")
+    await user.click(screen.getByRole("button", { name: "Create" }))
+
+    expect(
+      await screen.findByText("A category budget for this category and month already exists."),
+    ).toBeInTheDocument()
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  test("失敗後の再送信では前回のエラーメッセージを消して成功できる", async () => {
+    const onSuccess = vi.fn()
+    let requestCount = 0
+
+    server.resetHandlers(
+      ...createCategoryHandlers(),
+      http.post(CATEGORY_BUDGETS_REST_URL, async ({ request }) => {
+        requestCount += 1
+
+        if (requestCount === 1) {
+          return HttpResponse.json(
+            {
+              code: POSTGRES_UNIQUE_VIOLATION_CODE,
+              message: "duplicate key value violates unique constraint",
+            },
+            { status: 500 },
+          )
+        }
+
+        const requestBody = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json([{ id: 999, ...requestBody }], { status: 201 })
+      }),
+    )
+
+    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
+
+    await selectCategory(user, "Food")
+    await selectMonth("2026", "3", user)
+    await user.type(screen.getByRole("textbox", { name: /amount/i }), "50000")
+    await user.click(screen.getByRole("button", { name: "Create" }))
+
+    expect(
+      await screen.findByText("A category budget for this category and month already exists."),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Create" }))
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
+    expect(
+      screen.queryByText("A category budget for this category and month already exists."),
+    ).not.toBeInTheDocument()
+  })
+
+  test("作成失敗時は汎用メッセージを表示してonSuccessを呼ばない", async () => {
+    const onSuccess = vi.fn()
+    const onError = vi.fn()
+
+    server.resetHandlers(
+      ...createCategoryHandlers(),
+      ...createCategoryBudgetHandlers({
+        create: {
+          error: true,
+          errorResponse: { message: "Failed to create category budget." },
+        },
+      }),
+    )
+
+    const { user } = await renderStory(<Default onSuccess={onSuccess} onError={onError} />)
+
+    await selectCategory(user, "Food")
+    await selectMonth("2026", "3", user)
+    await user.type(screen.getByRole("textbox", { name: /amount/i }), "50000")
+    await user.click(screen.getByRole("button", { name: "Create" }))
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledTimes(1)
+    })
+    expect(await screen.findByText("Failed to create category budget.")).toBeInTheDocument()
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+})
+
+async function selectCategory(user: ReturnType<typeof render>["user"], name: string) {
+  await user.click(await screen.findByRole("combobox", { name: /category/i }))
+  const listbox = await screen.findByRole("listbox")
+  await waitFor(() => {
+    expect(within(listbox).queryByRole("option", { name: /loading/i })).not.toBeInTheDocument()
+  })
+  await user.click(await within(listbox).findByRole("option", { name }))
+}
+
+async function selectMonth(year: string, month: string, user: ReturnType<typeof render>["user"]) {
+  await user.click(screen.getByRole("combobox", { name: "Year" }))
+  await user.click(await screen.findByRole("option", { name: year }))
+
+  await user.click(screen.getByRole("combobox", { name: "Month" }))
+  await user.click(await screen.findByRole("option", { name: month }))
+}

--- a/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetForm/CreateCategoryBudgetForm.tsx
+++ b/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetForm/CreateCategoryBudgetForm.tsx
@@ -1,0 +1,154 @@
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons"
+import { Callout, Flex } from "@radix-ui/themes"
+import { useForm } from "@tanstack/react-form"
+import { useCallback, useState } from "react"
+
+import { CancelButton } from "../../../../components/buttons/CancelButton"
+import { SubmitButton } from "../../../../components/buttons/SubmitButton"
+import { AmountField } from "../../createMonthlyBudget/AmountField/AmountField"
+import { MonthField } from "../../createMonthlyBudget/MonthField/MonthField"
+import { toCategoryBudgetCreateErrorMessage } from "../categoryBudgetCreateError"
+import {
+  createCategoryBudgetDefaultValues,
+  mapSubmitFormValuesToCategoryBudgetWriteInput,
+} from "../categoryBudgetFormAdapters"
+import { categoryBudgetFormSubmitSchema } from "../categoryBudgetFormSchema"
+import { CategoryField } from "../CategoryField"
+import { useCreateCategoryBudget } from "../useCreateCategoryBudget"
+
+interface CreateCategoryBudgetFormProps {
+  onSuccess?: () => void
+  onError?: (error: unknown) => void
+  onCancel: () => void
+}
+
+function getErrorMessages(errors: unknown): string[] | undefined {
+  if (!Array.isArray(errors)) {
+    return undefined
+  }
+
+  const messages = errors.flatMap((error) => {
+    if (typeof error === "string") {
+      return [error]
+    }
+
+    if (
+      error &&
+      typeof error === "object" &&
+      "message" in error &&
+      typeof error.message === "string"
+    ) {
+      return [error.message]
+    }
+
+    return []
+  })
+
+  return messages.length > 0 ? messages : undefined
+}
+
+function hasErrorMessages(messages: string[] | undefined): boolean {
+  return Boolean(messages && messages.length > 0)
+}
+
+export function CreateCategoryBudgetForm({
+  onSuccess,
+  onError,
+  onCancel,
+}: CreateCategoryBudgetFormProps) {
+  const { createCategoryBudget } = useCreateCategoryBudget()
+  const defaultValues = createCategoryBudgetDefaultValues()
+  const [submitErrorMessage, setSubmitErrorMessage] = useState<string | undefined>()
+
+  const form = useForm({
+    defaultValues,
+    validators: {
+      onSubmit: categoryBudgetFormSubmitSchema,
+    },
+    onSubmit: async ({ value }) => {
+      try {
+        const parsedValue = categoryBudgetFormSubmitSchema.parse(value)
+        await createCategoryBudget(mapSubmitFormValuesToCategoryBudgetWriteInput(parsedValue))
+        onSuccess?.()
+      } catch (error) {
+        setSubmitErrorMessage(toCategoryBudgetCreateErrorMessage(error))
+        onError?.(error)
+      }
+    },
+  })
+
+  const handleCancel = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+      onCancel()
+    },
+    [onCancel],
+  )
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        setSubmitErrorMessage(undefined)
+        void form.handleSubmit()
+      }}
+    >
+      <Flex direction="column" gap="4">
+        {submitErrorMessage ? (
+          <Callout.Root aria-live="polite" role="alert" color="red" variant="surface" size="1">
+            <Callout.Icon>
+              <ExclamationTriangleIcon />
+            </Callout.Icon>
+            <Callout.Text>{submitErrorMessage}</Callout.Text>
+          </Callout.Root>
+        ) : null}
+        <Flex direction="column" gap="3">
+          <form.Field name="categoryId">
+            {(field) => {
+              const errorMessages = getErrorMessages(field.state.meta.errors)
+              return (
+                <CategoryField
+                  value={field.state.value}
+                  onChange={(categoryId) => field.handleChange(categoryId)}
+                  error={hasErrorMessages(errorMessages)}
+                  messages={errorMessages}
+                />
+              )
+            }}
+          </form.Field>
+          <form.Field name="targetMonth">
+            {(field) => {
+              const errorMessages = getErrorMessages(field.state.meta.errors)
+              return (
+                <MonthField
+                  value={field.state.value}
+                  onChange={(targetMonth) => field.handleChange(targetMonth)}
+                  error={hasErrorMessages(errorMessages)}
+                  messages={errorMessages}
+                />
+              )
+            }}
+          </form.Field>
+          <form.Field name="amount">
+            {(field) => {
+              const errorMessages = getErrorMessages(field.state.meta.errors)
+              return (
+                <AmountField
+                  value={field.state.value}
+                  onChange={(amount) => field.handleChange(amount)}
+                  error={hasErrorMessages(errorMessages)}
+                  messages={errorMessages}
+                />
+              )
+            }}
+          </form.Field>
+        </Flex>
+        <Flex gap="3" justify="end">
+          <CancelButton onClick={handleCancel} />
+          <SubmitButton>Create</SubmitButton>
+        </Flex>
+      </Flex>
+    </form>
+  )
+}

--- a/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetForm/index.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetForm/index.ts
@@ -1,0 +1,1 @@
+export { CreateCategoryBudgetForm } from "./CreateCategoryBudgetForm"

--- a/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetModal/CreateCategoryBudgetModal.stories.tsx
+++ b/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetModal/CreateCategoryBudgetModal.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { QueryClientProvider } from "@tanstack/react-query"
+
+import { createQueryClient } from "../../../../lib/queryClient"
+import { ThemeProvider } from "../../../../providers/theme/ThemeProvider"
+import { createCategoryHandlers } from "../../../../test/msw/handlers/categories"
+import { createCategoryBudgetHandlers } from "../../../../test/msw/handlers/categoryBudgets"
+import { CreateCategoryBudgetModal } from "./CreateCategoryBudgetModal"
+
+const meta = {
+  title: "Features/Budgets/CreateCategoryBudgetModal",
+  component: CreateCategoryBudgetModal,
+  parameters: {
+    layout: "centered",
+    msw: {
+      handlers: [...createCategoryHandlers(), ...createCategoryBudgetHandlers()],
+    },
+  },
+  tags: ["autodocs"],
+  decorators: (Story) => {
+    const queryClient = createQueryClient()
+
+    return (
+      <ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      </ThemeProvider>
+    )
+  },
+} satisfies Meta<typeof CreateCategoryBudgetModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetModal/CreateCategoryBudgetModal.test.tsx
+++ b/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetModal/CreateCategoryBudgetModal.test.tsx
@@ -1,6 +1,6 @@
 import { composeStories } from "@storybook/react-vite"
 import { HttpResponse, http } from "msw"
-import { describe, expect, test } from "vite-plus/test"
+import { afterEach, describe, expect, test, vi } from "vite-plus/test"
 
 import { createCategoryHandlers } from "../../../../test/msw/handlers/categories"
 import { server } from "../../../../test/msw/server"
@@ -9,6 +9,18 @@ import * as stories from "./CreateCategoryBudgetModal.stories"
 
 const { Default } = composeStories(stories)
 const CATEGORY_BUDGETS_REST_URL = "*/rest/v1/category_budgets*"
+const { mockCaptureCategoryBudgetCreateError } = vi.hoisted(() => ({
+  mockCaptureCategoryBudgetCreateError: vi.fn(),
+}))
+
+vi.mock("../../../../lib/sentry", () => ({
+  captureCategoryBudgetCreateError: mockCaptureCategoryBudgetCreateError,
+}))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  mockCaptureCategoryBudgetCreateError.mockReset()
+})
 
 async function renderStory(story: React.ReactElement) {
   return await act(async () => {
@@ -80,6 +92,11 @@ describe("CreateCategoryBudgetModal", () => {
     await user.type(within(dialog).getByRole("textbox", { name: /amount/i }), "50000")
     await user.click(within(dialog).getByRole("button", { name: "Create" }))
 
+    await waitFor(() => {
+      expect(mockCaptureCategoryBudgetCreateError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Failed to create category budget." }),
+      )
+    })
     expect(await within(dialog).findByText("Failed to create category budget.")).toBeInTheDocument()
     expect(screen.getByRole("dialog", { name: "Create category budget" })).toBeInTheDocument()
   })

--- a/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetModal/CreateCategoryBudgetModal.test.tsx
+++ b/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetModal/CreateCategoryBudgetModal.test.tsx
@@ -1,0 +1,119 @@
+import { composeStories } from "@storybook/react-vite"
+import { HttpResponse, http } from "msw"
+import { describe, expect, test } from "vite-plus/test"
+
+import { createCategoryHandlers } from "../../../../test/msw/handlers/categories"
+import { server } from "../../../../test/msw/server"
+import { act, fireEvent, render, screen, waitFor, within } from "../../../../test/test-utils"
+import * as stories from "./CreateCategoryBudgetModal.stories"
+
+const { Default } = composeStories(stories)
+const CATEGORY_BUDGETS_REST_URL = "*/rest/v1/category_budgets*"
+
+async function renderStory(story: React.ReactElement) {
+  return await act(async () => {
+    return render(story)
+  })
+}
+
+describe("CreateCategoryBudgetModal", () => {
+  test("トリガー操作でダイアログと入力欄を表示する", async () => {
+    await renderStory(<Default />)
+
+    const dialog = await openCreateCategoryBudgetModal()
+
+    expect(dialog).toBeInTheDocument()
+    expect(within(dialog).getByText("Set a category budget amount.")).toBeInTheDocument()
+    expect(within(dialog).getByRole("combobox", { name: /category/i })).toBeInTheDocument()
+    expect(within(dialog).getByRole("combobox", { name: "Month" })).toBeInTheDocument()
+    expect(within(dialog).getByRole("textbox", { name: /amount/i })).toBeInTheDocument()
+  })
+
+  test("Cancelをクリックするとダイアログを閉じる", async () => {
+    const { user } = await renderStory(<Default />)
+
+    await openCreateCategoryBudgetModal()
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+
+    expect(screen.queryByRole("dialog", { name: "Create category budget" })).not.toBeInTheDocument()
+  })
+
+  test("作成成功後にダイアログを閉じる", async () => {
+    server.resetHandlers(
+      ...createCategoryHandlers(),
+      http.post(CATEGORY_BUDGETS_REST_URL, async ({ request }) => {
+        const requestBody = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json([{ id: 999, ...requestBody }], { status: 201 })
+      }),
+    )
+    const { user, baseElement } = await renderStory(<Default />)
+
+    const body = within(baseElement)
+    const dialog = await openCreateCategoryBudgetModal()
+
+    await selectCategory(user, dialog, body)
+    await selectMonth(user, dialog, body)
+    await user.type(within(dialog).getByRole("textbox", { name: /amount/i }), "50000")
+    await user.click(within(dialog).getByRole("button", { name: "Create" }))
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", { name: "Create category budget" }),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  test("作成失敗時はダイアログを閉じない", async () => {
+    server.resetHandlers(
+      ...createCategoryHandlers(),
+      http.post(CATEGORY_BUDGETS_REST_URL, () => {
+        return HttpResponse.json({ message: "Failed to create category budget." }, { status: 500 })
+      }),
+    )
+    const { user, baseElement } = await renderStory(<Default />)
+
+    const body = within(baseElement)
+    const dialog = await openCreateCategoryBudgetModal()
+
+    await selectCategory(user, dialog, body)
+    await selectMonth(user, dialog, body)
+    await user.type(within(dialog).getByRole("textbox", { name: /amount/i }), "50000")
+    await user.click(within(dialog).getByRole("button", { name: "Create" }))
+
+    expect(await within(dialog).findByText("Failed to create category budget.")).toBeInTheDocument()
+    expect(screen.getByRole("dialog", { name: "Create category budget" })).toBeInTheDocument()
+  })
+})
+
+async function openCreateCategoryBudgetModal() {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Create category budget" }))
+  })
+
+  return await screen.findByRole("dialog", { name: "Create category budget" })
+}
+
+async function selectCategory(
+  user: ReturnType<typeof render>["user"],
+  dialog: HTMLElement,
+  body: ReturnType<typeof within>,
+) {
+  await user.click(within(dialog).getByRole("combobox", { name: /category/i }))
+  const listbox = await body.findByRole("listbox")
+  await waitFor(() => {
+    expect(within(listbox).queryByRole("option", { name: /loading/i })).not.toBeInTheDocument()
+  })
+  await user.click(await within(listbox).findByRole("option", { name: "Food" }))
+}
+
+async function selectMonth(
+  user: ReturnType<typeof render>["user"],
+  dialog: HTMLElement,
+  body: ReturnType<typeof within>,
+) {
+  await user.click(within(dialog).getByRole("combobox", { name: "Year" }))
+  await user.click(await body.findByRole("option", { name: "2026" }))
+
+  await user.click(within(dialog).getByRole("combobox", { name: "Month" }))
+  await user.click(await body.findByRole("option", { name: "3" }))
+}

--- a/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetModal/CreateCategoryBudgetModal.tsx
+++ b/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetModal/CreateCategoryBudgetModal.tsx
@@ -1,0 +1,37 @@
+import { Button } from "@radix-ui/themes"
+import { useCallback, type ReactElement } from "react"
+
+import { ResponsiveOverlay } from "../../../../components/overlay/ResponsiveOverlay"
+import { useDialog } from "../../../../utils/useDialog"
+import { CreateCategoryBudgetForm } from "../CreateCategoryBudgetForm"
+
+interface CreateCategoryBudgetModalProps {
+  trigger?: ReactElement
+}
+
+export function CreateCategoryBudgetModal({
+  trigger = <Button>Create category budget</Button>,
+}: CreateCategoryBudgetModalProps) {
+  const { open, closeDialog, onOpenChange } = useDialog()
+
+  const handleSuccess = useCallback(() => {
+    closeDialog()
+  }, [closeDialog])
+
+  const handleCancel = useCallback(() => {
+    closeDialog()
+  }, [closeDialog])
+
+  return (
+    <ResponsiveOverlay
+      open={open}
+      onOpenChange={onOpenChange}
+      dismissible={false}
+      trigger={trigger}
+      title="Create category budget"
+      description="Set a category budget amount."
+    >
+      <CreateCategoryBudgetForm onSuccess={handleSuccess} onCancel={handleCancel} />
+    </ResponsiveOverlay>
+  )
+}

--- a/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetModal/CreateCategoryBudgetModal.tsx
+++ b/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetModal/CreateCategoryBudgetModal.tsx
@@ -2,6 +2,7 @@ import { Button } from "@radix-ui/themes"
 import { useCallback, type ReactElement } from "react"
 
 import { ResponsiveOverlay } from "../../../../components/overlay/ResponsiveOverlay"
+import { captureCategoryBudgetCreateError } from "../../../../lib/sentry"
 import { useDialog } from "../../../../utils/useDialog"
 import { CreateCategoryBudgetForm } from "../CreateCategoryBudgetForm"
 
@@ -18,6 +19,10 @@ export function CreateCategoryBudgetModal({
     closeDialog()
   }, [closeDialog])
 
+  const handleError = useCallback((error: unknown) => {
+    captureCategoryBudgetCreateError(error)
+  }, [])
+
   const handleCancel = useCallback(() => {
     closeDialog()
   }, [closeDialog])
@@ -31,7 +36,11 @@ export function CreateCategoryBudgetModal({
       title="Create category budget"
       description="Set a category budget amount."
     >
-      <CreateCategoryBudgetForm onSuccess={handleSuccess} onCancel={handleCancel} />
+      <CreateCategoryBudgetForm
+        onSuccess={handleSuccess}
+        onError={handleError}
+        onCancel={handleCancel}
+      />
     </ResponsiveOverlay>
   )
 }

--- a/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetModal/index.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetModal/index.ts
@@ -1,0 +1,1 @@
+export { CreateCategoryBudgetModal } from "./CreateCategoryBudgetModal"

--- a/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormAdapters.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormAdapters.ts
@@ -1,0 +1,23 @@
+import type { CategoryBudgetWriteInput } from "./categoryBudgetFormMappers"
+import type {
+  CategoryBudgetFormSubmitValues,
+  CategoryBudgetFormValues,
+} from "./categoryBudgetFormSchema"
+
+export function createCategoryBudgetDefaultValues(): CategoryBudgetFormValues {
+  return {
+    categoryId: "",
+    targetMonth: undefined,
+    amount: undefined,
+  }
+}
+
+export function mapSubmitFormValuesToCategoryBudgetWriteInput(
+  value: CategoryBudgetFormSubmitValues,
+): CategoryBudgetWriteInput {
+  return {
+    categoryId: Number.parseInt(value.categoryId, 10),
+    targetMonth: value.targetMonth,
+    amount: value.amount,
+  }
+}

--- a/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormSchema.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormSchema.ts
@@ -1,0 +1,49 @@
+import * as z from "zod"
+
+import {
+  monthlyBudgetAmountFieldSchema,
+  targetMonthFieldSchema,
+} from "../createMonthlyBudget/monthlyBudgetFormSchema"
+
+export const categoryBudgetCategoryFieldSchema = z
+  .string({
+    error: (iss) => {
+      if (iss.input === undefined || iss.input === null || iss.input === "") {
+        return "Category cannot be empty"
+      }
+      return "Category is invalid"
+    },
+  })
+  .superRefine((value, context) => {
+    if (value === "") {
+      context.addIssue({
+        code: "custom",
+        message: "Category cannot be empty",
+      })
+      return
+    }
+
+    if (!/^\d+$/.test(value)) {
+      context.addIssue({
+        code: "custom",
+        message: "Category is invalid",
+      })
+    }
+  })
+
+const baseSchema = z.object({
+  categoryId: categoryBudgetCategoryFieldSchema,
+  targetMonth: targetMonthFieldSchema,
+  amount: monthlyBudgetAmountFieldSchema,
+})
+
+export const categoryBudgetFormSchema = baseSchema.partial()
+
+export const categoryBudgetFormSubmitSchema = baseSchema.required({
+  categoryId: true,
+  targetMonth: true,
+  amount: true,
+})
+
+export type CategoryBudgetFormValues = z.infer<typeof categoryBudgetFormSchema>
+export type CategoryBudgetFormSubmitValues = z.infer<typeof categoryBudgetFormSubmitSchema>

--- a/apps/web/src/features/budgets/listCategoryBudget/CategoryBudgetList/CategoryBudgetList.test.tsx
+++ b/apps/web/src/features/budgets/listCategoryBudget/CategoryBudgetList/CategoryBudgetList.test.tsx
@@ -27,7 +27,7 @@ describe("CategoryBudgetList", () => {
     await renderCategoryBudgetList(<Default />)
 
     expect(await screen.findByText("Category Budgets")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Add category budget" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Add category budget" })).toBeEnabled()
     expect(await screen.findByText("Food ￥50,000")).toBeInTheDocument()
     expect(await screen.findByText("Daily Necessities ￥12,000")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Food category budget menu" })).toBeDisabled()
@@ -42,7 +42,7 @@ describe("CategoryBudgetList", () => {
 
     await renderCategoryBudgetList(<Empty />)
 
-    expect(await screen.findByRole("button", { name: "Create category budget" })).toBeDisabled()
+    expect(await screen.findByRole("button", { name: "Create category budget" })).toBeEnabled()
   })
 
   test("取得中はスケルトンを表示する", async () => {

--- a/apps/web/src/features/budgets/listCategoryBudget/CategoryBudgetList/CategoryBudgetList.tsx
+++ b/apps/web/src/features/budgets/listCategoryBudget/CategoryBudgetList/CategoryBudgetList.tsx
@@ -4,6 +4,7 @@ import { Suspense, use } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 
 import { toCurrency } from "../../../../utils/toCurrency"
+import { CreateCategoryBudgetModal } from "../../createCategoryBudget/CreateCategoryBudgetModal"
 import type { CategoryBudget } from "../../types"
 import { useCategoryBudgets } from "../useCategoryBudgets"
 
@@ -16,9 +17,13 @@ export function CategoryBudgetList() {
         <Text as="p" size="4" weight="medium">
           Category Budgets
         </Text>
-        <Button aria-label="Add category budget" disabled size="2" variant="ghost">
-          <PlusIcon />
-        </Button>
+        <CreateCategoryBudgetModal
+          trigger={
+            <Button aria-label="Add category budget" size="2" variant="ghost">
+              <PlusIcon />
+            </Button>
+          }
+        />
       </Flex>
       <ErrorBoundary
         fallback={
@@ -40,9 +45,13 @@ function CategoryBudgetListContent({ promise }: { promise: Promise<CategoryBudge
 
   if (categoryBudgets.length === 0) {
     return (
-      <Button disabled variant="soft">
-        <PlusIcon /> Create category budget
-      </Button>
+      <CreateCategoryBudgetModal
+        trigger={
+          <Button variant="soft">
+            <PlusIcon /> Create category budget
+          </Button>
+        }
+      />
     )
   }
 

--- a/apps/web/src/lib/sentry.test.ts
+++ b/apps/web/src/lib/sentry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from "vite-plus/test"
 
 import {
   captureAuthCallbackError,
+  captureCategoryBudgetCreateError,
   captureMonthlyBudgetCreateError,
   captureSupabaseSessionError,
 } from "./sentry"
@@ -73,5 +74,22 @@ describe("captureMonthlyBudgetCreateError", () => {
       message: "duplicate key value violates unique constraint",
     })
     expect(mockCaptureMessage).toHaveBeenCalledWith("Monthly budget creation failed", "error")
+  })
+})
+
+describe("captureCategoryBudgetCreateError", () => {
+  test("Sentry にカテゴリ別予算作成失敗を送る", () => {
+    captureCategoryBudgetCreateError({
+      code: "23505",
+      message: "duplicate key value violates unique constraint",
+    })
+
+    expect(mockSetTag).toHaveBeenCalledWith("feature", "budgets")
+    expect(mockSetContext).toHaveBeenCalledWith("category_budget_create_error", {
+      code: "23505",
+      name: undefined,
+      message: "duplicate key value violates unique constraint",
+    })
+    expect(mockCaptureMessage).toHaveBeenCalledWith("Category budget creation failed", "error")
   })
 })

--- a/apps/web/src/lib/sentry.ts
+++ b/apps/web/src/lib/sentry.ts
@@ -52,6 +52,19 @@ export function captureMonthlyBudgetCreateError(error: unknown) {
   })
 }
 
+export function captureCategoryBudgetCreateError(error: unknown) {
+  Sentry.withScope((scope) => {
+    scope.setTag("feature", "budgets")
+    scope.setContext("category_budget_create_error", {
+      code: getErrorCode(error),
+      name: error instanceof Error ? error.name : undefined,
+      message: error instanceof Error ? error.message : getErrorMessage(error),
+    })
+
+    Sentry.captureMessage("Category budget creation failed", "error")
+  })
+}
+
 function getErrorCode(error: unknown): string | undefined {
   if (!error || typeof error !== "object" || !("code" in error)) {
     return undefined

--- a/apps/web/src/test/msw/handlers/categoryBudgets.ts
+++ b/apps/web/src/test/msw/handlers/categoryBudgets.ts
@@ -1,4 +1,5 @@
 import { type DelayMode, HttpResponse, delay, http } from "msw"
+import * as z from "zod"
 
 import type { CategoryBudgetRow } from "../../../features/budgets/types"
 import { categories } from "../../data/categories"
@@ -13,15 +14,32 @@ interface CategoryBudgetResponseRow extends CategoryBudgetRow {
   }
 }
 
-interface GetCategoryBudgetsOptions {
-  response?: CategoryBudgetResponseRow[]
+interface BaseOptions {
   error?: boolean
   durationOrMode?: number | DelayMode | undefined
 }
 
+interface GetCategoryBudgetsOptions extends BaseOptions {
+  response?: CategoryBudgetResponseRow[]
+}
+
+interface CreateCategoryBudgetOptions extends BaseOptions {
+  response?: CategoryBudgetResponseRow
+  errorResponse?: unknown
+}
+
 interface CreateCategoryBudgetHandlersOptions {
   get?: GetCategoryBudgetsOptions
+  create?: CreateCategoryBudgetOptions
 }
+
+const createCategoryBudgetBodySchema = z.object({
+  amount: z.number(),
+  category_id: z.number(),
+  effective_from: z.string(),
+})
+
+type CreateCategoryBudgetBody = z.infer<typeof createCategoryBudgetBodySchema>
 
 const defaultCategoryBudgetRows: CategoryBudgetResponseRow[] = categoryBudgets.map((row) => {
   const category = categories.find((candidate) => candidate.id === row.category_id)
@@ -37,7 +55,10 @@ const defaultCategoryBudgetRows: CategoryBudgetResponseRow[] = categoryBudgets.m
 
 export function createCategoryBudgetHandlers({
   get = {},
+  create = {},
 }: CreateCategoryBudgetHandlersOptions = {}) {
+  let categoryBudgetRows = [...(get.response ?? defaultCategoryBudgetRows)]
+
   const categoryBudgetsHandler = http.get(REST_URL, async () => {
     await delay(get.durationOrMode)
 
@@ -45,10 +66,58 @@ export function createCategoryBudgetHandlers({
       return HttpResponse.json({ message: "Failed to fetch category budgets." }, { status: 500 })
     }
 
-    return HttpResponse.json(get.response ?? defaultCategoryBudgetRows)
+    return HttpResponse.json(categoryBudgetRows)
   })
 
-  return [categoryBudgetsHandler]
+  const createCategoryBudgetHandler = http.post(REST_URL, async ({ request }) => {
+    await delay(create.durationOrMode)
+
+    if (create.error) {
+      return HttpResponse.json(
+        create.errorResponse ?? { message: "Failed to create category budget." },
+        { status: 500 },
+      )
+    }
+
+    if (create.response) {
+      categoryBudgetRows = [...categoryBudgetRows, create.response]
+      return HttpResponse.json([create.response], { status: 201 })
+    }
+
+    const body = await request.json()
+    const parsedBody = createCategoryBudgetBodySchema.parse(body)
+    const newRow = buildCategoryBudgetRow(parsedBody, categoryBudgetRows)
+    categoryBudgetRows = [...categoryBudgetRows, newRow]
+
+    return HttpResponse.json([newRow], { status: 201 })
+  })
+
+  return [categoryBudgetsHandler, createCategoryBudgetHandler]
+}
+
+function buildCategoryBudgetRow(
+  body: CreateCategoryBudgetBody,
+  rows: CategoryBudgetResponseRow[],
+): CategoryBudgetResponseRow {
+  const [year, month] = body.effective_from.split("-").map((value) => Number.parseInt(value, 10))
+  const now = new Date().toISOString()
+  const category = categories.find((candidate) => candidate.id === body.category_id)
+
+  return {
+    id: Math.max(0, ...rows.map((row) => row.id)) + 1,
+    amount: body.amount,
+    category_id: body.category_id,
+    created_at: now,
+    effective_from: body.effective_from,
+    effective_month: month,
+    effective_year: year,
+    updated_at: now,
+    user_id: 100,
+    category: {
+      id: body.category_id,
+      name: category?.name ?? "Unknown",
+    },
+  }
 }
 
 export const categoryBudgetHandlers = createCategoryBudgetHandlers()


### PR DESCRIPTION
## 関連Issue

- closes #1199

## 変更内容

- カテゴリ別予算の作成フォームとモーダルを追加
- 予算設定画面のカテゴリ別予算一覧から作成モーダルを開けるように変更
- 作成フォームの unit/story と MSW handler を追加し、Web コンポーネント構成ルールを文書化

## 動作確認

- [x] `task web:lint`
- [x] `task web:format-check`
- [x] `task web:typecheck`
- [x] `task web:test-unit`
- [x] `task web:test-storybook`

## 補足

`task web:test-storybook` では既存の Fetch Error ストーリー由来の `console.error` が出ますが、テストは pass しています。
