### PR TITLE
カテゴリ名と支払いメモの文字数制限を追加

### DIFF
--- a/apps/web/src/features/categories/categorySchema.test.ts
+++ b/apps/web/src/features/categories/categorySchema.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vite-plus/test"
+import z from "zod"
+
+import { CATEGORY_NAME_MAX_LENGTH, categoryNameSchema } from "./categorySchema"
+
+describe("categoryNameSchema", () => {
+  test("20文字以下のカテゴリ名を許可する", () => {
+    const result = categoryNameSchema.safeParse("a".repeat(CATEGORY_NAME_MAX_LENGTH))
+
+    expect(result.success).toBe(true)
+  })
+
+  test("20文字を超えるカテゴリ名を拒否する", () => {
+    const result = categoryNameSchema.safeParse("a".repeat(CATEGORY_NAME_MAX_LENGTH + 1))
+
+    expect(result.success).toBe(false)
+
+    const error = result.error && z.flattenError(result.error).formErrors
+    expect(error).toEqual([`Category name must be ${CATEGORY_NAME_MAX_LENGTH} characters or less`])
+  })
+})

--- a/apps/web/src/features/categories/categorySchema.ts
+++ b/apps/web/src/features/categories/categorySchema.ts
@@ -1,0 +1,10 @@
+import * as z from "zod"
+
+export const CATEGORY_NAME_MAX_LENGTH = 20
+
+export const categoryNameSchema = z
+  .string()
+  .max(
+    CATEGORY_NAME_MAX_LENGTH,
+    `Category name must be ${CATEGORY_NAME_MAX_LENGTH} characters or less`,
+  )

--- a/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.test.tsx
+++ b/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.test.tsx
@@ -6,6 +6,7 @@ import { createCategoryHandlers } from "../../../../test/msw/handlers/categories
 import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
 import { server } from "../../../../test/msw/server"
 import { act, render, screen, type TestUser, waitFor, within } from "../../../../test/test-utils"
+import { PAYMENT_NOTE_MAX_LENGTH } from "../../paymentFormSchema"
 import * as stories from "./CreatePaymentForm.stories"
 
 const { Default } = composeStories(stories)
@@ -65,6 +66,24 @@ describe("CreatePaymentForm", () => {
     await user.click(screen.getByRole("button", { name: /create/i }))
 
     expect(await screen.findByText("Amount cannot be empty")).toBeInTheDocument()
+  })
+
+  test("note が30文字を超えると作成せずにエラーを表示する", async () => {
+    const onSuccess = vi.fn()
+
+    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
+
+    await user.type(screen.getByRole("textbox", { name: /amount/i }), "1080")
+    await user.type(
+      screen.getByRole("textbox", { name: /note/i }),
+      "a".repeat(PAYMENT_NOTE_MAX_LENGTH + 1),
+    )
+    await user.click(screen.getByRole("button", { name: /create/i }))
+
+    expect(
+      await screen.findByText(`Note must be ${PAYMENT_NOTE_MAX_LENGTH} characters or less`),
+    ).toBeInTheDocument()
+    expect(onSuccess).not.toHaveBeenCalled()
   })
 
   test("category と note が空でも作成できる", async () => {

--- a/apps/web/src/features/payments/createPayment/CreatePaymentModal/CreatePaymentModal.test.tsx
+++ b/apps/web/src/features/payments/createPayment/CreatePaymentModal/CreatePaymentModal.test.tsx
@@ -148,7 +148,7 @@ describe("CreatePaymentModal", () => {
     const checkbox = within(dialog).getByRole("checkbox", { name: /continue creating/i })
     expect(checkbox).not.toBeChecked()
 
-    await fillAndSubmit(user, dialog, body, "Test payment without continuous mode")
+    await fillAndSubmit(user, dialog, body, "Test payment once")
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledTimes(1)

--- a/apps/web/src/features/payments/createPayment/formSchema.test.ts
+++ b/apps/web/src/features/payments/createPayment/formSchema.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "vite-plus/test"
 import z from "zod"
 
-import { paymentFormSchema, paymentFormSubmitSchema } from "../paymentFormSchema"
+import {
+  PAYMENT_NOTE_MAX_LENGTH,
+  paymentFormSchema,
+  paymentFormSubmitSchema,
+} from "../paymentFormSchema"
 
 describe("paymentFormSchema", () => {
   const data = {
@@ -40,6 +44,26 @@ describe("paymentFormSchema", () => {
     const result = paymentFormSchema.safeParse({ ...data, note: "" })
     expect(result.success).toBe(true)
     expect(result.data?.note).toBe("")
+  })
+
+  test("should allow note with max length", () => {
+    const note = "a".repeat(PAYMENT_NOTE_MAX_LENGTH)
+    const result = paymentFormSchema.safeParse({ ...data, note })
+
+    expect(result.success).toBe(true)
+    expect(result.data?.note).toBe(note)
+  })
+
+  test("should fail when note exceeds max length", () => {
+    const result = paymentFormSchema.safeParse({
+      ...data,
+      note: "a".repeat(PAYMENT_NOTE_MAX_LENGTH + 1),
+    })
+
+    expect(result.success).toBe(false)
+
+    const error = result.error && z.flattenError(result.error).fieldErrors.note
+    expect(error).toEqual([`Note must be ${PAYMENT_NOTE_MAX_LENGTH} characters or less`])
   })
 
   test("should fail when date is iso", () => {
@@ -130,6 +154,18 @@ describe("paymentFormSubmitSchema", () => {
       expect(result.data?.category).toBe("")
       expect(result.data?.note).toBe("")
     }
+  })
+
+  test("should fail when note exceeds max length", () => {
+    const result = paymentFormSubmitSchema.safeParse({
+      ...data,
+      note: "a".repeat(PAYMENT_NOTE_MAX_LENGTH + 1),
+    })
+
+    expect(result.success).toBe(false)
+
+    const error = result.error && z.flattenError(result.error).fieldErrors.note
+    expect(error).toEqual([`Note must be ${PAYMENT_NOTE_MAX_LENGTH} characters or less`])
   })
 
   test("should fail when amount is empty", () => {

--- a/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.test.tsx
@@ -1,12 +1,15 @@
 import { composeStories } from "@storybook/react-vite"
+import { HttpResponse, http } from "msw"
 import { beforeEach, describe, expect, test, vi } from "vite-plus/test"
 
 import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
 import { server } from "../../../../test/msw/server"
 import { render, screen, waitFor } from "../../../../test/test-utils"
+import { PAYMENT_NOTE_MAX_LENGTH } from "../../paymentFormSchema"
 import * as stories from "./NoteField.stories"
 
 const { Default, EmptyNote } = composeStories(stories)
+const PAYMENTS_REST_URL = "*/rest/v1/payments*"
 
 describe("PaymentDetails NoteField", () => {
   beforeEach(() => {
@@ -46,6 +49,33 @@ describe("PaymentDetails NoteField", () => {
     await waitFor(() => {
       expect(screen.queryByRole("textbox", { name: /note/i })).not.toBeInTheDocument()
     })
+  })
+
+  test("30文字を超えるノートは保存せずにエラーを表示する", async () => {
+    let updateRequested = false
+
+    server.resetHandlers(
+      http.patch(PAYMENTS_REST_URL, () => {
+        updateRequested = true
+        return HttpResponse.json({ message: "Updated" })
+      }),
+    )
+
+    const { user } = render(<Default />)
+
+    await user.click(screen.getByRole("button", { name: /edit note/i }))
+    const noteInput = screen.getByRole("textbox", { name: /note/i })
+    await user.clear(noteInput)
+    await user.type(noteInput, "a".repeat(PAYMENT_NOTE_MAX_LENGTH + 1))
+    await user.click(screen.getByRole("button", { name: /save note/i }))
+
+    expect(
+      await screen.findByText(`Note must be ${PAYMENT_NOTE_MAX_LENGTH} characters or less`, {
+        selector: "span",
+      }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole("textbox", { name: /note/i })).toBeInTheDocument()
+    expect(updateRequested).toBe(false)
   })
 
   test("編集中の Escape は編集だけ解除する", async () => {

--- a/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.tsx
+++ b/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.tsx
@@ -12,7 +12,9 @@ import {
 
 import { useSnackbar } from "../../../../providers/snackbar"
 import type { PaymentId } from "../../../../types/payment"
+import { getZodErrorMessages } from "../../../../utils/getZodErrorMessages"
 import { NoteInput } from "../../components/NoteInput"
+import { noteFieldSchema } from "../../paymentFormSchema"
 import { useUpdatePayment } from "../../updatePayment/useUpdatePayment"
 import { EditableField } from "../EditableField"
 import { SubmitIconButton } from "../SubmitIconButton"
@@ -87,11 +89,18 @@ export function NoteField({
       return
     }
 
+    const result = noteFieldSchema.safeParse(draftNote)
+
+    if (!result.success) {
+      setMessages(getZodErrorMessages(result.error))
+      return
+    }
+
     try {
       setMessages(undefined)
       await updatePayment({
         paymentId,
-        patch: { note: draftNote },
+        patch: { note: result.data },
       })
       editingRef.current = false
       setEditing(false)

--- a/apps/web/src/features/payments/paymentFormMappers.test.ts
+++ b/apps/web/src/features/payments/paymentFormMappers.test.ts
@@ -6,6 +6,7 @@ import {
   toPaymentWriteInsert,
   toPaymentWriteUpdate,
 } from "./paymentFormMappers"
+import { PAYMENT_NOTE_MAX_LENGTH } from "./paymentFormSchema"
 
 function createPaymentFixture(overrides: Partial<Payment> = {}): Payment {
   return {
@@ -81,6 +82,17 @@ describe("toPaymentWriteInsert", () => {
       amount: 0,
     })
   })
+
+  test("30文字を超える note は reject する", () => {
+    expect(() =>
+      toPaymentWriteInsert({
+        date: new Date(2024, 8, 22),
+        categoryId: "",
+        note: "a".repeat(PAYMENT_NOTE_MAX_LENGTH + 1),
+        amount: 0,
+      }),
+    ).toThrow(`Note must be ${PAYMENT_NOTE_MAX_LENGTH} characters or less`)
+  })
 })
 
 describe("toPaymentWriteUpdate", () => {
@@ -112,5 +124,13 @@ describe("toPaymentWriteUpdate", () => {
 
   test("空 patch は reject する", () => {
     expect(() => toPaymentWriteUpdate({})).toThrow("Payment update patch cannot be empty")
+  })
+
+  test("30文字を超える note は reject する", () => {
+    expect(() =>
+      toPaymentWriteUpdate({
+        note: "a".repeat(PAYMENT_NOTE_MAX_LENGTH + 1),
+      }),
+    ).toThrow(`Note must be ${PAYMENT_NOTE_MAX_LENGTH} characters or less`)
   })
 })

--- a/apps/web/src/features/payments/paymentFormMappers.ts
+++ b/apps/web/src/features/payments/paymentFormMappers.ts
@@ -2,7 +2,7 @@ import { format } from "date-fns"
 
 import type { TablesInsert, TablesUpdate } from "../../types/database.types"
 import type { Payment } from "../../types/payment"
-import type { PaymentFormValues } from "./paymentFormSchema"
+import { noteFieldSchema, type PaymentFormValues } from "./paymentFormSchema"
 
 type PaymentInsert = Omit<TablesInsert<"payments">, "user_id">
 type PaymentUpdate = Omit<TablesUpdate<"payments">, "user_id" | "id" | "created_at" | "updated_at">
@@ -31,10 +31,12 @@ export function mapPaymentToFormValues(payment: Payment): PaymentFormValues {
 }
 
 export function toPaymentWriteInsert(value: PaymentWriteInput): PaymentInsert {
+  const note = validatePaymentNote(value.note)
+
   return {
     amount: value.amount,
     date: format(value.date, "yyyy-MM-dd"),
-    note: value.note === "" ? null : (value.note ?? null),
+    note: note === "" ? null : (note ?? null),
     category_id: toCategoryId(value.categoryId),
   }
 }
@@ -55,7 +57,8 @@ export function toPaymentWriteUpdate(patch: PaymentUpdatePatch): PaymentUpdate {
     updatePayload.date = format(patch.date, "yyyy-MM-dd")
   }
   if (patch.note !== undefined) {
-    updatePayload.note = patch.note || null
+    const note = validatePaymentNote(patch.note)
+    updatePayload.note = note === "" ? null : note
   }
   if (patch.categoryId !== undefined) {
     updatePayload.category_id = toCategoryId(patch.categoryId)
@@ -68,4 +71,10 @@ function toCategoryId(categoryId?: string): number | null {
   if (!categoryId) return null
   const parsed = Number(categoryId)
   return Number.isNaN(parsed) ? null : parsed
+}
+
+function validatePaymentNote(note?: string): string | undefined {
+  if (note === undefined) return undefined
+
+  return noteFieldSchema.parse(note)
 }

--- a/apps/web/src/features/payments/paymentFormSchema.ts
+++ b/apps/web/src/features/payments/paymentFormSchema.ts
@@ -1,5 +1,7 @@
 import * as z from "zod"
 
+export const PAYMENT_NOTE_MAX_LENGTH = 30
+
 export const categoryFieldSchema = z.string()
 
 export const dateFieldSchema = z.date({
@@ -11,7 +13,9 @@ export const dateFieldSchema = z.date({
   },
 })
 
-export const noteFieldSchema = z.string()
+export const noteFieldSchema = z
+  .string()
+  .max(PAYMENT_NOTE_MAX_LENGTH, `Note must be ${PAYMENT_NOTE_MAX_LENGTH} characters or less`)
 
 export const amountFieldSchema = z
   .number({


### PR DESCRIPTION
## 関連Issue

- closes #1208

## 変更内容

- カテゴリ名を20文字以下、支払いメモを30文字以下として扱う schema を追加
- 支払いメモの作成フォーム、詳細編集、保存前変換で同じ validation を適用
- 空メモの null 正規化を維持し、DB migration は追加しない

## 動作確認

- [x] task web:lint
- [x] task web:format-check
- [x] task web:typecheck
- [x] task web:test-unit
- [x] task web:test-storybook