### PR TITLE
支払い一覧取得でカテゴリ条件を扱う

### DIFF
--- a/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
@@ -1,8 +1,15 @@
 import { composeStories } from "@storybook/react-vite"
+import { createRoute } from "@tanstack/react-router"
+import { HttpResponse, http } from "msw"
 import { describe, expect, test } from "vite-plus/test"
 
 import { createQueryClient } from "../../../../lib/queryClient"
+import { renderWithRouter } from "../../../../test/helpers/renderWithRouter"
+import { createCategoryHandlers } from "../../../../test/msw/handlers/categories"
+import { server } from "../../../../test/msw/server"
 import { render, screen, waitFor, within } from "../../../../test/test-utils"
+import { paymentsSearchSchema } from "../paymentsSearchSchema"
+import { PaymentList } from "./PaymentList"
 import * as stories from "./PaymentList.stories"
 
 const { Default, Loading } = composeStories(stories)
@@ -11,6 +18,28 @@ function renderStory() {
   const queryClient = createQueryClient()
 
   return render(<Default />, { queryClient })
+}
+
+function renderPaymentList(initialEntry: string) {
+  return renderWithRouter(
+    initialEntry,
+    (root) => {
+      const authenticatedRoute = createRoute({
+        getParentRoute: () => root,
+        id: "authenticated",
+      })
+
+      const paymentsRoute = createRoute({
+        getParentRoute: () => authenticatedRoute,
+        path: "/payments",
+        component: PaymentList,
+        validateSearch: paymentsSearchSchema,
+      })
+
+      return [authenticatedRoute.addChildren([paymentsRoute])]
+    },
+    { queryClient: createQueryClient() },
+  )
 }
 
 describe("PaymentList", () => {
@@ -97,4 +126,62 @@ describe("PaymentList", () => {
 
     expect(await screen.findAllByLabelText("loading-payment-item")).toHaveLength(3)
   })
+
+  test("URL searchの登録済みカテゴリIDを一覧取得条件に反映する", async () => {
+    const requestCapture: { url: URL | null } = { url: null }
+    server.resetHandlers(
+      http.get("*/rest/v1/payments*", ({ request }) => {
+        requestCapture.url = new URL(request.url)
+
+        return HttpResponse.json([])
+      }),
+      ...createCategoryHandlers(),
+    )
+
+    renderPaymentList("/payments?year=2025&month=6&category=10")
+
+    await waitFor(() => {
+      expect(requestCapture.url?.searchParams.get("category_id")).toBe("eq.10")
+    })
+  })
+
+  test("URL searchのカテゴリ未設定を一覧取得条件に反映する", async () => {
+    const requestCapture: { url: URL | null } = { url: null }
+    server.resetHandlers(
+      http.get("*/rest/v1/payments*", ({ request }) => {
+        requestCapture.url = new URL(request.url)
+
+        return HttpResponse.json([])
+      }),
+      ...createCategoryHandlers(),
+    )
+
+    renderPaymentList("/payments?year=2025&month=6&category=none")
+
+    await waitFor(() => {
+      expect(requestCapture.url?.searchParams.get("category_id")).toBe("is.null")
+    })
+  })
+
+  test.each(["0", "-1", "1.2", "abc"])(
+    "URL searchの不正カテゴリ %s は一覧取得条件に反映しない",
+    async (category) => {
+      const requestCapture: { url: URL | null } = { url: null }
+      server.resetHandlers(
+        http.get("*/rest/v1/payments*", ({ request }) => {
+          requestCapture.url = new URL(request.url)
+
+          return HttpResponse.json([])
+        }),
+        ...createCategoryHandlers(),
+      )
+
+      renderPaymentList(`/payments?year=2025&month=6&category=${category}`)
+
+      await waitFor(() => {
+        expect(requestCapture.url).not.toBeNull()
+        expect(requestCapture.url?.searchParams.has("category_id")).toBe(false)
+      })
+    },
+  )
 })

--- a/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.tsx
@@ -9,10 +9,12 @@ import { useCategories } from "../../../categories/listCategory/useCategories"
 import { DeletePaymentModal } from "../../deletePayment/DeletePaymentModal"
 import { PaymentDetailsOverlay, usePaymentDetailsState } from "../../paymentDetails"
 import { PaymentItem } from "../PaymentItem"
+import { useCategoryId } from "../useCategoryId"
 import { usePayments } from "../usePayments"
 
 export const PaymentList = memo(function PaymentList() {
-  const { promise: promisePayments } = usePayments()
+  const categoryId = useCategoryId()
+  const { promise: promisePayments } = usePayments({ categoryId })
   const { promise: promiseCategories } = useCategories()
   const { selectedPaymentId, openPaymentDetails, closePaymentDetails, onOpenChange } =
     usePaymentDetailsState()

--- a/apps/web/src/features/payments/listPayment/fetchPayments.test.ts
+++ b/apps/web/src/features/payments/listPayment/fetchPayments.test.ts
@@ -1,5 +1,7 @@
+import { HttpResponse, http } from "msw"
 import { describe, expect, it, vi } from "vite-plus/test"
 
+import { server } from "../../../test/msw/server"
 import { supabaseTestClient } from "../../../test/utils/createSupabaseTestClient"
 import { fetchPayments } from "./fetchPayments"
 
@@ -50,5 +52,69 @@ describe("fetchPayments", () => {
     const payments = await fetchPayments([new Date("2025-04-01"), new Date("2025-05-31")])
 
     expect(payments).toHaveLength(1) // id:3
+  })
+
+  it("登録済みカテゴリIDを指定するとcategory_idのeq条件を送る", async () => {
+    const requestCapture: { url: URL | null } = { url: null }
+    server.use(
+      http.get("*/rest/v1/payments*", ({ request }) => {
+        requestCapture.url = new URL(request.url)
+
+        return HttpResponse.json([])
+      }),
+    )
+
+    await fetchPayments([null, null], { categoryId: 10 })
+
+    expect(requestCapture.url?.searchParams.get("category_id")).toBe("eq.10")
+  })
+
+  it("カテゴリ未設定を指定するとcategory_idのis null条件を送る", async () => {
+    const requestCapture: { url: URL | null } = { url: null }
+    server.use(
+      http.get("*/rest/v1/payments*", ({ request }) => {
+        requestCapture.url = new URL(request.url)
+
+        return HttpResponse.json([])
+      }),
+    )
+
+    await fetchPayments([null, null], { categoryId: null })
+
+    expect(requestCapture.url?.searchParams.get("category_id")).toBe("is.null")
+  })
+
+  it("年月条件とカテゴリ条件を併用する", async () => {
+    const requestCapture: { url: URL | null } = { url: null }
+    server.use(
+      http.get("*/rest/v1/payments*", ({ request }) => {
+        requestCapture.url = new URL(request.url)
+
+        return HttpResponse.json([])
+      }),
+    )
+
+    await fetchPayments([new Date("2025-04-01"), new Date("2025-04-30")], { categoryId: 10 })
+
+    expect(requestCapture.url?.searchParams.getAll("date")).toEqual([
+      "gte.2025-04-01",
+      "lte.2025-04-30",
+    ])
+    expect(requestCapture.url?.searchParams.get("category_id")).toBe("eq.10")
+  })
+
+  it("カテゴリ条件なしではcategory_id条件を送らない", async () => {
+    const requestCapture: { url: URL | null } = { url: null }
+    server.use(
+      http.get("*/rest/v1/payments*", ({ request }) => {
+        requestCapture.url = new URL(request.url)
+
+        return HttpResponse.json([])
+      }),
+    )
+
+    await fetchPayments([null, null])
+
+    expect(requestCapture.url?.searchParams.has("category_id")).toBe(false)
   })
 })

--- a/apps/web/src/features/payments/listPayment/fetchPayments.ts
+++ b/apps/web/src/features/payments/listPayment/fetchPayments.ts
@@ -3,9 +3,14 @@ import { format } from "date-fns"
 import { getSupabaseClient } from "../../../lib/supabase"
 import type { Payment } from "../../../types/payment"
 
-export async function fetchPayments([startDate, endDate]: [Date | null, Date | null]): Promise<
-  Payment[]
-> {
+interface FetchPaymentsOptions {
+  categoryId?: number | null
+}
+
+export async function fetchPayments(
+  [startDate, endDate]: [Date | null, Date | null],
+  { categoryId }: FetchPaymentsOptions = {},
+): Promise<Payment[]> {
   const supabase = getSupabaseClient()
   let query = supabase
     .from("payments")
@@ -18,6 +23,12 @@ export async function fetchPayments([startDate, endDate]: [Date | null, Date | n
   }
   if (endDate) {
     query = query.lte("date", format(endDate, "yyyy-MM-dd"))
+  }
+  if (typeof categoryId === "number") {
+    query = query.eq("category_id", categoryId)
+  }
+  if (categoryId === null) {
+    query = query.is("category_id", null)
   }
 
   const { data, error } = await query

--- a/apps/web/src/features/payments/listPayment/paymentCategorySearch.test.ts
+++ b/apps/web/src/features/payments/listPayment/paymentCategorySearch.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vite-plus/test"
+
+import { toPaymentCategoryId } from "./paymentCategorySearch"
+import { PAYMENT_SEARCH_CATEGORY_NONE_VALUE } from "./paymentsSearchSchema"
+
+describe("toPaymentCategoryId", () => {
+  test("登録済みカテゴリIDのURL searchをnumberに変換する", () => {
+    expect(toPaymentCategoryId("10")).toBe(10)
+  })
+
+  test("カテゴリ未設定のURL searchをnullに変換する", () => {
+    expect(toPaymentCategoryId(PAYMENT_SEARCH_CATEGORY_NONE_VALUE)).toBeNull()
+  })
+
+  test.each([undefined, "0", "-1", "1.2", "abc"])(
+    "カテゴリ条件に使わないURL search %s はundefinedに変換する",
+    (categorySearch) => {
+      expect(toPaymentCategoryId(categorySearch)).toBeUndefined()
+    },
+  )
+})

--- a/apps/web/src/features/payments/listPayment/paymentCategorySearch.ts
+++ b/apps/web/src/features/payments/listPayment/paymentCategorySearch.ts
@@ -1,0 +1,18 @@
+import { PAYMENT_SEARCH_CATEGORY_NONE_VALUE } from "./paymentsSearchSchema"
+
+export function toPaymentCategoryId(categorySearch?: string): number | null | undefined {
+  if (categorySearch === PAYMENT_SEARCH_CATEGORY_NONE_VALUE) {
+    return null
+  }
+  if (categorySearch === undefined) {
+    return undefined
+  }
+
+  const categoryId = Number(categorySearch)
+
+  if (!Number.isInteger(categoryId) || categoryId <= 0) {
+    return undefined
+  }
+
+  return categoryId
+}

--- a/apps/web/src/features/payments/listPayment/useCategoryId.test.tsx
+++ b/apps/web/src/features/payments/listPayment/useCategoryId.test.tsx
@@ -1,0 +1,64 @@
+import { createRoute, RouterProvider } from "@tanstack/react-router"
+import { renderHook } from "@testing-library/react"
+import type { PropsWithChildren, ReactNode } from "react"
+import { beforeEach, describe, expect, test, vi } from "vite-plus/test"
+
+import { createTestRouter } from "../../../test/helpers/createTestRouter"
+import { waitFor } from "../../../test/test-utils"
+import { toPaymentCategoryId } from "./paymentCategorySearch"
+import { paymentsSearchSchema } from "./paymentsSearchSchema"
+import { useCategoryId } from "./useCategoryId"
+
+vi.mock("./paymentCategorySearch", () => ({
+  toPaymentCategoryId: vi.fn(() => 10),
+}))
+
+function renderUseCategoryId(initialEntry: string) {
+  let routeChildren: ReactNode = null
+  const router = createTestRouter(initialEntry, (root) => {
+    const authenticatedRoute = createRoute({
+      getParentRoute: () => root,
+      id: "authenticated",
+    })
+
+    const paymentsRoute = createRoute({
+      getParentRoute: () => authenticatedRoute,
+      path: "/payments",
+      component: () => <>{routeChildren}</>,
+      validateSearch: paymentsSearchSchema,
+    })
+
+    return [authenticatedRoute.addChildren([paymentsRoute])]
+  })
+
+  return renderHook(() => useCategoryId(), {
+    wrapper: ({ children }: PropsWithChildren) => {
+      routeChildren = children
+
+      return <RouterProvider router={router} />
+    },
+  })
+}
+
+describe("useCategoryId", () => {
+  beforeEach(() => {
+    vi.mocked(toPaymentCategoryId).mockClear()
+  })
+
+  test("URL searchのcategoryをカテゴリID変換に渡す", async () => {
+    const { result } = renderUseCategoryId("/payments?year=2025&month=6&category=10")
+
+    await waitFor(() => {
+      expect(toPaymentCategoryId).toHaveBeenCalledWith("10")
+      expect(result.current).toBe(10)
+    })
+  })
+
+  test("URL searchにcategoryがない場合はundefinedをカテゴリID変換に渡す", async () => {
+    renderUseCategoryId("/payments?year=2025&month=6")
+
+    await waitFor(() => {
+      expect(toPaymentCategoryId).toHaveBeenCalledWith(undefined)
+    })
+  })
+})

--- a/apps/web/src/features/payments/listPayment/useCategoryId.ts
+++ b/apps/web/src/features/payments/listPayment/useCategoryId.ts
@@ -1,0 +1,11 @@
+import { useLocation } from "@tanstack/react-router"
+
+import { toPaymentCategoryId } from "./paymentCategorySearch"
+
+export function useCategoryId(): number | null | undefined {
+  const categorySearch = useLocation({
+    select: (location) => location.search.category,
+  })
+
+  return toPaymentCategoryId(categorySearch)
+}

--- a/apps/web/src/features/payments/listPayment/usePayments.test.tsx
+++ b/apps/web/src/features/payments/listPayment/usePayments.test.tsx
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, test, vi } from "vite-plus/test"
+
+import { renderHook, waitFor } from "../../../test/test-utils"
+import type { Payment } from "../../../types/payment"
+import { fetchPayments } from "./fetchPayments"
+import { usePayments } from "./usePayments"
+
+const dateRange: [Date, Date] = [new Date(2025, 5, 1), new Date(2025, 5, 30)]
+
+vi.mock("../../../utils/useDateRange", () => ({
+  useDateRange: () => ({
+    date: dateRange[0],
+    dateRange,
+  }),
+}))
+
+vi.mock("./fetchPayments", () => ({
+  fetchPayments: vi.fn(),
+}))
+
+function buildPayment(id: number): Payment {
+  return {
+    id,
+    amount: 1000 + id,
+    categoryId: 10,
+    date: new Date(2025, 5, id),
+    note: `payment ${id}`,
+    userId: 100,
+    createdDate: new Date("2025-06-01T00:00:00.000Z"),
+    updatedDate: new Date("2025-06-01T00:00:00.000Z"),
+  }
+}
+
+describe("usePayments", () => {
+  beforeEach(() => {
+    vi.mocked(fetchPayments).mockReset()
+  })
+
+  test("カテゴリIDを指定するとカテゴリ条件を渡して支払い一覧を取得する", async () => {
+    const payment = buildPayment(1)
+    vi.mocked(fetchPayments).mockResolvedValue([payment])
+
+    const { result } = renderHook(() => usePayments({ categoryId: 10 }))
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([payment])
+    })
+    expect(fetchPayments).toHaveBeenCalledTimes(1)
+    expect(fetchPayments).toHaveBeenCalledWith(dateRange, { categoryId: 10 })
+  })
+
+  test("カテゴリIDが変わると別queryとして取得し直す", async () => {
+    const firstPayment = buildPayment(1)
+    const secondPayment = buildPayment(2)
+    vi.mocked(fetchPayments)
+      .mockResolvedValueOnce([firstPayment])
+      .mockResolvedValueOnce([secondPayment])
+
+    const { result, rerender } = renderHook(
+      ({ categoryId }: { categoryId: number }) => usePayments({ categoryId }),
+      {
+        initialProps: { categoryId: 10 },
+      },
+    )
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([firstPayment])
+    })
+
+    rerender({ categoryId: 20 })
+
+    await waitFor(() => {
+      expect(fetchPayments).toHaveBeenCalledTimes(2)
+    })
+    expect(fetchPayments).toHaveBeenNthCalledWith(1, dateRange, { categoryId: 10 })
+    expect(fetchPayments).toHaveBeenNthCalledWith(2, dateRange, { categoryId: 20 })
+  })
+
+  test("カテゴリ条件なしではカテゴリ条件を渡さない", async () => {
+    const payment = buildPayment(1)
+    vi.mocked(fetchPayments).mockResolvedValue([payment])
+
+    const { result } = renderHook(() => usePayments())
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([payment])
+    })
+    expect(fetchPayments).toHaveBeenCalledWith(dateRange, { categoryId: undefined })
+  })
+})

--- a/apps/web/src/features/payments/listPayment/usePayments.ts
+++ b/apps/web/src/features/payments/listPayment/usePayments.ts
@@ -11,11 +11,15 @@ interface UseGetPaymentsReturn {
   error: Error | null
 }
 
-export function usePayments(): UseGetPaymentsReturn {
+interface UsePaymentsOptions {
+  categoryId?: number | null
+}
+
+export function usePayments({ categoryId }: UsePaymentsOptions = {}): UseGetPaymentsReturn {
   const { date, dateRange } = useDateRange()
   const query = useQuery({
-    queryKey: ["payments", date?.toISOString() ?? "all"],
-    queryFn: async () => fetchPayments(dateRange),
+    queryKey: ["payments", date?.toISOString() ?? "all", getCategoryQueryKey(categoryId)],
+    queryFn: async () => fetchPayments(dateRange, { categoryId }),
     enabled: date !== null,
     staleTime: 3000, // 3秒
   })
@@ -26,4 +30,10 @@ export function usePayments(): UseGetPaymentsReturn {
     promise: query.promise,
     error: query.error,
   }
+}
+
+function getCategoryQueryKey(categoryId: number | null | undefined): string {
+  if (categoryId === undefined) return "all-categories"
+  if (categoryId === null) return "uncategorized"
+  return `category-${categoryId}`
 }


### PR DESCRIPTION
## 関連Issue

- closes #1202

## 変更内容

- 支払い一覧取得にカテゴリ条件を追加し、登録済みカテゴリとカテゴリ未設定を Supabase query に反映するようにした
- PaymentList で URL search の category を取得条件へ変換し、React Query key にカテゴリ条件を含めるようにした
- MSW handler に絞り込みロジックを足さず、request capture で取得条件を確認する unit test を追加した

## 動作確認

- [x] テストの実行: `task web:lint`, `task web:format-check`, `task web:typecheck`, `task web:test-unit`, `task web:test-storybook`
