### PR TITLE
支払い一覧のカテゴリ検索パラメータを追加

### DIFF
--- a/apps/web/src/features/payments/listPayment/paymentsSearchSchema.test.ts
+++ b/apps/web/src/features/payments/listPayment/paymentsSearchSchema.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vite-plus/test"
+
+import { PAYMENT_SEARCH_CATEGORY_NONE_VALUE, paymentsSearchSchema } from "./paymentsSearchSchema"
+
+describe("paymentsSearchSchema", () => {
+  test("年月のみの URL search を扱える", () => {
+    const result = paymentsSearchSchema.parse({ year: "2025", month: "5" })
+
+    expect(result).toEqual({ year: "2025", month: "5" })
+  })
+
+  test("登録済みカテゴリ ID の URL search を扱える", () => {
+    const result = paymentsSearchSchema.parse({ category: "10" })
+
+    expect(result).toEqual({ category: "10" })
+  })
+
+  test.each(["0", "-1", "1.2"])("数値として読めるカテゴリ条件 %s を扱える", (category) => {
+    const result = paymentsSearchSchema.parse({ category })
+
+    expect(result).toEqual({ category })
+  })
+
+  test("年月と登録済みカテゴリ ID を併用できる", () => {
+    const result = paymentsSearchSchema.parse({ year: "2025", month: "5", category: "10" })
+
+    expect(result).toEqual({ year: "2025", month: "5", category: "10" })
+  })
+
+  test("カテゴリ未設定の URL search を扱える", () => {
+    const result = paymentsSearchSchema.parse({
+      category: PAYMENT_SEARCH_CATEGORY_NONE_VALUE,
+    })
+
+    expect(result).toEqual({ category: PAYMENT_SEARCH_CATEGORY_NONE_VALUE })
+  })
+
+  test.each(["abc", ""])("不正なカテゴリ条件 %s は条件なしにする", (category) => {
+    const result = paymentsSearchSchema.parse({ year: "2025", month: "5", category })
+
+    expect(result).toEqual({ year: "2025", month: "5", category: undefined })
+  })
+})

--- a/apps/web/src/features/payments/listPayment/paymentsSearchSchema.ts
+++ b/apps/web/src/features/payments/listPayment/paymentsSearchSchema.ts
@@ -1,6 +1,15 @@
 import { z } from "zod"
 
+export const PAYMENT_SEARCH_CATEGORY_NONE_VALUE = "none"
+
+const paymentSearchCategoryIdSchema = z.coerce.string().pipe(z.templateLiteral([z.number()]))
+const paymentSearchCategorySchema = z
+  .union([z.literal(PAYMENT_SEARCH_CATEGORY_NONE_VALUE), paymentSearchCategoryIdSchema])
+  .optional()
+  .catch(undefined)
+
 export const paymentsSearchSchema = z.object({
   year: z.coerce.string().optional(),
   month: z.coerce.string().optional(),
+  category: paymentSearchCategorySchema,
 })

--- a/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.test.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.test.tsx
@@ -5,7 +5,10 @@ import type { SupabaseSessionState } from "../../../providers/supabase/SupabaseS
 import { mockSession } from "../../../test/data/supabaseSession"
 import { renderWithRouter as renderWithTestRouter } from "../../../test/helpers/renderWithRouter"
 import { screen, waitFor } from "../../../test/test-utils"
-import { paymentsSearchSchema } from "../../payments/listPayment/paymentsSearchSchema"
+import {
+  PAYMENT_SEARCH_CATEGORY_NONE_VALUE,
+  paymentsSearchSchema,
+} from "../../payments/listPayment/paymentsSearchSchema"
 import { MonthSelector } from "./MonthSelector"
 
 const mockSessionState: SupabaseSessionState = {
@@ -109,7 +112,9 @@ describe("MonthSelector", () => {
   })
 
   test("年月を初期化してもカテゴリ条件を保持する", async () => {
-    const { router } = renderMonthSelector("/payments?category=none")
+    const { router } = renderMonthSelector(
+      `/payments?category=${PAYMENT_SEARCH_CATEGORY_NONE_VALUE}`,
+    )
 
     await waitFor(() => {
       const { year, month, category } = router.state.location.search as {
@@ -119,7 +124,7 @@ describe("MonthSelector", () => {
       }
       expect(year).toMatch(/\d{4}/)
       expect(month).toMatch(/\d{1,2}/)
-      expect(category).toBe("none")
+      expect(category).toBe(PAYMENT_SEARCH_CATEGORY_NONE_VALUE)
     })
   })
 })

--- a/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.test.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.test.tsx
@@ -83,4 +83,43 @@ describe("MonthSelector", () => {
       expect(month).toBe("6")
     })
   })
+
+  test("年月を選択してもカテゴリ条件を保持する", async () => {
+    const { router, user } = renderMonthSelector("/payments?year=2025&month=5&category=10")
+
+    await waitFor(() => {
+      expect(screen.getByText("5")).toBeInTheDocument()
+    })
+
+    await user.click(screen.getByRole("combobox", { name: "Month" }))
+
+    const juneOption = await screen.findByRole("option", { name: "6" })
+    await user.click(juneOption)
+
+    await waitFor(() => {
+      const { year, month, category } = router.state.location.search as {
+        year?: string
+        month?: string
+        category?: string
+      }
+      expect(year).toBe("2025")
+      expect(month).toBe("6")
+      expect(category).toBe("10")
+    })
+  })
+
+  test("年月を初期化してもカテゴリ条件を保持する", async () => {
+    const { router } = renderMonthSelector("/payments?category=none")
+
+    await waitFor(() => {
+      const { year, month, category } = router.state.location.search as {
+        year?: string
+        month?: string
+        category?: string
+      }
+      expect(year).toMatch(/\d{4}/)
+      expect(month).toMatch(/\d{1,2}/)
+      expect(category).toBe("none")
+    })
+  })
 })

--- a/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.tsx
@@ -1,12 +1,12 @@
-import { useNavigate, useSearch } from "@tanstack/react-router"
+import { useLocation, useNavigate } from "@tanstack/react-router"
 import { useCallback, useEffect } from "react"
 
 import { MonthPicker } from "../../../components/inputs/MonthPicker"
 import { useSupabaseSession } from "../../../providers/supabase/useSupabaseSession"
 
 export function MonthSelector() {
-  const { year: yearParam, month: monthParam } = useSearch({
-    from: "/authenticated/payments",
+  const { year: yearParam, month: monthParam } = useLocation({
+    select: (location) => location.search,
   })
   const navigate = useNavigate({ from: "/payments" })
   const { session } = useSupabaseSession()

--- a/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.tsx
@@ -8,7 +8,7 @@ export function MonthSelector() {
   const { year: yearParam, month: monthParam } = useSearch({
     from: "/authenticated/payments",
   })
-  const navigate = useNavigate()
+  const navigate = useNavigate({ from: "/payments" })
   const { session } = useSupabaseSession()
 
   // 現在選択されている年月、またはnullの場合は今月
@@ -22,7 +22,10 @@ export function MonthSelector() {
       if (date) {
         const year = date.getFullYear().toString()
         const month = (date.getMonth() + 1).toString()
-        void navigate({ to: "/payments", search: { year, month } })
+        void navigate({
+          to: "/payments",
+          search: (prev) => ({ ...prev, year, month }),
+        })
       }
     },
     [navigate],
@@ -36,7 +39,11 @@ export function MonthSelector() {
       const now = new Date()
       const year = now.getFullYear().toString()
       const month = (now.getMonth() + 1).toString()
-      void navigate({ to: "/payments", search: { year, month }, replace: true })
+      void navigate({
+        to: "/payments",
+        search: (prev) => ({ ...prev, year, month }),
+        replace: true,
+      })
     }
   }, [session, yearParam, monthParam, navigate])
 

--- a/apps/web/src/utils/useDateRange.tsx
+++ b/apps/web/src/utils/useDateRange.tsx
@@ -1,9 +1,9 @@
-import { useSearch } from "@tanstack/react-router"
+import { useLocation } from "@tanstack/react-router"
 import { endOfMonth, startOfMonth } from "date-fns"
 
 export function useDateRange() {
-  const { year: yearParam, month: monthParam } = useSearch({
-    from: "/authenticated/payments",
+  const { year: yearParam, month: monthParam } = useLocation({
+    select: (location) => location.search,
   })
 
   const date = parseDateParam(yearParam, monthParam)


### PR DESCRIPTION
## 関連Issue

- closes #1201

## 変更内容

- 支払い一覧の URL search schema にカテゴリ条件を追加
- カテゴリ未設定の値と数値として読めるカテゴリ条件を扱えるようにした
- 年月変更時に既存のカテゴリ条件を保持

## 動作確認

- [x] task web:lint
- [x] task web:format-check
- [x] task web:typecheck
- [x] task web:test-unit
- [x] task web:test-storybook