### PR TITLE
支払い一覧の年月初期化をページ側へ移す

### DIFF
--- a/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
@@ -42,6 +42,7 @@ const initialPaymentRows = payments.map(mapPaymentToRow)
 const initialCurrentMonthPaymentRows = initialPaymentRows.filter((payment) =>
   payment.date.startsWith("2025-06-"),
 )
+const currentMonthPaymentsQueryDate = new Date(2025, 5, 1).toISOString()
 const uncategorizedPayment = mapPaymentToRow({
   ...payments[0],
   id: 1000,
@@ -69,6 +70,21 @@ function renderStory() {
 function renderPaymentsPageRoute(initialEntry: string) {
   const queryClient = createQueryClient()
   queryClient.setQueryData(["categories"], categories)
+  queryClient.setQueryData(
+    ["payments", currentMonthPaymentsQueryDate, `category-${foodCat.id}`],
+    initialCurrentMonthPaymentRows.filter((payment) => payment.category_id === foodCat.id),
+    { updatedAt: 0 },
+  )
+  queryClient.setQueryData(
+    ["payments", currentMonthPaymentsQueryDate, `category-${entertainmentCat.id}`],
+    [],
+    { updatedAt: 0 },
+  )
+  queryClient.setQueryData(
+    ["payments", currentMonthPaymentsQueryDate, "uncategorized"],
+    [uncategorizedPayment],
+    { updatedAt: 0 },
+  )
 
   const view = renderWithRouter(
     initialEntry,

--- a/apps/web/src/app/routes/PaymentsPage/PaymentsPage.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentsPage.tsx
@@ -3,8 +3,11 @@ import { Box, Container, Flex } from "@radix-ui/themes"
 import { CreatePaymentModal } from "../../../features/payments/createPayment"
 import { PaymentCategoryFilter, PaymentList } from "../../../features/payments/listPayment"
 import { Summary } from "../../../features/summaryByMonth"
+import { useInitializePaymentsMonthSearch } from "./useInitializePaymentsMonthSearch"
 
 export function PaymentsPage() {
+  useInitializePaymentsMonthSearch()
+
   return (
     <Container size="4">
       <Flex direction="column" gap="3">

--- a/apps/web/src/app/routes/PaymentsPage/useInitializePaymentsMonthSearch.test.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/useInitializePaymentsMonthSearch.test.tsx
@@ -1,0 +1,113 @@
+import { renderHook, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, test, vi } from "vite-plus/test"
+
+import { useInitializePaymentsMonthSearch } from "./useInitializePaymentsMonthSearch"
+
+interface TestLocation {
+  pathname: string
+  search: {
+    year?: string
+    month?: string
+    category?: string
+  }
+}
+
+const { locationState, mockNavigate, mockUseSupabaseSession } = vi.hoisted(() => ({
+  locationState: {
+    pathname: "/payments",
+    search: {},
+  } as TestLocation,
+  mockNavigate: vi.fn(),
+  mockUseSupabaseSession: vi.fn(() => ({ session: { user: { id: "user-id" } } })),
+}))
+
+vi.mock("@tanstack/react-router", () => ({
+  useLocation: ({ select }: { select: (location: TestLocation) => unknown }) =>
+    select(locationState),
+  useNavigate: () => mockNavigate,
+}))
+
+vi.mock("../../../providers/supabase/useSupabaseSession", () => ({
+  useSupabaseSession: mockUseSupabaseSession,
+}))
+
+function renderUseInitializePaymentsMonthSearch(location: TestLocation) {
+  locationState.pathname = location.pathname
+  locationState.search = location.search
+
+  renderHook(() => useInitializePaymentsMonthSearch())
+}
+
+describe("useInitializePaymentsMonthSearch", () => {
+  beforeEach(() => {
+    locationState.pathname = "/payments"
+    locationState.search = {}
+    mockNavigate.mockClear()
+    mockUseSupabaseSession.mockReturnValue({ session: { user: { id: "user-id" } } })
+  })
+
+  test("年月 search がない場合は今月の年月で初期化する", async () => {
+    renderUseInitializePaymentsMonthSearch({
+      pathname: "/payments",
+      search: {},
+    })
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/payments",
+        search: expect.any(Function) as unknown,
+        replace: true,
+      })
+    })
+
+    const searchUpdater = mockNavigate.mock.calls[0]?.[0].search as (
+      prev: TestLocation["search"],
+    ) => TestLocation["search"]
+    expect(searchUpdater({})).toMatchObject({
+      year: expect.stringMatching(/\d{4}/),
+      month: expect.stringMatching(/\d{1,2}/),
+    })
+  })
+
+  test("年月 search を初期化してもカテゴリ条件を保持する", async () => {
+    renderUseInitializePaymentsMonthSearch({
+      pathname: "/payments",
+      search: { category: "none" },
+    })
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalled()
+    })
+
+    const searchUpdater = mockNavigate.mock.calls[0]?.[0].search as (
+      prev: TestLocation["search"],
+    ) => TestLocation["search"]
+    expect(searchUpdater({ category: "none" })).toMatchObject({
+      year: expect.stringMatching(/\d{4}/),
+      month: expect.stringMatching(/\d{1,2}/),
+      category: "none",
+    })
+  })
+
+  test("年月 search がある場合は初期化しない", async () => {
+    renderUseInitializePaymentsMonthSearch({
+      pathname: "/payments",
+      search: { year: "2025", month: "6" },
+    })
+
+    await waitFor(() => {
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+  })
+
+  test("Payments 外の pathname では年月 search がなくても Payments に巻き戻さない", async () => {
+    renderUseInitializePaymentsMonthSearch({
+      pathname: "/settings",
+      search: {},
+    })
+
+    await waitFor(() => {
+      expect(mockNavigate).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/web/src/app/routes/PaymentsPage/useInitializePaymentsMonthSearch.test.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/useInitializePaymentsMonthSearch.test.tsx
@@ -38,6 +38,10 @@ function renderUseInitializePaymentsMonthSearch(location: TestLocation) {
   renderHook(() => useInitializePaymentsMonthSearch())
 }
 
+async function waitForEffectTick() {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
 describe("useInitializePaymentsMonthSearch", () => {
   beforeEach(() => {
     locationState.pathname = "/payments"
@@ -89,15 +93,69 @@ describe("useInitializePaymentsMonthSearch", () => {
     })
   })
 
+  test("Payments 詳細 route では pathname を維持して年月 search を初期化する", async () => {
+    renderUseInitializePaymentsMonthSearch({
+      pathname: "/payments/details/1",
+      search: {},
+    })
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: "/payments/details/1",
+        search: expect.any(Function) as unknown,
+        replace: true,
+      })
+    })
+  })
+
+  test("year だけある場合は month だけ補完する", async () => {
+    renderUseInitializePaymentsMonthSearch({
+      pathname: "/payments",
+      search: { year: "2025" },
+    })
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalled()
+    })
+
+    const searchUpdater = mockNavigate.mock.calls[0]?.[0].search as (
+      prev: TestLocation["search"],
+    ) => TestLocation["search"]
+    expect(searchUpdater({ year: "2025" })).toMatchObject({
+      year: "2025",
+      month: expect.stringMatching(/\d{1,2}/),
+    })
+  })
+
+  test("month だけある場合は year だけ補完する", async () => {
+    renderUseInitializePaymentsMonthSearch({
+      pathname: "/payments",
+      search: { month: "6" },
+    })
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalled()
+    })
+
+    const searchUpdater = mockNavigate.mock.calls[0]?.[0].search as (
+      prev: TestLocation["search"],
+    ) => TestLocation["search"]
+    expect(searchUpdater({ month: "6" })).toMatchObject({
+      year: expect.stringMatching(/\d{4}/),
+      month: "6",
+    })
+  })
+
   test("年月 search がある場合は初期化しない", async () => {
     renderUseInitializePaymentsMonthSearch({
       pathname: "/payments",
       search: { year: "2025", month: "6" },
     })
 
-    await waitFor(() => {
-      expect(mockNavigate).not.toHaveBeenCalled()
-    })
+    // useEffect が実行される前に no-op の検証が通ることを避けるため、effect の tick を待つ
+    await waitForEffectTick()
+
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 
   test("Payments 外の pathname では年月 search がなくても Payments に巻き戻さない", async () => {
@@ -106,8 +164,9 @@ describe("useInitializePaymentsMonthSearch", () => {
       search: {},
     })
 
-    await waitFor(() => {
-      expect(mockNavigate).not.toHaveBeenCalled()
-    })
+    // useEffect が実行される前に no-op の検証が通ることを避けるため、effect の tick を待つ
+    await waitForEffectTick()
+
+    expect(mockNavigate).not.toHaveBeenCalled()
   })
 })

--- a/apps/web/src/app/routes/PaymentsPage/useInitializePaymentsMonthSearch.ts
+++ b/apps/web/src/app/routes/PaymentsPage/useInitializePaymentsMonthSearch.ts
@@ -28,8 +28,12 @@ export function useInitializePaymentsMonthSearch() {
     const month = (now.getMonth() + 1).toString()
 
     void navigate({
-      to: "/payments",
-      search: (prev) => ({ ...prev, year, month }),
+      to: pathname,
+      search: (prev) => ({
+        ...prev,
+        year: prev.year ?? year,
+        month: prev.month ?? month,
+      }),
       replace: true,
     })
   }, [session, yearParam, monthParam, navigate, pathname])

--- a/apps/web/src/app/routes/PaymentsPage/useInitializePaymentsMonthSearch.ts
+++ b/apps/web/src/app/routes/PaymentsPage/useInitializePaymentsMonthSearch.ts
@@ -1,0 +1,36 @@
+import { useLocation, useNavigate } from "@tanstack/react-router"
+import { useEffect } from "react"
+
+import { useSupabaseSession } from "../../../providers/supabase/useSupabaseSession"
+
+export function useInitializePaymentsMonthSearch() {
+  const yearParam = useLocation({
+    select: (location) => location.search.year,
+  })
+  const monthParam = useLocation({
+    select: (location) => location.search.month,
+  })
+  const pathname = useLocation({
+    select: (location) => location.pathname,
+  })
+  const navigate = useNavigate({ from: "/payments" })
+  const { session } = useSupabaseSession()
+
+  useEffect(() => {
+    const isPaymentsRoute = pathname === "/payments" || pathname.startsWith("/payments/")
+    if (!isPaymentsRoute) return
+    // NOTE: セッションがない場合はリダイレクト処理を行わないようにしないと、その後のセッション取得で null になってしまう
+    if (!session) return
+    if (yearParam && monthParam) return
+
+    const now = new Date()
+    const year = now.getFullYear().toString()
+    const month = (now.getMonth() + 1).toString()
+
+    void navigate({
+      to: "/payments",
+      search: (prev) => ({ ...prev, year, month }),
+      replace: true,
+    })
+  }, [session, yearParam, monthParam, navigate, pathname])
+}

--- a/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.test.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.test.tsx
@@ -1,63 +1,32 @@
 import { createRoute } from "@tanstack/react-router"
 import { describe, expect, test } from "vite-plus/test"
 
-import type { SupabaseSessionState } from "../../../providers/supabase/SupabaseSessionProvider"
-import { mockSession } from "../../../test/data/supabaseSession"
 import { renderWithRouter as renderWithTestRouter } from "../../../test/helpers/renderWithRouter"
 import { screen, waitFor } from "../../../test/test-utils"
-import {
-  PAYMENT_SEARCH_CATEGORY_NONE_VALUE,
-  paymentsSearchSchema,
-} from "../../payments/listPayment/paymentsSearchSchema"
+import { paymentsSearchSchema } from "../../payments/listPayment/paymentsSearchSchema"
 import { MonthSelector } from "./MonthSelector"
 
-const mockSessionState: SupabaseSessionState = {
-  status: "authenticated",
-  session: mockSession(),
-}
-
 function renderMonthSelector(initialEntry: string) {
-  return renderWithRouterHelper(initialEntry, mockSessionState)
-}
-
-function renderWithRouterHelper(initialEntry: string, sessionState: SupabaseSessionState) {
   window.history.replaceState({}, "", initialEntry)
 
-  return renderWithTestRouter(
-    initialEntry,
-    (root) => {
-      const authenticatedRoute = createRoute({
-        getParentRoute: () => root,
-        id: "authenticated",
-      })
+  return renderWithTestRouter(initialEntry, (root) => {
+    const authenticatedRoute = createRoute({
+      getParentRoute: () => root,
+      id: "authenticated",
+    })
 
-      const paymentsRoute = createRoute({
-        getParentRoute: () => authenticatedRoute,
-        path: "/payments",
-        component: MonthSelector,
-        validateSearch: paymentsSearchSchema,
-      })
+    const paymentsRoute = createRoute({
+      getParentRoute: () => authenticatedRoute,
+      path: "/payments",
+      component: MonthSelector,
+      validateSearch: paymentsSearchSchema,
+    })
 
-      return [authenticatedRoute.addChildren([paymentsRoute])]
-    },
-    { sessionState },
-  )
+    return [authenticatedRoute.addChildren([paymentsRoute])]
+  })
 }
 
 describe("MonthSelector", () => {
-  test("クエリパラメータがない場合、今月の年月で初期化される", async () => {
-    const { router } = renderMonthSelector("/payments")
-
-    await waitFor(() => {
-      const { year, month } = router.state.location.search as {
-        year?: string
-        month?: string
-      }
-      expect(year).toMatch(/\d{4}/)
-      expect(month).toMatch(/\d{1,2}/)
-    })
-  })
-
   test("クエリパラメータがある場合、その年月が表示される", async () => {
     renderMonthSelector("/payments?year=2025&month=5")
 
@@ -110,23 +79,6 @@ describe("MonthSelector", () => {
       expect(year).toBe("2025")
       expect(month).toBe("6")
       expect(category).toBe("10")
-    })
-  })
-
-  test("年月を初期化してもカテゴリ条件を保持する", async () => {
-    const { router } = renderMonthSelector(
-      `/payments?category=${PAYMENT_SEARCH_CATEGORY_NONE_VALUE}`,
-    )
-
-    await waitFor(() => {
-      const { year, month, category } = router.state.location.search as {
-        year?: string
-        month?: string
-        category?: string
-      }
-      expect(year).toMatch(/\d{4}/)
-      expect(month).toMatch(/\d{1,2}/)
-      expect(category).toBe(PAYMENT_SEARCH_CATEGORY_NONE_VALUE)
     })
   })
 })

--- a/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthSelector/MonthSelector.tsx
@@ -1,8 +1,7 @@
 import { useLocation, useNavigate } from "@tanstack/react-router"
-import { useCallback, useEffect } from "react"
+import { useCallback } from "react"
 
 import { MonthPicker } from "../../../components/inputs/MonthPicker"
-import { useSupabaseSession } from "../../../providers/supabase/useSupabaseSession"
 
 export function MonthSelector() {
   const yearParam = useLocation({
@@ -12,7 +11,6 @@ export function MonthSelector() {
     select: (location) => location.search.month,
   })
   const navigate = useNavigate({ from: "/payments" })
-  const { session } = useSupabaseSession()
 
   // 現在選択されている年月、またはnullの場合は今月
   const currentDate =
@@ -33,22 +31,6 @@ export function MonthSelector() {
     },
     [navigate],
   )
-
-  // デフォルトで今月を設定する（クエリパラメータがない場合）
-  useEffect(() => {
-    // NOTE: セッションがない場合はリダイレクト処理を行わないようにしないと、その後のセッション取得で null になってしまう
-    if (!session) return
-    if (!yearParam || !monthParam) {
-      const now = new Date()
-      const year = now.getFullYear().toString()
-      const month = (now.getMonth() + 1).toString()
-      void navigate({
-        to: "/payments",
-        search: (prev) => ({ ...prev, year, month }),
-        replace: true,
-      })
-    }
-  }, [session, yearParam, monthParam, navigate])
 
   return <MonthPicker value={currentDate ?? undefined} onChange={handleMonthChange} />
 }


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- MonthSelector から年月 search 初期化を外し、PaymentsPage 専用 hook に移動
- Payments 外への遷移を年月補完が巻き戻さないことを hook テストで確認
- PaymentsPage テストのカテゴリ選択時に Suspense 警告が出ないよう stale cache を用意

## 動作確認

- [x] task web:lint
- [x] task web:format-check
- [x] task web:typecheck
- [x] task web:test-unit
- [x] task web:test-storybook

## 補足

なし