### PR TITLE
支払い一覧にカテゴリフィルタを追加する

### DIFF
--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -16,6 +16,7 @@ import { ErrorPage } from "./routes/ErrorPage"
 import { PaymentsPage } from "./routes/PaymentsPage"
 import { SettingsPage } from "./routes/SettingsPage"
 import { TopPage } from "./routes/TopPage"
+import { parseSearch, stringifySearch } from "./searchSerialization"
 
 export interface RouterContext {
   authStatus: AuthStatus
@@ -97,6 +98,8 @@ const routeTree = rootRoute.addChildren([
 
 export const router = createRouter({
   routeTree,
+  parseSearch,
+  stringifySearch,
   context: {
     authStatus: "loading",
     supabaseSession: null,

--- a/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
@@ -1,17 +1,25 @@
 import { composeStories } from "@storybook/react-vite"
+import { createRoute } from "@tanstack/react-router"
+import { HttpResponse, http } from "msw"
 import { afterEach, beforeEach, describe, expect, test, vi } from "vite-plus/test"
 
+import {
+  PAYMENT_SEARCH_CATEGORY_NONE_VALUE,
+  paymentsSearchSchema,
+} from "../../../features/payments/listPayment/paymentsSearchSchema"
 import { createQueryClient } from "../../../lib/queryClient"
-import { entertainmentCat } from "../../../test/data/categories"
+import { categories, entertainmentCat } from "../../../test/data/categories"
 import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
 import { payments } from "../../../test/data/payments"
+import { renderWithRouter } from "../../../test/helpers/renderWithRouter"
 import { createCategoryHandlers } from "../../../test/msw/handlers/categories"
 import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
 import { createPaymentHandlers } from "../../../test/msw/handlers/payments"
 import { server } from "../../../test/msw/server"
-import { render, screen, waitFor, within } from "../../../test/test-utils"
+import { render, screen, type TestUser, waitFor, within } from "../../../test/test-utils"
 import { mapPaymentToRow } from "../../../test/utils/mapPaymentToRow"
 import * as stories from "./PaymentPage.stories"
+import { PaymentsPage } from "./PaymentsPage"
 
 const { Default } = composeStories(stories)
 const createdPaymentFormInput = {
@@ -49,6 +57,51 @@ function renderStory() {
   }
 }
 
+function renderPaymentsPageRoute(initialEntry: string) {
+  const queryClient = createQueryClient()
+  queryClient.setQueryData(["categories"], categories)
+
+  const view = renderWithRouter(
+    initialEntry,
+    (root) => {
+      const authenticatedRoute = createRoute({
+        getParentRoute: () => root,
+        id: "authenticated",
+      })
+
+      const paymentsRoute = createRoute({
+        getParentRoute: () => authenticatedRoute,
+        path: "/payments",
+        component: PaymentsPage,
+        validateSearch: paymentsSearchSchema,
+      })
+
+      return [authenticatedRoute.addChildren([paymentsRoute])]
+    },
+    { queryClient },
+  )
+
+  return {
+    queryClient,
+    ...view,
+  }
+}
+
+async function selectCategoryFilterOption(user: TestUser, optionName: string) {
+  await user.click(await screen.findByRole("combobox", { name: /category filter/i }))
+
+  const listbox = await screen.findByRole("listbox")
+  await waitFor(() => {
+    expect(within(listbox).queryByRole("option", { name: /loading/i })).not.toBeInTheDocument()
+  })
+
+  await user.click(await within(listbox).findByRole("option", { name: optionName }))
+}
+
+function lastRequest(requests: URL[]): URL | undefined {
+  return requests[requests.length - 1]
+}
+
 describe("PaymentsPage", () => {
   beforeEach(() => {
     server.resetHandlers(
@@ -68,6 +121,103 @@ describe("PaymentsPage", () => {
   afterEach(() => {
     server.resetHandlers()
     vi.useRealTimers()
+  })
+
+  test("初期URL searchの登録済みカテゴリIDを一覧取得条件に反映する", async () => {
+    const requestCapture: { url: URL | null } = { url: null }
+    server.use(
+      http.get("*/rest/v1/payments*", ({ request }) => {
+        requestCapture.url = new URL(request.url)
+
+        return HttpResponse.json([])
+      }),
+    )
+
+    renderPaymentsPageRoute("/payments?year=2025&month=6&category=10")
+
+    await waitFor(() => {
+      expect(requestCapture.url?.searchParams.get("category_id")).toBe("eq.10")
+    })
+  })
+
+  test("初期URL searchのカテゴリ未設定を一覧取得条件に反映する", async () => {
+    const requestCapture: { url: URL | null } = { url: null }
+    server.use(
+      http.get("*/rest/v1/payments*", ({ request }) => {
+        requestCapture.url = new URL(request.url)
+
+        return HttpResponse.json([])
+      }),
+    )
+
+    renderPaymentsPageRoute(
+      `/payments?year=2025&month=6&category=${PAYMENT_SEARCH_CATEGORY_NONE_VALUE}`,
+    )
+
+    await waitFor(() => {
+      expect(requestCapture.url?.searchParams.get("category_id")).toBe("is.null")
+    })
+  })
+
+  test("カテゴリ変更時はRouter searchを更新して一覧取得条件へ反映する", async () => {
+    const requests: URL[] = []
+    server.use(
+      http.get("*/rest/v1/payments*", ({ request }) => {
+        requests.push(new URL(request.url))
+
+        return HttpResponse.json([])
+      }),
+    )
+    const { router, user } = renderPaymentsPageRoute("/payments?year=2025&month=6")
+
+    await selectCategoryFilterOption(user, "Food")
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: /category filter/i })).toHaveTextContent("Food")
+      expect(router.state.location.search).toEqual({
+        year: "2025",
+        month: "6",
+        category: "10",
+      })
+      expect(requests.some((url) => url.searchParams.get("category_id") === "eq.10")).toBe(true)
+    })
+  })
+
+  test("ブラウザバックでカテゴリ条件を戻す", async () => {
+    const requests: URL[] = []
+    server.use(
+      http.get("*/rest/v1/payments*", ({ request }) => {
+        requests.push(new URL(request.url))
+
+        return HttpResponse.json([])
+      }),
+    )
+    const { queryClient, router, user } = renderPaymentsPageRoute("/payments?year=2025&month=6")
+
+    await selectCategoryFilterOption(user, "Food")
+
+    await waitFor(() => {
+      expect(router.state.location.search.category).toBe("10")
+      expect(lastRequest(requests)?.searchParams.get("category_id")).toBe("eq.10")
+    })
+
+    queryClient.removeQueries({
+      queryKey: ["payments"],
+      predicate: (query) => query.queryKey[2] === "all-categories",
+    })
+
+    router.history.back()
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: /category filter/i })).toHaveTextContent(
+        "All categories",
+      )
+      expect(router.state.location.search).toEqual({
+        year: "2025",
+        month: "6",
+      })
+      expect(lastRequest(requests)?.searchParams.has("category_id")).toBe(false)
+    })
   })
 
   test("支払いを作成すると一覧に追加される", async () => {

--- a/apps/web/src/app/routes/PaymentsPage/PaymentsPage.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentsPage.tsx
@@ -1,7 +1,7 @@
-import { Container, Flex } from "@radix-ui/themes"
+import { Box, Container, Flex } from "@radix-ui/themes"
 
 import { CreatePaymentModal } from "../../../features/payments/createPayment"
-import { PaymentList } from "../../../features/payments/listPayment"
+import { PaymentCategoryFilter, PaymentList } from "../../../features/payments/listPayment"
 import { Summary } from "../../../features/summaryByMonth"
 
 export function PaymentsPage() {
@@ -9,8 +9,13 @@ export function PaymentsPage() {
     <Container size="4">
       <Flex direction="column" gap="3">
         <Summary />
-        <Flex justify="end" align="center" gap="3">
-          <CreatePaymentModal />
+        <Flex align="center" gap="3">
+          <Box flexGrow="1" minWidth="0">
+            <PaymentCategoryFilter />
+          </Box>
+          <Box flexShrink="0">
+            <CreatePaymentModal />
+          </Box>
         </Flex>
         <PaymentList />
       </Flex>

--- a/apps/web/src/app/searchSerialization.test.ts
+++ b/apps/web/src/app/searchSerialization.test.ts
@@ -7,6 +7,21 @@ describe("searchSerialization", () => {
     expect(stringifySearch({ category: "4" })).toBe("?category=4")
   })
 
+  test("引用符なしのscalar値は文字列として復元する", () => {
+    expect(parseSearch("?category=4&enabled=true&empty=null")).toEqual({
+      category: "4",
+      enabled: "true",
+      empty: "null",
+    })
+  })
+
+  test("legacyのquoted stringを文字列として復元する", () => {
+    expect(parseSearch("?year=%222025%22&month=%226%22")).toEqual({
+      year: "2025",
+      month: "6",
+    })
+  })
+
   test("objectとarrayをURL searchから復元する", () => {
     const search = {
       filter: { category: "4" },

--- a/apps/web/src/app/searchSerialization.test.ts
+++ b/apps/web/src/app/searchSerialization.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vite-plus/test"
+
+import { parseSearch, stringifySearch } from "./searchSerialization"
+
+describe("searchSerialization", () => {
+  test("文字列の数値を引用符なしでURL searchにする", () => {
+    expect(stringifySearch({ category: "4" })).toBe("?category=4")
+  })
+
+  test("objectとarrayをURL searchから復元する", () => {
+    const search = {
+      filter: { category: "4" },
+      ids: ["1", "2"],
+    }
+
+    expect(parseSearch(stringifySearch(search))).toEqual(search)
+  })
+})

--- a/apps/web/src/app/searchSerialization.ts
+++ b/apps/web/src/app/searchSerialization.ts
@@ -22,7 +22,7 @@ export function parseSearch(searchStr: string) {
 export const stringifySearch = stringifySearchWith(JSON.stringify)
 
 function parseSearchValue(value: string): unknown {
-  if (!value.startsWith("{") && !value.startsWith("[")) {
+  if (!value.startsWith('"') && !value.startsWith("{") && !value.startsWith("[")) {
     return value
   }
 

--- a/apps/web/src/app/searchSerialization.ts
+++ b/apps/web/src/app/searchSerialization.ts
@@ -1,0 +1,34 @@
+import { stringifySearchWith } from "@tanstack/react-router"
+
+export function parseSearch(searchStr: string) {
+  const params = new URLSearchParams(searchStr.startsWith("?") ? searchStr.slice(1) : searchStr)
+  const search: Record<string, unknown> = Object.create(null)
+
+  for (const [key, value] of params.entries()) {
+    const parsedValue = parseSearchValue(value)
+    const previousValue = search[key]
+    if (previousValue === undefined) {
+      search[key] = parsedValue
+    } else if (Array.isArray(previousValue)) {
+      previousValue.push(parsedValue)
+    } else {
+      search[key] = [previousValue, parsedValue]
+    }
+  }
+
+  return search
+}
+
+export const stringifySearch = stringifySearchWith(JSON.stringify)
+
+function parseSearchValue(value: string): unknown {
+  if (!value.startsWith("{") && !value.startsWith("[")) {
+    return value
+  }
+
+  try {
+    return JSON.parse(value)
+  } catch {
+    return value
+  }
+}

--- a/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/PaymentCategoryFilter.test.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/PaymentCategoryFilter.test.tsx
@@ -1,29 +1,38 @@
 import { createRoute } from "@tanstack/react-router"
 import { beforeEach, describe, expect, test } from "vite-plus/test"
 
+import { createQueryClient } from "../../../../lib/queryClient"
+import { categories } from "../../../../test/data/categories"
 import { renderWithRouter } from "../../../../test/helpers/renderWithRouter"
 import { createCategoryHandlers } from "../../../../test/msw/handlers/categories"
 import { server } from "../../../../test/msw/server"
 import { screen, type TestUser, waitFor, within } from "../../../../test/test-utils"
-import { paymentsSearchSchema } from "../paymentsSearchSchema"
+import { PAYMENT_SEARCH_CATEGORY_NONE_VALUE, paymentsSearchSchema } from "../paymentsSearchSchema"
 import { PaymentCategoryFilter } from "./PaymentCategoryFilter"
 
 function renderPaymentCategoryFilter(initialEntry: string) {
-  return renderWithRouter(initialEntry, (root) => {
-    const authenticatedRoute = createRoute({
-      getParentRoute: () => root,
-      id: "authenticated",
-    })
+  const queryClient = createQueryClient()
+  queryClient.setQueryData(["categories"], categories)
 
-    const paymentsRoute = createRoute({
-      getParentRoute: () => authenticatedRoute,
-      path: "/payments",
-      component: PaymentCategoryFilter,
-      validateSearch: paymentsSearchSchema,
-    })
+  return renderWithRouter(
+    initialEntry,
+    (root) => {
+      const authenticatedRoute = createRoute({
+        getParentRoute: () => root,
+        id: "authenticated",
+      })
 
-    return [authenticatedRoute.addChildren([paymentsRoute])]
-  })
+      const paymentsRoute = createRoute({
+        getParentRoute: () => authenticatedRoute,
+        path: "/payments",
+        component: PaymentCategoryFilter,
+        validateSearch: paymentsSearchSchema,
+      })
+
+      return [authenticatedRoute.addChildren([paymentsRoute])]
+    },
+    { queryClient },
+  )
 }
 
 async function selectCategoryFilterOption(user: TestUser, optionName: string) {
@@ -50,7 +59,25 @@ describe("PaymentCategoryFilter", () => {
     )
   })
 
-  test("登録済みカテゴリを選ぶと年月条件を保ったまま category を更新する", async () => {
+  test("URL search のカテゴリ未設定を表示する", async () => {
+    renderPaymentCategoryFilter(
+      `/payments?year=2025&month=6&category=${PAYMENT_SEARCH_CATEGORY_NONE_VALUE}`,
+    )
+
+    expect(await screen.findByRole("combobox", { name: /category filter/i })).toHaveTextContent(
+      "Uncategorized",
+    )
+  })
+
+  test("URL search の登録済みカテゴリを表示する", async () => {
+    renderPaymentCategoryFilter("/payments?year=2025&month=6&category=10")
+
+    expect(await screen.findByRole("combobox", { name: /category filter/i })).toHaveTextContent(
+      "Food",
+    )
+  })
+
+  test("登録済みカテゴリを選ぶとcategoryをRouter searchに反映する", async () => {
     const { router, user } = renderPaymentCategoryFilter("/payments?year=2025&month=6")
 
     await selectCategoryFilterOption(user, "Food")
@@ -61,10 +88,11 @@ describe("PaymentCategoryFilter", () => {
         month: "6",
         category: "10",
       })
+      expect(router.state.location.href).toBe("/payments?year=2025&month=6&category=10")
     })
   })
 
-  test("カテゴリ未設定を選ぶと年月条件を保ったまま category=none にする", async () => {
+  test("カテゴリ未設定を選ぶとcategory=noneをRouter searchに反映する", async () => {
     const { router, user } = renderPaymentCategoryFilter("/payments?year=2025&month=6")
 
     await selectCategoryFilterOption(user, "Uncategorized")
@@ -73,23 +101,25 @@ describe("PaymentCategoryFilter", () => {
       expect(router.state.location.search).toEqual({
         year: "2025",
         month: "6",
-        category: "none",
+        category: PAYMENT_SEARCH_CATEGORY_NONE_VALUE,
       })
     })
   })
 
-  test("All categories を選ぶと年月条件を保ったまま category を外す", async () => {
+  test("All categories を選ぶとRouter searchからcategoryを外す", async () => {
     const { router, user } = renderPaymentCategoryFilter(
-      "/payments?year=2025&month=6&category=none",
+      `/payments?year=2025&month=6&category=${PAYMENT_SEARCH_CATEGORY_NONE_VALUE}`,
     )
 
     await selectCategoryFilterOption(user, "All categories")
 
     await waitFor(() => {
-      expect(router.state.location.search.year).toBe("2025")
-      expect(router.state.location.search.month).toBe("6")
-      expect(router.state.location.search.category).toBeUndefined()
-      expect(router.state.location.href).not.toContain("category")
+      expect(router.state.location.search).toEqual({
+        year: "2025",
+        month: "6",
+        category: undefined,
+      })
+      expect(router.state.location.href).toBe("/payments?year=2025&month=6")
     })
   })
 })

--- a/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/PaymentCategoryFilter.test.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/PaymentCategoryFilter.test.tsx
@@ -1,0 +1,95 @@
+import { createRoute } from "@tanstack/react-router"
+import { beforeEach, describe, expect, test } from "vite-plus/test"
+
+import { renderWithRouter } from "../../../../test/helpers/renderWithRouter"
+import { createCategoryHandlers } from "../../../../test/msw/handlers/categories"
+import { server } from "../../../../test/msw/server"
+import { screen, type TestUser, waitFor, within } from "../../../../test/test-utils"
+import { paymentsSearchSchema } from "../paymentsSearchSchema"
+import { PaymentCategoryFilter } from "./PaymentCategoryFilter"
+
+function renderPaymentCategoryFilter(initialEntry: string) {
+  return renderWithRouter(initialEntry, (root) => {
+    const authenticatedRoute = createRoute({
+      getParentRoute: () => root,
+      id: "authenticated",
+    })
+
+    const paymentsRoute = createRoute({
+      getParentRoute: () => authenticatedRoute,
+      path: "/payments",
+      component: PaymentCategoryFilter,
+      validateSearch: paymentsSearchSchema,
+    })
+
+    return [authenticatedRoute.addChildren([paymentsRoute])]
+  })
+}
+
+async function selectCategoryFilterOption(user: TestUser, optionName: string) {
+  await user.click(await screen.findByRole("combobox", { name: /category filter/i }))
+
+  const listbox = await screen.findByRole("listbox")
+  await waitFor(() => {
+    expect(within(listbox).queryByRole("option", { name: /loading/i })).not.toBeInTheDocument()
+  })
+
+  await user.click(await within(listbox).findByRole("option", { name: optionName }))
+}
+
+describe("PaymentCategoryFilter", () => {
+  beforeEach(() => {
+    server.resetHandlers(...createCategoryHandlers())
+  })
+
+  test("URL search にカテゴリ条件がない場合は All categories を表示する", async () => {
+    renderPaymentCategoryFilter("/payments?year=2025&month=6")
+
+    expect(await screen.findByRole("combobox", { name: /category filter/i })).toHaveTextContent(
+      "All categories",
+    )
+  })
+
+  test("登録済みカテゴリを選ぶと年月条件を保ったまま category を更新する", async () => {
+    const { router, user } = renderPaymentCategoryFilter("/payments?year=2025&month=6")
+
+    await selectCategoryFilterOption(user, "Food")
+
+    await waitFor(() => {
+      expect(router.state.location.search).toEqual({
+        year: "2025",
+        month: "6",
+        category: "10",
+      })
+    })
+  })
+
+  test("カテゴリ未設定を選ぶと年月条件を保ったまま category=none にする", async () => {
+    const { router, user } = renderPaymentCategoryFilter("/payments?year=2025&month=6")
+
+    await selectCategoryFilterOption(user, "Uncategorized")
+
+    await waitFor(() => {
+      expect(router.state.location.search).toEqual({
+        year: "2025",
+        month: "6",
+        category: "none",
+      })
+    })
+  })
+
+  test("All categories を選ぶと年月条件を保ったまま category を外す", async () => {
+    const { router, user } = renderPaymentCategoryFilter(
+      "/payments?year=2025&month=6&category=none",
+    )
+
+    await selectCategoryFilterOption(user, "All categories")
+
+    await waitFor(() => {
+      expect(router.state.location.search.year).toBe("2025")
+      expect(router.state.location.search.month).toBe("6")
+      expect(router.state.location.search.category).toBeUndefined()
+      expect(router.state.location.href).not.toContain("category")
+    })
+  })
+})

--- a/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/PaymentCategoryFilter.test.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/PaymentCategoryFilter.test.tsx
@@ -1,4 +1,5 @@
 import { createRoute } from "@tanstack/react-router"
+import { http } from "msw"
 import { beforeEach, describe, expect, test } from "vite-plus/test"
 
 import { createQueryClient } from "../../../../lib/queryClient"
@@ -10,9 +11,14 @@ import { screen, type TestUser, waitFor, within } from "../../../../test/test-ut
 import { PAYMENT_SEARCH_CATEGORY_NONE_VALUE, paymentsSearchSchema } from "../paymentsSearchSchema"
 import { PaymentCategoryFilter } from "./PaymentCategoryFilter"
 
-function renderPaymentCategoryFilter(initialEntry: string) {
+function renderPaymentCategoryFilter(
+  initialEntry: string,
+  { cacheCategories = true }: { cacheCategories?: boolean } = {},
+) {
   const queryClient = createQueryClient()
-  queryClient.setQueryData(["categories"], categories)
+  if (cacheCategories) {
+    queryClient.setQueryData(["categories"], categories)
+  }
 
   return renderWithRouter(
     initialEntry,
@@ -75,6 +81,39 @@ describe("PaymentCategoryFilter", () => {
     expect(await screen.findByRole("combobox", { name: /category filter/i })).toHaveTextContent(
       "Food",
     )
+  })
+
+  test("カテゴリ取得中でもURL searchの登録済みカテゴリは読み込み中表示にする", async () => {
+    server.use(
+      http.get("*/rest/v1/categories*", async () => {
+        await new Promise(() => undefined)
+      }),
+    )
+
+    renderPaymentCategoryFilter("/payments?year=2025&month=6&category=10", {
+      cacheCategories: false,
+    })
+
+    expect(await screen.findByRole("combobox", { name: /category filter/i })).toHaveTextContent(
+      "Loading",
+    )
+  })
+
+  test("URL search のカテゴリが存在しない登録済みIDの場合は Unknown category を表示する", async () => {
+    renderPaymentCategoryFilter("/payments?year=2025&month=6&category=999")
+
+    expect(await screen.findByRole("combobox", { name: /category filter/i })).toHaveTextContent(
+      "Unknown category",
+    )
+  })
+
+  test("URL search の不正カテゴリは All categories に正規化する", async () => {
+    const { router } = renderPaymentCategoryFilter("/payments?year=2025&month=6&category=-1")
+
+    expect(await screen.findByRole("combobox", { name: /category filter/i })).toHaveTextContent(
+      "All categories",
+    )
+    expect(router.state.location.search.category).toBeUndefined()
   })
 
   test("登録済みカテゴリを選ぶとcategoryをRouter searchに反映する", async () => {

--- a/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/PaymentCategoryFilter.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/PaymentCategoryFilter.tsx
@@ -1,0 +1,82 @@
+import { Select } from "@radix-ui/themes"
+import { useLocation, useNavigate } from "@tanstack/react-router"
+import { memo, Suspense, use, useCallback } from "react"
+import { ErrorBoundary } from "react-error-boundary"
+
+import {
+  CategoryOption,
+  ErrorCategoryOption,
+  LoadingCategoryOption,
+} from "../../../categories/components/CategorySelect"
+import { useCategories } from "../../../categories/listCategory/useCategories"
+import { toPaymentCategoryId } from "../paymentCategorySearch"
+import { PAYMENT_SEARCH_CATEGORY_NONE_VALUE } from "../paymentsSearchSchema"
+
+const PAYMENT_SEARCH_CATEGORY_ALL_VALUE = "all"
+
+export const PaymentCategoryFilter = memo(function PaymentCategoryFilter() {
+  const categorySearch = useLocation({
+    select: (location) => location.search.category,
+  })
+  const navigate = useNavigate({ from: "/payments" })
+  const { promise: categoriesPromise } = useCategories()
+  const value = toPaymentCategoryFilterValue(categorySearch)
+
+  const handleChange = useCallback(
+    (nextValue: string) => {
+      const category = nextValue === PAYMENT_SEARCH_CATEGORY_ALL_VALUE ? undefined : nextValue
+
+      void navigate({
+        to: "/payments",
+        search: (prev) => ({ ...prev, category }),
+      })
+    },
+    [navigate],
+  )
+
+  return (
+    <Select.Root name="category-filter" value={value} onValueChange={handleChange}>
+      <Select.Trigger aria-label="Category filter" style={{ width: "100%" }} />
+      <Select.Content>
+        <Select.Item value={PAYMENT_SEARCH_CATEGORY_ALL_VALUE}>All categories</Select.Item>
+        <Select.Item value={PAYMENT_SEARCH_CATEGORY_NONE_VALUE}>Uncategorized</Select.Item>
+        <ErrorBoundary fallback={<ErrorCategoryOption />}>
+          <Suspense fallback={<LoadingCategoryOption />}>
+            <PaymentCategoryOptions categoriesPromise={categoriesPromise} />
+          </Suspense>
+        </ErrorBoundary>
+      </Select.Content>
+    </Select.Root>
+  )
+})
+
+interface PaymentCategoryOptionsProps {
+  categoriesPromise: ReturnType<typeof useCategories>["promise"]
+}
+
+const PaymentCategoryOptions = memo(function PaymentCategoryOptions({
+  categoriesPromise,
+}: PaymentCategoryOptionsProps) {
+  const categories = use(categoriesPromise)
+
+  return (
+    <>
+      {categories.map((category) => (
+        <CategoryOption key={category.id} category={category} />
+      ))}
+    </>
+  )
+})
+
+function toPaymentCategoryFilterValue(categorySearch?: string): string {
+  const categoryId = toPaymentCategoryId(categorySearch)
+
+  if (categoryId === undefined) {
+    return PAYMENT_SEARCH_CATEGORY_ALL_VALUE
+  }
+  if (categoryId === null) {
+    return PAYMENT_SEARCH_CATEGORY_NONE_VALUE
+  }
+
+  return String(categoryId)
+}

--- a/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/PaymentCategoryFilter.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/PaymentCategoryFilter.tsx
@@ -3,16 +3,13 @@ import { useLocation, useNavigate } from "@tanstack/react-router"
 import { memo, Suspense, use, useCallback } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 
-import {
-  CategoryOption,
-  ErrorCategoryOption,
-  LoadingCategoryOption,
-} from "../../../categories/components/CategorySelect"
+import { CategoryOption, ErrorCategoryOption } from "../../../categories/components/CategorySelect"
 import { useCategories } from "../../../categories/listCategory/useCategories"
 import { toPaymentCategoryId, toPaymentCategorySearch } from "../paymentCategorySearch"
 import { PAYMENT_SEARCH_CATEGORY_NONE_VALUE } from "../paymentsSearchSchema"
 
 const PAYMENT_SEARCH_CATEGORY_ALL_VALUE = "all"
+const PAYMENT_SEARCH_CATEGORY_UNKNOWN_LABEL = "Unknown category"
 
 export const PaymentCategoryFilter = memo(function PaymentCategoryFilter() {
   const categorySearch = useLocation({
@@ -20,7 +17,9 @@ export const PaymentCategoryFilter = memo(function PaymentCategoryFilter() {
   })
   const navigate = useNavigate({ from: "/payments" })
   const { promise: categoriesPromise } = useCategories()
+  const categoryId = toPaymentCategoryId(categorySearch)
   const value = toPaymentCategoryFilterValue(categorySearch)
+  const selectedCategoryValue = typeof categoryId === "number" ? String(categoryId) : undefined
 
   const handleChange = useCallback(
     (nextValue: string) => {
@@ -44,8 +43,13 @@ export const PaymentCategoryFilter = memo(function PaymentCategoryFilter() {
         <Select.Item value={PAYMENT_SEARCH_CATEGORY_ALL_VALUE}>All categories</Select.Item>
         <Select.Item value={PAYMENT_SEARCH_CATEGORY_NONE_VALUE}>Uncategorized</Select.Item>
         <ErrorBoundary fallback={<ErrorCategoryOption />}>
-          <Suspense fallback={<LoadingCategoryOption />}>
-            <PaymentCategoryOptions categoriesPromise={categoriesPromise} />
+          <Suspense
+            fallback={<LoadingSelectedCategoryOption selectedValue={selectedCategoryValue} />}
+          >
+            <PaymentCategoryOptions
+              categoriesPromise={categoriesPromise}
+              selectedValue={selectedCategoryValue}
+            />
           </Suspense>
         </ErrorBoundary>
       </Select.Content>
@@ -55,21 +59,43 @@ export const PaymentCategoryFilter = memo(function PaymentCategoryFilter() {
 
 interface PaymentCategoryOptionsProps {
   categoriesPromise: ReturnType<typeof useCategories>["promise"]
+  selectedValue?: string
 }
 
 const PaymentCategoryOptions = memo(function PaymentCategoryOptions({
   categoriesPromise,
+  selectedValue,
 }: PaymentCategoryOptionsProps) {
   const categories = use(categoriesPromise)
+  const hasSelectedCategory =
+    selectedValue === undefined ||
+    categories.some((category) => String(category.id) === selectedValue)
 
   return (
     <>
+      {!hasSelectedCategory && <UnknownCategoryOption value={selectedValue} />}
       {categories.map((category) => (
         <CategoryOption key={category.id} category={category} />
       ))}
     </>
   )
 })
+
+function LoadingSelectedCategoryOption({ selectedValue }: { selectedValue?: string }) {
+  return (
+    <Select.Item disabled value={selectedValue ?? "loading"}>
+      Loading
+    </Select.Item>
+  )
+}
+
+function UnknownCategoryOption({ value }: { value: string }) {
+  return (
+    <Select.Item disabled value={value}>
+      {PAYMENT_SEARCH_CATEGORY_UNKNOWN_LABEL}
+    </Select.Item>
+  )
+}
 
 function toPaymentCategoryFilterValue(categorySearch?: string): string {
   const categoryId = toPaymentCategoryId(categorySearch)

--- a/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/PaymentCategoryFilter.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/PaymentCategoryFilter.tsx
@@ -9,7 +9,7 @@ import {
   LoadingCategoryOption,
 } from "../../../categories/components/CategorySelect"
 import { useCategories } from "../../../categories/listCategory/useCategories"
-import { toPaymentCategoryId } from "../paymentCategorySearch"
+import { toPaymentCategoryId, toPaymentCategorySearch } from "../paymentCategorySearch"
 import { PAYMENT_SEARCH_CATEGORY_NONE_VALUE } from "../paymentsSearchSchema"
 
 const PAYMENT_SEARCH_CATEGORY_ALL_VALUE = "all"
@@ -24,11 +24,14 @@ export const PaymentCategoryFilter = memo(function PaymentCategoryFilter() {
 
   const handleChange = useCallback(
     (nextValue: string) => {
-      const category = nextValue === PAYMENT_SEARCH_CATEGORY_ALL_VALUE ? undefined : nextValue
+      const categorySearch =
+        nextValue === PAYMENT_SEARCH_CATEGORY_ALL_VALUE
+          ? undefined
+          : toPaymentCategorySearch(nextValue)
 
       void navigate({
         to: "/payments",
-        search: (prev) => ({ ...prev, category }),
+        search: (prev) => ({ ...prev, category: categorySearch }),
       })
     },
     [navigate],

--- a/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/index.ts
+++ b/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/index.ts
@@ -1,2 +1,1 @@
 export * from "./PaymentCategoryFilter"
-export * from "./PaymentList"

--- a/apps/web/src/features/payments/listPayment/paymentCategorySearch.test.ts
+++ b/apps/web/src/features/payments/listPayment/paymentCategorySearch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vite-plus/test"
 
-import { toPaymentCategoryId } from "./paymentCategorySearch"
+import { toPaymentCategoryId, toPaymentCategorySearch } from "./paymentCategorySearch"
 import { PAYMENT_SEARCH_CATEGORY_NONE_VALUE } from "./paymentsSearchSchema"
 
 describe("toPaymentCategoryId", () => {
@@ -16,6 +16,25 @@ describe("toPaymentCategoryId", () => {
     "カテゴリ条件に使わないURL search %s はundefinedに変換する",
     (categorySearch) => {
       expect(toPaymentCategoryId(categorySearch)).toBeUndefined()
+    },
+  )
+})
+
+describe("toPaymentCategorySearch", () => {
+  test("登録済みカテゴリIDのURL searchを正規化する", () => {
+    expect(toPaymentCategorySearch("10")).toBe("10")
+  })
+
+  test("カテゴリ未設定のURL searchを維持する", () => {
+    expect(toPaymentCategorySearch(PAYMENT_SEARCH_CATEGORY_NONE_VALUE)).toBe(
+      PAYMENT_SEARCH_CATEGORY_NONE_VALUE,
+    )
+  })
+
+  test.each([undefined, null, "", "0", "-1", "1.2", "abc"])(
+    "カテゴリ条件に使わないURL search %s はundefinedにする",
+    (categorySearch) => {
+      expect(toPaymentCategorySearch(categorySearch)).toBeUndefined()
     },
   )
 })

--- a/apps/web/src/features/payments/listPayment/paymentCategorySearch.ts
+++ b/apps/web/src/features/payments/listPayment/paymentCategorySearch.ts
@@ -1,10 +1,11 @@
 import { PAYMENT_SEARCH_CATEGORY_NONE_VALUE } from "./paymentsSearchSchema"
 
-export function toPaymentCategoryId(categorySearch?: string): number | null | undefined {
+export function toPaymentCategorySearch(categorySearch?: string | null): string | undefined {
   if (categorySearch === PAYMENT_SEARCH_CATEGORY_NONE_VALUE) {
-    return null
+    return PAYMENT_SEARCH_CATEGORY_NONE_VALUE
   }
-  if (categorySearch === undefined) {
+
+  if (categorySearch === undefined || categorySearch === null || categorySearch === "") {
     return undefined
   }
 
@@ -14,5 +15,18 @@ export function toPaymentCategoryId(categorySearch?: string): number | null | un
     return undefined
   }
 
-  return categoryId
+  return String(categoryId)
+}
+
+export function toPaymentCategoryId(categorySearch?: string): number | null | undefined {
+  const normalizedCategorySearch = toPaymentCategorySearch(categorySearch)
+
+  if (normalizedCategorySearch === PAYMENT_SEARCH_CATEGORY_NONE_VALUE) {
+    return null
+  }
+  if (normalizedCategorySearch === undefined) {
+    return undefined
+  }
+
+  return Number(normalizedCategorySearch)
 }

--- a/apps/web/src/features/payments/listPayment/paymentsSearchSchema.test.ts
+++ b/apps/web/src/features/payments/listPayment/paymentsSearchSchema.test.ts
@@ -15,12 +15,6 @@ describe("paymentsSearchSchema", () => {
     expect(result).toEqual({ category: "10" })
   })
 
-  test.each(["0", "-1", "1.2"])("数値として読めるカテゴリ条件 %s を扱える", (category) => {
-    const result = paymentsSearchSchema.parse({ category })
-
-    expect(result).toEqual({ category })
-  })
-
   test("年月と登録済みカテゴリ ID を併用できる", () => {
     const result = paymentsSearchSchema.parse({ year: "2025", month: "5", category: "10" })
 
@@ -35,7 +29,7 @@ describe("paymentsSearchSchema", () => {
     expect(result).toEqual({ category: PAYMENT_SEARCH_CATEGORY_NONE_VALUE })
   })
 
-  test.each(["abc", ""])("不正なカテゴリ条件 %s は条件なしにする", (category) => {
+  test.each(["0", "-1", "1.2", "abc", ""])("不正なカテゴリ条件 %s は条件なしにする", (category) => {
     const result = paymentsSearchSchema.parse({ year: "2025", month: "5", category })
 
     expect(result).toEqual({ year: "2025", month: "5", category: undefined })

--- a/apps/web/src/features/payments/listPayment/paymentsSearchSchema.ts
+++ b/apps/web/src/features/payments/listPayment/paymentsSearchSchema.ts
@@ -2,7 +2,7 @@ import { z } from "zod"
 
 export const PAYMENT_SEARCH_CATEGORY_NONE_VALUE = "none"
 
-const paymentSearchCategoryIdSchema = z.coerce.string().pipe(z.templateLiteral([z.number()]))
+const paymentSearchCategoryIdSchema = z.coerce.number().int().positive().transform(String)
 const paymentSearchCategorySchema = z
   .union([z.literal(PAYMENT_SEARCH_CATEGORY_NONE_VALUE), paymentSearchCategoryIdSchema])
   .optional()

--- a/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.test.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.test.tsx
@@ -21,6 +21,8 @@ function renderMonthSelector(initialEntry: string) {
 }
 
 function renderWithRouterHelper(initialEntry: string, sessionState: SupabaseSessionState) {
+  window.history.replaceState({}, "", initialEntry)
+
   return renderWithTestRouter(
     initialEntry,
     (root) => {

--- a/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.tsx
@@ -5,8 +5,11 @@ import { MonthPicker } from "../../../components/inputs/MonthPicker"
 import { useSupabaseSession } from "../../../providers/supabase/useSupabaseSession"
 
 export function MonthSelector() {
-  const { year: yearParam, month: monthParam } = useLocation({
-    select: (location) => location.search,
+  const yearParam = useLocation({
+    select: (location) => location.search.year,
+  })
+  const monthParam = useLocation({
+    select: (location) => location.search.month,
   })
   const navigate = useNavigate({ from: "/payments" })
   const { session } = useSupabaseSession()

--- a/apps/web/src/test/helpers/createTestRouter.ts
+++ b/apps/web/src/test/helpers/createTestRouter.ts
@@ -6,6 +6,8 @@ import {
   type AnyRoute,
 } from "@tanstack/react-router"
 
+import { parseSearch, stringifySearch } from "../../app/searchSerialization"
+
 export type TestRouteBuilder = (rootRoute: AnyRootRoute) => AnyRoute[]
 
 export function createTestRouter(initialEntry: string, routeBuilder: TestRouteBuilder) {
@@ -17,5 +19,5 @@ export function createTestRouter(initialEntry: string, routeBuilder: TestRouteBu
     initialEntries: [initialEntry],
   })
 
-  return createRouter({ routeTree, history: memoryHistory })
+  return createRouter({ routeTree, history: memoryHistory, parseSearch, stringifySearch })
 }

--- a/apps/web/src/utils/useDateRange.tsx
+++ b/apps/web/src/utils/useDateRange.tsx
@@ -2,8 +2,11 @@ import { useLocation } from "@tanstack/react-router"
 import { endOfMonth, startOfMonth } from "date-fns"
 
 export function useDateRange() {
-  const { year: yearParam, month: monthParam } = useLocation({
-    select: (location) => location.search,
+  const yearParam = useLocation({
+    select: (location) => location.search.year,
+  })
+  const monthParam = useLocation({
+    select: (location) => location.search.month,
   })
 
   const date = parseDateParam(yearParam, monthParam)


### PR DESCRIPTION
## 関連Issue

- closes #1203

## 変更内容

- 支払い一覧にカテゴリフィルタを追加し、登録済みカテゴリ / Uncategorized / All categories で一覧取得条件を切り替えられるようにした
- カテゴリ条件を Router search で管理し、ブラウザバックで絞り込みを戻せるようにした
- URL search のシリアライズを調整し、カテゴリ ID を `category=4` 形式で扱うようにした

## 動作確認

- [x] `task web:lint`
- [x] `task web:format-check`
- [x] `task web:typecheck`
- [x] `task web:test-unit`
- [x] `task web:test-storybook`
- [x] UIの確認

![カテゴリフィルタとCreate paymentボタンの表示確認](https://github.com/kosnu/savings/raw/fc2b440f6cbd71e75d6a7b9b0a5b6ee65ac9204b/screenshot-1203.png)
