### PR TITLE
サイドバー外クリックで閉じる

### DIFF
--- a/apps/web/src/app/AppLayout/AppLayout.test.tsx
+++ b/apps/web/src/app/AppLayout/AppLayout.test.tsx
@@ -34,8 +34,18 @@ describe("AppLayout", () => {
     window.localStorage.clear()
   })
 
+  test("初期表示では Sidebar を閉じた状態にする", async () => {
+    renderAppLayout()
+
+    expect(await screen.findByRole("complementary")).toHaveAttribute("data-open", "false")
+    expect(screen.queryByTestId("sidebar-backdrop")).not.toBeInTheDocument()
+  })
+
   test("Sidebar に Payments と Settings への導線を表示する", async () => {
     const { router, user } = renderAppLayout()
+
+    await user.click(await screen.findByLabelText("Menu button"))
+    expect(await screen.findByRole("complementary")).toHaveAttribute("data-open", "true")
 
     expect(
       await screen.findByRole("link", { name: "Navigate to Payments page" }),

--- a/apps/web/src/app/Sidebar/Sidebar.module.css
+++ b/apps/web/src/app/Sidebar/Sidebar.module.css
@@ -1,3 +1,10 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 9;
+  background: transparent;
+}
+
 /* Sidebarのスタイル */
 .sidebar {
   /* サイドバーを浮かすためにposition: absoluteを設定 */

--- a/apps/web/src/app/Sidebar/Sidebar.stories.tsx
+++ b/apps/web/src/app/Sidebar/Sidebar.stories.tsx
@@ -4,7 +4,7 @@ import { fn } from "storybook/test"
 import { createStoryRouter } from "../../test/helpers/routerDecorator"
 import { Sidebar } from "./Sidebar"
 
-const meta = {
+const meta: Meta<typeof Sidebar> = {
   title: "Shared/Sidebar/Sidebar",
   component: Sidebar,
   parameters: {
@@ -18,7 +18,7 @@ const meta = {
   args: {
     onClose: fn(),
   },
-} satisfies Meta<typeof Sidebar>
+}
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/apps/web/src/app/Sidebar/Sidebar.test.tsx
+++ b/apps/web/src/app/Sidebar/Sidebar.test.tsx
@@ -1,5 +1,5 @@
 import { composeStories } from "@storybook/react-vite"
-import { describe, expect, test } from "vite-plus/test"
+import { describe, expect, test, vi } from "vite-plus/test"
 
 import { render, screen } from "../../test/test-utils"
 import * as stories from "./Sidebar.stories"
@@ -23,5 +23,31 @@ describe("Sidebar", () => {
     expect(await screen.findByText("My Savings")).toBeInTheDocument()
     expect(await screen.findByText("Sidebar Content")).toBeInTheDocument()
     expect(sidebar).toHaveAttribute("data-open", "false")
+  })
+
+  test("開いている状態でサイドバー領域外をクリックすると onClose を呼ぶ", async () => {
+    const onClose = vi.fn()
+    const { user } = render(<Default onClose={onClose} />)
+
+    await user.click(await screen.findByTestId("sidebar-backdrop"))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  test("サイドバー内をクリックしても領域外クリックとして onClose を呼ばない", async () => {
+    const onClose = vi.fn()
+    const { user } = render(<Default onClose={onClose} />)
+
+    await user.click(await screen.findByText("Sidebar Content"))
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  test("閉じている状態では領域外クリック用の backdrop を表示しない", async () => {
+    const onClose = vi.fn()
+    render(<Closed onClose={onClose} />)
+
+    expect(screen.queryByTestId("sidebar-backdrop")).not.toBeInTheDocument()
+    expect(onClose).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/app/Sidebar/Sidebar.tsx
+++ b/apps/web/src/app/Sidebar/Sidebar.tsx
@@ -28,32 +28,42 @@ export function Sidebar({ children, open, onClose }: SidebarProps) {
   }, [navigate, onClose, supabase])
 
   return (
-    <aside data-open={open} className={styles.sidebar}>
-      {/* Sidebar Header */}
-      <Flex className={styles.sidebarHeader} p="4" justify="between" align="center" gap="4">
-        <Link to="/" className={styles.link}>
-          <Button className={styles.sidebarButton} variant="ghost" size="3">
-            <Text size="3" weight="bold">
-              My Savings
-            </Text>
+    <>
+      {open ? (
+        <div
+          aria-hidden="true"
+          className={styles.backdrop}
+          data-testid="sidebar-backdrop"
+          onClick={onClose}
+        />
+      ) : null}
+      <aside data-open={open} className={styles.sidebar}>
+        {/* Sidebar Header */}
+        <Flex className={styles.sidebarHeader} p="4" justify="between" align="center" gap="4">
+          <Link to="/" className={styles.link}>
+            <Button className={styles.sidebarButton} variant="ghost" size="3">
+              <Text size="3" weight="bold">
+                My Savings
+              </Text>
+            </Button>
+          </Link>
+          <IconButton variant="ghost" onClick={onClose}>
+            <Cross1Icon />
+          </IconButton>
+        </Flex>
+        <Separator size="4" />
+        {/* Sidebar Contents */}
+        <Flex className={styles.sidebarContents} align="start" direction="column" gap="4" p="4">
+          {children}
+        </Flex>
+        <Separator size="4" />
+        {/* Sidebar Footer */}
+        <Flex className={styles.sidebarFooter} p="4">
+          <Button color="red" variant="soft" onClick={handleLogout}>
+            Supabaseログアウト（検証用）
           </Button>
-        </Link>
-        <IconButton variant="ghost" onClick={onClose}>
-          <Cross1Icon />
-        </IconButton>
-      </Flex>
-      <Separator size="4" />
-      {/* Sidebar Contents */}
-      <Flex className={styles.sidebarContents} align="start" direction="column" gap="4" p="4">
-        {children}
-      </Flex>
-      <Separator size="4" />
-      {/* Sidebar Footer */}
-      <Flex className={styles.sidebarFooter} p="4">
-        <Button color="red" variant="soft" onClick={handleLogout}>
-          Supabaseログアウト（検証用）
-        </Button>
-      </Flex>
-    </aside>
+        </Flex>
+      </aside>
+    </>
   )
 }

--- a/apps/web/src/app/Sidebar/useSidebar.test.tsx
+++ b/apps/web/src/app/Sidebar/useSidebar.test.tsx
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, test } from "vite-plus/test"
+
+import { act, renderHook } from "../../test/test-utils"
+import { useSidebar } from "./useSidebar"
+
+describe("useSidebar", () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  test("保存済みの状態がない場合は閉じた状態で初期化する", () => {
+    const { result } = renderHook(() => useSidebar())
+
+    expect(result.current.open).toBe(false)
+  })
+
+  test("保存済みの状態がある場合は保存値を初期状態に使う", () => {
+    window.localStorage.setItem("sidebarOpen", "true")
+
+    const { result } = renderHook(() => useSidebar())
+
+    expect(result.current.open).toBe(true)
+  })
+
+  test("openSidebar で開き、closeSidebar で閉じる", () => {
+    const { result } = renderHook(() => useSidebar())
+
+    act(() => {
+      result.current.openSidebar()
+    })
+
+    expect(result.current.open).toBe(true)
+
+    act(() => {
+      result.current.closeSidebar()
+    })
+
+    expect(result.current.open).toBe(false)
+  })
+})

--- a/apps/web/src/app/Sidebar/useSidebar.ts
+++ b/apps/web/src/app/Sidebar/useSidebar.ts
@@ -9,7 +9,7 @@ interface UseSidebarReturn {
 
 const SIDEBAR_STATE_KEY = "sidebarOpen"
 
-export function useSidebar(defaultOpen: boolean = true): UseSidebarReturn {
+export function useSidebar(defaultOpen: boolean = false): UseSidebarReturn {
   const [open, setOpen] = useState<boolean>(() => {
     // サーバーサイドレンダリング(SSR)中はwindowオブジェクトがないため、エラーを回避します。
     if (typeof window === "undefined") {


### PR DESCRIPTION
## 関連Issue

- closes #1205

## 変更内容

- サイドバーが開いている間だけ透明な backdrop を表示し、領域外クリックで既存の onClose を呼ぶようにしました。
- Sidebar の Story を使った unit test に、外側クリック・内側クリック・閉じた状態の確認を追加しました。

## 動作確認

- [x] task web:lint
- [x] task web:format-check
- [x] task web:typecheck
- [x] task web:test-unit
- [x] task web:test-storybook