### PR TITLE
支払い詳細をURLから開けるようにする

### DIFF
--- a/apps/web/src/app/routes.ts
+++ b/apps/web/src/app/routes.ts
@@ -68,6 +68,11 @@ const paymentsRoute = createRoute({
   validateSearch: paymentsSearchSchema,
 })
 
+const paymentDetailsRoute = createRoute({
+  getParentRoute: () => paymentsRoute,
+  path: "details/$paymentId",
+})
+
 const aggregatesRoute = createRoute({
   getParentRoute: () => authenticatedRoute,
   path: "/aggregates",
@@ -90,7 +95,7 @@ const routeTree = rootRoute.addChildren([
   indexRoute,
   authRoute,
   authenticatedRoute.addChildren([
-    paymentsRoute,
+    paymentsRoute.addChildren([paymentDetailsRoute]),
     aggregatesRoute,
     settingsRoute.addChildren([settingsBudgetsRoute]),
   ]),

--- a/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
@@ -85,7 +85,12 @@ function renderPaymentsPageRoute(initialEntry: string) {
         validateSearch: paymentsSearchSchema,
       })
 
-      return [authenticatedRoute.addChildren([paymentsRoute])]
+      const paymentDetailsRoute = createRoute({
+        getParentRoute: () => paymentsRoute,
+        path: "details/$paymentId",
+      })
+
+      return [authenticatedRoute.addChildren([paymentsRoute.addChildren([paymentDetailsRoute])])]
     },
     { queryClient },
   )
@@ -330,6 +335,22 @@ describe("PaymentsPage", () => {
         month: "6",
       })
       expect(lastRequest(requests)?.searchParams.has("category_id")).toBe(false)
+    })
+  })
+
+  test("詳細URLを直接開いて閉じると一覧条件を維持して一覧URLへ戻る", async () => {
+    const { router, user } = renderPaymentsPageRoute(
+      "/payments/details/2?year=2025&month=6&category=20",
+    )
+
+    const detailDialog = await screen.findByRole("dialog", { name: /payment details/i })
+    expect(await within(detailDialog).findByText("Daily Necessities")).toBeInTheDocument()
+
+    await user.click(within(detailDialog).getByRole("button", { name: /close payment details/i }))
+
+    await waitFor(() => {
+      expect(router.state.location.href).toBe("/payments?year=2025&month=6&category=20")
+      expect(screen.queryByRole("dialog", { name: /payment details/i })).not.toBeInTheDocument()
     })
   })
 

--- a/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
@@ -162,12 +162,21 @@ describe("PaymentList", () => {
   })
 
   test("不正な詳細URLの支払いIDはnot foundとして表示する", async () => {
-    server.resetHandlers(...createPaymentHandlers(), ...createCategoryHandlers())
+    const requests: URL[] = []
+    server.resetHandlers(
+      http.get("*/rest/v1/payments*", ({ request }) => {
+        requests.push(new URL(request.url))
+
+        return HttpResponse.json([])
+      }),
+      ...createCategoryHandlers(),
+    )
 
     renderPaymentList("/payments/details/abc?year=2025&month=6")
 
     const dialog = await screen.findByRole("dialog", { name: /payment details/i })
     expect(await within(dialog).findByText("Payment not found.")).toBeInTheDocument()
+    expect(requests.some((url) => url.searchParams.get("id") === "eq.0")).toBe(false)
   })
 
   test("詳細表示中にブラウザバックすると一覧URLに戻り詳細を閉じる", async () => {
@@ -182,6 +191,23 @@ describe("PaymentList", () => {
 
     await waitFor(() => {
       expect(router.state.location.href).toBe("/payments?year=2025&month=6")
+      expect(screen.queryByRole("dialog", { name: /payment details/i })).not.toBeInTheDocument()
+    })
+  })
+
+  test("一覧から開いた詳細を閉じると履歴を戻して一覧URLへ戻る", async () => {
+    server.resetHandlers(...createPaymentHandlers(), ...createCategoryHandlers())
+    const { router, user } = renderPaymentList("/payments?year=2025&month=6")
+
+    const paymentButton = (await screen.findAllByRole("button", { name: /コンビニ/ }))[0]
+    await user.click(paymentButton)
+
+    const dialog = await screen.findByRole("dialog", { name: /payment details/i })
+    await user.click(within(dialog).getByRole("button", { name: /close payment details/i }))
+
+    await waitFor(() => {
+      expect(router.state.location.href).toBe("/payments?year=2025&month=6")
+      expect(router.state.location.state.__TSR_index).toBe(0)
       expect(screen.queryByRole("dialog", { name: /payment details/i })).not.toBeInTheDocument()
     })
   })

--- a/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
@@ -6,6 +6,7 @@ import { describe, expect, test } from "vite-plus/test"
 import { createQueryClient } from "../../../../lib/queryClient"
 import { renderWithRouter } from "../../../../test/helpers/renderWithRouter"
 import { createCategoryHandlers } from "../../../../test/msw/handlers/categories"
+import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
 import { server } from "../../../../test/msw/server"
 import { render, screen, waitFor, within } from "../../../../test/test-utils"
 import { paymentsSearchSchema } from "../paymentsSearchSchema"
@@ -36,7 +37,12 @@ function renderPaymentList(initialEntry: string) {
         validateSearch: paymentsSearchSchema,
       })
 
-      return [authenticatedRoute.addChildren([paymentsRoute])]
+      const paymentDetailsRoute = createRoute({
+        getParentRoute: () => paymentsRoute,
+        path: "details/$paymentId",
+      })
+
+      return [authenticatedRoute.addChildren([paymentsRoute.addChildren([paymentDetailsRoute])])]
     },
     { queryClient: createQueryClient() },
   )
@@ -125,6 +131,59 @@ describe("PaymentList", () => {
     render(<Loading />)
 
     expect(await screen.findAllByLabelText("loading-payment-item")).toHaveLength(3)
+  })
+
+  test("支払い行を開くと現在の検索条件を維持して詳細URLへ遷移する", async () => {
+    server.resetHandlers(...createPaymentHandlers(), ...createCategoryHandlers())
+    const { router, user } = renderPaymentList("/payments?year=2025&month=6&category=10")
+
+    const paymentButton = (await screen.findAllByRole("button", { name: /コンビニ/ }))[0]
+    await user.click(paymentButton)
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/payments/details/2")
+      expect(router.state.location.search).toEqual({
+        year: "2025",
+        month: "6",
+        category: "10",
+      })
+      expect("paymentId" in router.state.location.search).toBe(false)
+    })
+    expect(await screen.findByRole("dialog", { name: /payment details/i })).toBeInTheDocument()
+  })
+
+  test("詳細URLを直接開くと詳細を表示する", async () => {
+    server.resetHandlers(...createPaymentHandlers(), ...createCategoryHandlers())
+
+    renderPaymentList("/payments/details/2?year=2025&month=6")
+
+    const dialog = await screen.findByRole("dialog", { name: /payment details/i })
+    expect(await within(dialog).findByText("Daily Necessities")).toBeInTheDocument()
+  })
+
+  test("不正な詳細URLの支払いIDはnot foundとして表示する", async () => {
+    server.resetHandlers(...createPaymentHandlers(), ...createCategoryHandlers())
+
+    renderPaymentList("/payments/details/abc?year=2025&month=6")
+
+    const dialog = await screen.findByRole("dialog", { name: /payment details/i })
+    expect(await within(dialog).findByText("Payment not found.")).toBeInTheDocument()
+  })
+
+  test("詳細表示中にブラウザバックすると一覧URLに戻り詳細を閉じる", async () => {
+    server.resetHandlers(...createPaymentHandlers(), ...createCategoryHandlers())
+    const { router, user } = renderPaymentList("/payments?year=2025&month=6")
+
+    const paymentButton = (await screen.findAllByRole("button", { name: /コンビニ/ }))[0]
+    await user.click(paymentButton)
+
+    await screen.findByRole("dialog", { name: /payment details/i })
+    router.history.back()
+
+    await waitFor(() => {
+      expect(router.state.location.href).toBe("/payments?year=2025&month=6")
+      expect(screen.queryByRole("dialog", { name: /payment details/i })).not.toBeInTheDocument()
+    })
   })
 
   test("URL searchの登録済みカテゴリIDを一覧取得条件に反映する", async () => {

--- a/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.tsx
@@ -18,8 +18,13 @@ export const PaymentList = memo(function PaymentList() {
   const navigate = useNavigate({ from: "/payments" })
   const { promise: promisePayments } = usePayments({ categoryId })
   const { promise: promiseCategories } = useCategories()
-  const { selectedPaymentId, openPaymentDetails, closePaymentDetails, onOpenChange } =
-    usePaymentDetailsState()
+  const {
+    hasPaymentDetailsRoute,
+    selectedPaymentId,
+    openPaymentDetails,
+    closePaymentDetails,
+    onOpenChange,
+  } = usePaymentDetailsState()
   const [paymentPendingDelete, setPaymentPendingDelete] = useState<Payment | null>(null)
 
   const handleDeleteIntent = useCallback((payment: Payment) => {
@@ -56,7 +61,7 @@ export const PaymentList = memo(function PaymentList() {
         </Suspense>
       </Flex>
       <PaymentDetailsOverlay
-        open={selectedPaymentId !== null}
+        open={hasPaymentDetailsRoute}
         paymentId={selectedPaymentId}
         onOpenChange={onOpenChange}
         onDelete={handleDeleteIntent}

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
@@ -25,12 +25,10 @@ export function PaymentDetailsOverlay({
 }: PaymentDetailsOverlayProps) {
   const { data: payment, isLoading, error } = usePaymentDetails(paymentId)
   const [isEditingField, setIsEditingField] = useState(false)
-  const hasPayment = payment !== null && payment !== undefined
-  const isNotFound =
-    !isLoading &&
-    !error &&
-    open &&
-    (paymentId === null || payment === null || payment === undefined)
+  const hasPaymentId = paymentId !== null
+  const hasPaymentDetails = payment !== null && payment !== undefined
+  const canShowPaymentDetails = hasPaymentId && hasPaymentDetails
+  const isNotFound = open && !isLoading && !error && !canShowPaymentDetails
   const description = error
     ? "Failed to load payment details."
     : isNotFound
@@ -67,7 +65,7 @@ export function PaymentDetailsOverlay({
     >
       {isLoading ? (
         <PaymentDetailsLoading />
-      ) : hasPayment ? (
+      ) : hasPaymentDetails ? (
         <Flex direction="column" gap="4">
           <Flex direction="column" gap="4">
             <PaymentDateField

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
@@ -27,7 +27,10 @@ export function PaymentDetailsOverlay({
   const [isEditingField, setIsEditingField] = useState(false)
   const hasPayment = payment !== null && payment !== undefined
   const isNotFound =
-    !isLoading && !error && paymentId !== null && (payment === null || payment === undefined)
+    !isLoading &&
+    !error &&
+    open &&
+    (paymentId === null || payment === null || payment === undefined)
   const description = error
     ? "Failed to load payment details."
     : isNotFound

--- a/apps/web/src/features/payments/paymentDetails/usePaymentDetailsState.ts
+++ b/apps/web/src/features/payments/paymentDetails/usePaymentDetailsState.ts
@@ -1,22 +1,35 @@
-import { useCallback, useRef, useState } from "react"
+import { useNavigate, useParams } from "@tanstack/react-router"
+import { useCallback, useRef } from "react"
 
 import type { PaymentId } from "../../../types/payment"
 
 export function usePaymentDetailsState() {
-  const [selectedPaymentId, setSelectedPaymentId] = useState<PaymentId | null>(null)
+  const selectedPaymentId = useSelectedPaymentId()
+  const navigate = useNavigate({ from: "/payments" })
   const lastOpenedTriggerRef = useRef<HTMLButtonElement | null>(null)
 
-  const openPaymentDetails = useCallback((paymentId: PaymentId, trigger: HTMLButtonElement) => {
-    lastOpenedTriggerRef.current = trigger
-    setSelectedPaymentId(paymentId)
-  }, [])
+  const openPaymentDetails = useCallback(
+    (paymentId: PaymentId, trigger: HTMLButtonElement) => {
+      lastOpenedTriggerRef.current = trigger
+      void navigate({
+        to: "/payments/details/$paymentId",
+        params: { paymentId: String(paymentId) },
+        search: (prev) => prev,
+      })
+    },
+    [navigate],
+  )
 
   const closePaymentDetails = useCallback(() => {
-    setSelectedPaymentId(null)
+    void navigate({
+      to: "/payments",
+      search: (prev) => prev,
+      replace: true,
+    })
     requestAnimationFrame(() => {
       lastOpenedTriggerRef.current?.focus()
     })
-  }, [])
+  }, [navigate])
 
   const onOpenChange = useCallback(
     (open: boolean) => {
@@ -32,4 +45,27 @@ export function usePaymentDetailsState() {
     closePaymentDetails,
     onOpenChange,
   }
+}
+
+function useSelectedPaymentId(): PaymentId | null {
+  const paymentIdParam = useParams({
+    strict: false,
+    select: (params) => params.paymentId,
+  })
+
+  if (paymentIdParam === undefined) {
+    return null
+  }
+
+  return toPaymentId(paymentIdParam)
+}
+
+function toPaymentId(paymentIdParam: string): PaymentId {
+  const paymentId = Number(paymentIdParam)
+
+  if (Number.isSafeInteger(paymentId) && paymentId > 0) {
+    return paymentId
+  }
+
+  return 0
 }

--- a/apps/web/src/features/payments/paymentDetails/usePaymentDetailsState.ts
+++ b/apps/web/src/features/payments/paymentDetails/usePaymentDetailsState.ts
@@ -1,11 +1,12 @@
-import { useNavigate, useParams } from "@tanstack/react-router"
+import { useNavigate, useParams, useRouter } from "@tanstack/react-router"
 import { useCallback, useRef } from "react"
 
 import type { PaymentId } from "../../../types/payment"
 
 export function usePaymentDetailsState() {
-  const selectedPaymentId = useSelectedPaymentId()
+  const { hasPaymentDetailsRoute, selectedPaymentId } = useSelectedPaymentDetails()
   const navigate = useNavigate({ from: "/payments" })
+  const router = useRouter()
   const lastOpenedTriggerRef = useRef<HTMLButtonElement | null>(null)
 
   const openPaymentDetails = useCallback(
@@ -21,15 +22,23 @@ export function usePaymentDetailsState() {
   )
 
   const closePaymentDetails = useCallback(() => {
-    void navigate({
-      to: "/payments",
-      search: (prev) => prev,
-      replace: true,
-    })
+    const openedTrigger = lastOpenedTriggerRef.current
+    lastOpenedTriggerRef.current = null
+
+    if (openedTrigger) {
+      router.history.back()
+    } else {
+      void navigate({
+        to: "/payments",
+        search: (prev) => prev,
+        replace: true,
+      })
+    }
+
     requestAnimationFrame(() => {
-      lastOpenedTriggerRef.current?.focus()
+      openedTrigger?.focus()
     })
-  }, [navigate])
+  }, [navigate, router])
 
   const onOpenChange = useCallback(
     (open: boolean) => {
@@ -40,6 +49,7 @@ export function usePaymentDetailsState() {
   )
 
   return {
+    hasPaymentDetailsRoute,
     selectedPaymentId,
     openPaymentDetails,
     closePaymentDetails,
@@ -47,25 +57,28 @@ export function usePaymentDetailsState() {
   }
 }
 
-function useSelectedPaymentId(): PaymentId | null {
+function useSelectedPaymentDetails(): {
+  hasPaymentDetailsRoute: boolean
+  selectedPaymentId: PaymentId | null
+} {
   const paymentIdParam = useParams({
     strict: false,
     select: (params) => params.paymentId,
   })
+  const hasPaymentDetailsRoute = paymentIdParam !== undefined
 
-  if (paymentIdParam === undefined) {
-    return null
+  return {
+    hasPaymentDetailsRoute,
+    selectedPaymentId: hasPaymentDetailsRoute ? toPaymentId(paymentIdParam) : null,
   }
-
-  return toPaymentId(paymentIdParam)
 }
 
-function toPaymentId(paymentIdParam: string): PaymentId {
+function toPaymentId(paymentIdParam: string | undefined): PaymentId | null {
   const paymentId = Number(paymentIdParam)
 
   if (Number.isSafeInteger(paymentId) && paymentId > 0) {
     return paymentId
   }
 
-  return 0
+  return null
 }

--- a/apps/web/src/test/helpers/routerDecorator.tsx
+++ b/apps/web/src/test/helpers/routerDecorator.tsx
@@ -46,5 +46,10 @@ export const paymentsRouteBuilder: StoryRouteBuilder = (root, Story) => {
     validateSearch: paymentsSearchSchema,
   })
 
-  return [authenticatedRoute.addChildren([paymentsRoute])]
+  const paymentDetailsRoute = createRoute({
+    getParentRoute: () => paymentsRoute,
+    path: "details/$paymentId",
+  })
+
+  return [authenticatedRoute.addChildren([paymentsRoute.addChildren([paymentDetailsRoute])])]
 }


### PR DESCRIPTION
## 関連Issue

- closes #1207

## 変更内容

- 支払い詳細用の `/payments/details/$paymentId` ルートを追加しました。
- 支払い詳細オーバーレイの開閉状態を local state ではなく URL と同期するようにしました。
- 行クリック、直URL、ブラウザバック、閉じる操作、既存 search params 維持のテストを追加しました。

## 動作確認

- [x] `task web:lint`
- [x] `task web:format-check`
- [x] `task web:typecheck`
- [x] `task web:test-unit`
- [x] `task web:test-storybook`
