### PR TITLE
カテゴリフィルタの空状態を追加

### DIFF
--- a/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
@@ -8,7 +8,7 @@ import {
   paymentsSearchSchema,
 } from "../../../features/payments/listPayment/paymentsSearchSchema"
 import { createQueryClient } from "../../../lib/queryClient"
-import { categories, entertainmentCat } from "../../../test/data/categories"
+import { categories, entertainmentCat, foodCat } from "../../../test/data/categories"
 import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
 import { payments } from "../../../test/data/payments"
 import { renderWithRouter } from "../../../test/helpers/renderWithRouter"
@@ -39,6 +39,15 @@ const createdPayment = mapPaymentToRow({
   updatedDate: new Date("2025-06-15T12:00:00+09:00"),
 })
 const initialPaymentRows = payments.map(mapPaymentToRow)
+const initialCurrentMonthPaymentRows = initialPaymentRows.filter((payment) =>
+  payment.date.startsWith("2025-06-"),
+)
+const uncategorizedPayment = mapPaymentToRow({
+  ...payments[0],
+  id: 1000,
+  categoryId: null,
+  note: "未設定の支払い",
+})
 
 function createStoryElement(queryClient = createQueryClient()) {
   return {
@@ -181,6 +190,110 @@ describe("PaymentsPage", () => {
       })
       expect(requests.some((url) => url.searchParams.get("category_id") === "eq.10")).toBe(true)
     })
+  })
+
+  test("ユーザー操作で登録済みカテゴリを選ぶと該当する支払いだけを表示する", async () => {
+    const requests: URL[] = []
+    server.use(
+      http.get("*/rest/v1/payments*", ({ request }) => {
+        const url = new URL(request.url)
+        requests.push(url)
+
+        if (url.searchParams.get("category_id") === `eq.${foodCat.id}`) {
+          return HttpResponse.json(
+            initialCurrentMonthPaymentRows.filter((payment) => payment.category_id === foodCat.id),
+          )
+        }
+
+        return HttpResponse.json(initialCurrentMonthPaymentRows)
+      }),
+    )
+    const { router, user } = renderPaymentsPageRoute("/payments?year=2025&month=6")
+
+    await selectCategoryFilterOption(user, foodCat.name)
+
+    await waitFor(() => {
+      expect(router.state.location.search).toEqual({
+        year: "2025",
+        month: "6",
+        category: String(foodCat.id),
+      })
+      expect(requests.some((url) => url.searchParams.get("category_id") === "eq.10")).toBe(true)
+    })
+
+    const paymentList = await screen.findByLabelText("payment-list")
+    expect(await within(paymentList).findAllByRole("button", { name: /コンビニ/ })).toHaveLength(1)
+    expect(within(paymentList).queryByText("Daily Necessities")).not.toBeInTheDocument()
+  })
+
+  test("ユーザー操作でカテゴリ未設定を選ぶと未設定の支払いを表示する", async () => {
+    const requests: URL[] = []
+    server.use(
+      http.get("*/rest/v1/payments*", ({ request }) => {
+        const url = new URL(request.url)
+        requests.push(url)
+
+        if (url.searchParams.get("category_id") === "is.null") {
+          return HttpResponse.json([uncategorizedPayment])
+        }
+
+        return HttpResponse.json(initialCurrentMonthPaymentRows)
+      }),
+    )
+    const { router, user } = renderPaymentsPageRoute("/payments?year=2025&month=6")
+
+    await selectCategoryFilterOption(user, "Uncategorized")
+
+    await waitFor(() => {
+      expect(router.state.location.search).toEqual({
+        year: "2025",
+        month: "6",
+        category: PAYMENT_SEARCH_CATEGORY_NONE_VALUE,
+      })
+      expect(requests.some((url) => url.searchParams.get("category_id") === "is.null")).toBe(true)
+    })
+
+    const paymentList = await screen.findByLabelText("payment-list")
+    expect(
+      await within(paymentList).findByRole("button", { name: /未設定の支払い/ }),
+    ).toBeInTheDocument()
+  })
+
+  test("カテゴリフィルタの空結果からフィルタを解除できる", async () => {
+    const requests: URL[] = []
+    server.use(
+      http.get("*/rest/v1/payments*", ({ request }) => {
+        const url = new URL(request.url)
+        requests.push(url)
+
+        if (url.searchParams.get("category_id") === `eq.${entertainmentCat.id}`) {
+          return HttpResponse.json([])
+        }
+
+        return HttpResponse.json(initialCurrentMonthPaymentRows)
+      }),
+    )
+    const { router, user } = renderPaymentsPageRoute("/payments?year=2025&month=6")
+
+    await selectCategoryFilterOption(user, entertainmentCat.name)
+
+    expect(await screen.findByText("No payments found.")).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Clear filter" }))
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: /category filter/i })).toHaveTextContent(
+        "All categories",
+      )
+      expect(router.state.location.search).toEqual({
+        year: "2025",
+        month: "6",
+        category: undefined,
+      })
+    })
+
+    const paymentList = await screen.findByLabelText("payment-list")
+    expect(await within(paymentList).findAllByRole("button", { name: /コンビニ/ })).toHaveLength(2)
   })
 
   test("ブラウザバックでカテゴリ条件を戻す", async () => {

--- a/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
@@ -177,6 +177,18 @@ describe("PaymentList", () => {
     expect(screen.getByRole("button", { name: "Clear filter" })).toBeInTheDocument()
   })
 
+  test("カテゴリ条件なしで支払いが0件の場合はフィルタ解除導線を表示しない", async () => {
+    server.resetHandlers(
+      http.get("*/rest/v1/payments*", () => HttpResponse.json([])),
+      ...createCategoryHandlers(),
+    )
+
+    renderPaymentList("/payments?year=2025&month=6")
+
+    expect(await screen.findByText("No payments found.")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Clear filter" })).not.toBeInTheDocument()
+  })
+
   test.each(["0", "-1", "1.2", "abc"])(
     "URL searchの不正カテゴリ %s は一覧取得条件に反映しない",
     async (category) => {

--- a/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
@@ -163,6 +163,20 @@ describe("PaymentList", () => {
     })
   })
 
+  test("支払いが0件の場合はカテゴリ取得完了を待たずに空状態を表示する", async () => {
+    server.resetHandlers(
+      http.get("*/rest/v1/payments*", () => HttpResponse.json([])),
+      http.get("*/rest/v1/categories*", async () => {
+        await new Promise(() => undefined)
+      }),
+    )
+
+    renderPaymentList("/payments?year=2025&month=6&category=10")
+
+    expect(await screen.findByText("No payments found.")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Clear filter" })).toBeInTheDocument()
+  })
+
   test.each(["0", "-1", "1.2", "abc"])(
     "URL searchの不正カテゴリ %s は一覧取得条件に反映しない",
     async (category) => {

--- a/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.tsx
@@ -1,4 +1,5 @@
-import { Flex } from "@radix-ui/themes"
+import { Button, Flex, Text } from "@radix-ui/themes"
+import { useNavigate } from "@tanstack/react-router"
 import { memo, Suspense, use, useCallback, useState } from "react"
 
 import { PaymentCard } from "../../../../components/payments/PaymentCard/PaymentCard"
@@ -14,6 +15,7 @@ import { usePayments } from "../usePayments"
 
 export const PaymentList = memo(function PaymentList() {
   const categoryId = useCategoryId()
+  const navigate = useNavigate({ from: "/payments" })
   const { promise: promisePayments } = usePayments({ categoryId })
   const { promise: promiseCategories } = useCategories()
   const { selectedPaymentId, openPaymentDetails, closePaymentDetails, onOpenChange } =
@@ -33,6 +35,13 @@ export const PaymentList = memo(function PaymentList() {
     closePaymentDetails()
   }, [closePaymentDetails])
 
+  const handleClearCategory = useCallback(() => {
+    void navigate({
+      to: "/payments",
+      search: (prev) => ({ ...prev, category: undefined }),
+    })
+  }, [navigate])
+
   return (
     <>
       <Flex aria-label="payment-list" direction="column" gap="2" tabIndex={-1}>
@@ -41,6 +50,8 @@ export const PaymentList = memo(function PaymentList() {
             promiseCategories={promiseCategories}
             getPayments={promisePayments}
             onOpenPayment={openPaymentDetails}
+            filtered={categoryId !== undefined}
+            onClearCategory={handleClearCategory}
           />
         </Suspense>
       </Flex>
@@ -64,10 +75,23 @@ interface ItemsProps {
   promiseCategories: Promise<Category[]>
   getPayments: Promise<Payment[]>
   onOpenPayment: (paymentId: PaymentId, trigger: HTMLButtonElement) => void
+  filtered: boolean
+  onClearCategory: () => void
 }
 
-const Items = memo(function Body({ promiseCategories, getPayments, onOpenPayment }: ItemsProps) {
+const Items = memo(function Body({
+  promiseCategories,
+  getPayments,
+  onOpenPayment,
+  filtered,
+  onClearCategory,
+}: ItemsProps) {
   const data = use(getPayments)
+
+  if (data.length === 0) {
+    return <EmptyItems filtered={filtered} onClearCategory={onClearCategory} />
+  }
+
   const categories = use(promiseCategories)
   const categoryMap = toCategoryMap(categories)
 
@@ -92,6 +116,25 @@ const Items = memo(function Body({ promiseCategories, getPayments, onOpenPayment
     </>
   )
 })
+
+function EmptyItems({
+  filtered,
+  onClearCategory,
+}: {
+  filtered: boolean
+  onClearCategory: () => void
+}) {
+  return (
+    <Flex align="start" direction="column" gap="2">
+      <Text color="gray">No payments found.</Text>
+      {filtered ? (
+        <Button variant="soft" onClick={onClearCategory}>
+          Clear filter
+        </Button>
+      ) : null}
+    </Flex>
+  )
+}
 
 function SkeltonItems() {
   return (


### PR DESCRIPTION
## 関連Issue

- #1204

## 変更内容

- カテゴリフィルタ適用中に支払いが0件の場合の空状態と解除導線を追加した
- ユーザー操作でカテゴリあり・カテゴリ未設定・空結果解除を確認するテストを追加した
- 支払い0件時はカテゴリ取得完了を待たずに空状態を表示するようにした

## 動作確認

- [x] task web:lint
- [x] task web:format-check
- [x] task web:typecheck
- [x] task web:test-unit
- [x] task web:test-storybook

## 補足

- PaymentsPage の story 追加は含めていません。