### PR TITLE
pnpmの依存解決にクールダウンを追加

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - apps/*
+minimumReleaseAge: 10080
 onlyBuiltDependencies:
   - "@sentry/cli"
   - esbuild


### PR DESCRIPTION
## Summary
- pnpm の依存解決に minimumReleaseAge: 10080 を追加
- Renovate の minimumReleaseAge: "7 days" と同じ待機期間に統一

## Verification
- pnpm config get minimumReleaseAge
- pnpm install --frozen-lockfile