### PR TITLE
支払い詳細の読み込み表示を追加

### DIFF
--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.stories.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.stories.tsx
@@ -69,6 +69,19 @@ export const EmptyNote: Story = {
   },
 }
 
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...createPaymentHandlers({
+          get: { durationOrMode: "infinite" },
+        }),
+        ...categoryHandlers,
+      ],
+    },
+  },
+}
+
 export const MissingPayment: Story = {
   args: {
     paymentId: 9999,

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
@@ -12,7 +12,7 @@ import { render, screen, waitFor, within } from "../../../../test/test-utils"
 import { mapPaymentToRow } from "../../../../test/utils/mapPaymentToRow"
 import * as stories from "./PaymentDetailsOverlay.stories"
 
-const { Default, EmptyNote, FetchError, MissingPayment } = composeStories(stories)
+const { Default, EmptyNote, FetchError, Loading, MissingPayment } = composeStories(stories)
 
 describe("PaymentDetailsOverlay", () => {
   beforeEach(() => {
@@ -48,6 +48,27 @@ describe("PaymentDetailsOverlay", () => {
     expect(await within(dialog).findByText("No note")).toBeInTheDocument()
     expect(await within(dialog).findAllByText(/Date|Category|Note|Amount/)).toHaveLength(4)
     expect(await within(dialog).findByRole("button", { name: /delete/i })).toBeInTheDocument()
+  })
+
+  test("Loading story では詳細領域にスケルトンを表示して操作導線を出さない", async () => {
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        get: { durationOrMode: 1000 },
+      }),
+      ...categoryHandlers,
+    )
+
+    render(<Loading />)
+
+    const dialog = await screen.findByRole("dialog", { name: /payment details/i })
+
+    expect(await within(dialog).findByLabelText("loading payment details")).toBeInTheDocument()
+    expect(await within(dialog).findAllByText(/Date|Category|Note|Amount/)).toHaveLength(4)
+    expect(within(dialog).queryByRole("button", { name: /delete/i })).not.toBeInTheDocument()
+    expect(within(dialog).queryByRole("button", { name: /edit date/i })).not.toBeInTheDocument()
+    expect(within(dialog).queryByRole("button", { name: /edit category/i })).not.toBeInTheDocument()
+    expect(within(dialog).queryByRole("button", { name: /edit note/i })).not.toBeInTheDocument()
+    expect(within(dialog).queryByRole("button", { name: /edit amount/i })).not.toBeInTheDocument()
   })
 
   test("編集中の Escape はオーバーレイを閉じずに編集だけ解除する", async () => {

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
@@ -53,7 +53,7 @@ describe("PaymentDetailsOverlay", () => {
   test("Loading story では詳細領域にスケルトンを表示して操作導線を出さない", async () => {
     server.resetHandlers(
       ...createPaymentHandlers({
-        get: { durationOrMode: 1000 },
+        get: { durationOrMode: "infinite" },
       }),
       ...categoryHandlers,
     )

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
@@ -127,11 +127,13 @@ function PaymentDetailsLoading() {
 function LoadingField({ label }: { label: string }) {
   return (
     <Flex direction="column" gap="2">
-      <Text as="label" size="2" weight="bold">
+      <Text as="p" size="2" weight="bold">
         {label}
       </Text>
       <Skeleton loading>
-        <Text size="4">Loading payment details</Text>
+        <Text aria-hidden size="4">
+          Loading payment details
+        </Text>
       </Skeleton>
     </Flex>
   )

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Separator } from "@radix-ui/themes"
+import { Button, Flex, Separator, Skeleton, Text } from "@radix-ui/themes"
 import { useCallback, useState } from "react"
 
 import { ResponsiveOverlay } from "../../../../components/overlay/ResponsiveOverlay"
@@ -62,7 +62,9 @@ export function PaymentDetailsOverlay({
       title="Payment details"
       description={description}
     >
-      {hasPayment ? (
+      {isLoading ? (
+        <PaymentDetailsLoading />
+      ) : hasPayment ? (
         <Flex direction="column" gap="4">
           <Flex direction="column" gap="4">
             <PaymentDateField
@@ -108,6 +110,30 @@ export function PaymentDetailsOverlay({
         </Flex>
       ) : null}
     </ResponsiveOverlay>
+  )
+}
+
+function PaymentDetailsLoading() {
+  return (
+    <Flex aria-label="loading payment details" direction="column" gap="4">
+      <LoadingField label="Date" />
+      <LoadingField label="Category" />
+      <LoadingField label="Note" />
+      <LoadingField label="Amount" />
+    </Flex>
+  )
+}
+
+function LoadingField({ label }: { label: string }) {
+  return (
+    <Flex direction="column" gap="2">
+      <Text as="label" size="2" weight="bold">
+        {label}
+      </Text>
+      <Skeleton loading>
+        <Text size="4">Loading payment details</Text>
+      </Skeleton>
+    </Flex>
   )
 }
 


### PR DESCRIPTION
## 関連Issue

- closes #1206

## 変更内容

- 支払い詳細取得中に Date / Category / Note / Amount 相当のスケルトン表示を追加
- loading 中は編集・削除導線を表示せず、取得成功後は既存詳細に切り替えるように変更
- Loading story と unit test を追加

## 動作確認

- [x] task web:lint
- [x] task web:format-check
- [x] task web:typecheck
- [x] task web:test-unit
- [x] task web:test-storybook