### PR TITLE
フォームエラーメッセージ取得を共通化

### DIFF
--- a/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetForm/CreateCategoryBudgetForm.tsx
+++ b/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetForm/CreateCategoryBudgetForm.tsx
@@ -5,6 +5,7 @@ import { useCallback, useState } from "react"
 
 import { CancelButton } from "../../../../components/buttons/CancelButton"
 import { SubmitButton } from "../../../../components/buttons/SubmitButton"
+import { getErrorMessages } from "../../../../utils/getErrorMessages"
 import { AmountField } from "../AmountField"
 import { toCategoryBudgetCreateErrorMessage } from "../categoryBudgetCreateError"
 import {
@@ -20,35 +21,6 @@ interface CreateCategoryBudgetFormProps {
   onSuccess?: () => void
   onError?: (error: unknown) => void
   onCancel: () => void
-}
-
-function getErrorMessages(errors: unknown): string[] | undefined {
-  if (!Array.isArray(errors)) {
-    return undefined
-  }
-
-  const messages = errors.flatMap((error) => {
-    if (typeof error === "string") {
-      return [error]
-    }
-
-    if (
-      error &&
-      typeof error === "object" &&
-      "message" in error &&
-      typeof error.message === "string"
-    ) {
-      return [error.message]
-    }
-
-    return []
-  })
-
-  return messages.length > 0 ? messages : undefined
-}
-
-function hasErrorMessages(messages: string[] | undefined): boolean {
-  return Boolean(messages && messages.length > 0)
 }
 
 export function CreateCategoryBudgetForm({
@@ -106,12 +78,13 @@ export function CreateCategoryBudgetForm({
         <Flex direction="column" gap="3">
           <form.Field name="categoryId">
             {(field) => {
+              const isValid = field.state.meta.isValid
               const errorMessages = getErrorMessages(field.state.meta.errors)
               return (
                 <CategoryField
                   value={field.state.value}
                   onChange={(categoryId) => field.handleChange(categoryId)}
-                  error={hasErrorMessages(errorMessages)}
+                  error={!isValid}
                   messages={errorMessages}
                 />
               )
@@ -119,12 +92,13 @@ export function CreateCategoryBudgetForm({
           </form.Field>
           <form.Field name="targetMonth">
             {(field) => {
+              const isValid = field.state.meta.isValid
               const errorMessages = getErrorMessages(field.state.meta.errors)
               return (
                 <MonthField
                   value={field.state.value}
                   onChange={(targetMonth) => field.handleChange(targetMonth)}
-                  error={hasErrorMessages(errorMessages)}
+                  error={!isValid}
                   messages={errorMessages}
                 />
               )
@@ -132,12 +106,13 @@ export function CreateCategoryBudgetForm({
           </form.Field>
           <form.Field name="amount">
             {(field) => {
+              const isValid = field.state.meta.isValid
               const errorMessages = getErrorMessages(field.state.meta.errors)
               return (
                 <AmountField
                   value={field.state.value}
                   onChange={(amount) => field.handleChange(amount)}
-                  error={hasErrorMessages(errorMessages)}
+                  error={!isValid}
                   messages={errorMessages}
                 />
               )

--- a/apps/web/src/features/budgets/createMonthlyBudget/CreateMonthlyBudgetForm/CreateMonthlyBudgetForm.tsx
+++ b/apps/web/src/features/budgets/createMonthlyBudget/CreateMonthlyBudgetForm/CreateMonthlyBudgetForm.tsx
@@ -5,6 +5,7 @@ import { useCallback, useState } from "react"
 
 import { CancelButton } from "../../../../components/buttons/CancelButton"
 import { SubmitButton } from "../../../../components/buttons/SubmitButton"
+import { getErrorMessages } from "../../../../utils/getErrorMessages"
 import { AmountField } from "../AmountField"
 import { MonthField } from "../MonthField"
 import { toMonthlyBudgetCreateErrorMessage } from "../monthlyBudgetCreateError"
@@ -19,35 +20,6 @@ interface CreateMonthlyBudgetFormProps {
   onSuccess?: () => void
   onError?: (error: unknown) => void
   onCancel: () => void
-}
-
-function getErrorMessages(errors: unknown): string[] | undefined {
-  if (!Array.isArray(errors)) {
-    return undefined
-  }
-
-  const messages = errors.flatMap((error) => {
-    if (typeof error === "string") {
-      return [error]
-    }
-
-    if (
-      error &&
-      typeof error === "object" &&
-      "message" in error &&
-      typeof error.message === "string"
-    ) {
-      return [error.message]
-    }
-
-    return []
-  })
-
-  return messages.length > 0 ? messages : undefined
-}
-
-function hasErrorMessages(messages: string[] | undefined): boolean {
-  return Boolean(messages && messages.length > 0)
 }
 
 export function CreateMonthlyBudgetForm({
@@ -105,12 +77,13 @@ export function CreateMonthlyBudgetForm({
         <Flex direction="column" gap="3">
           <form.Field name="targetMonth">
             {(field) => {
+              const isValid = field.state.meta.isValid
               const errorMessages = getErrorMessages(field.state.meta.errors)
               return (
                 <MonthField
                   value={field.state.value}
                   onChange={(targetMonth) => field.handleChange(targetMonth)}
-                  error={hasErrorMessages(errorMessages)}
+                  error={!isValid}
                   messages={errorMessages}
                 />
               )
@@ -118,12 +91,13 @@ export function CreateMonthlyBudgetForm({
           </form.Field>
           <form.Field name="amount">
             {(field) => {
+              const isValid = field.state.meta.isValid
               const errorMessages = getErrorMessages(field.state.meta.errors)
               return (
                 <AmountField
                   value={field.state.value}
                   onChange={(amount) => field.handleChange(amount)}
-                  error={hasErrorMessages(errorMessages)}
+                  error={!isValid}
                   messages={errorMessages}
                 />
               )

--- a/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.tsx
+++ b/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect } from "react"
 
 import { CancelButton } from "../../../../components/buttons/CancelButton"
 import { SubmitButton } from "../../../../components/buttons/SubmitButton"
+import { getErrorMessages } from "../../../../utils/getErrorMessages"
 import { paymentFormSubmitSchema } from "../../paymentFormSchema"
 import { AmountField } from "../AmountField/AmountField"
 import { CategoryField } from "../CategoryField"
@@ -23,35 +24,6 @@ interface CreatePaymentFormProps {
   onResetReady?: (resetFn: () => void) => void
   continuousMode?: boolean
   onContinuousModeChange?: (checked: boolean) => void
-}
-
-function getErrorMessages(errors: unknown): string[] | undefined {
-  if (!Array.isArray(errors)) {
-    return undefined
-  }
-
-  const messages = errors.flatMap((error) => {
-    if (typeof error === "string") {
-      return [error]
-    }
-
-    if (
-      error &&
-      typeof error === "object" &&
-      "message" in error &&
-      typeof error.message === "string"
-    ) {
-      return [error.message]
-    }
-
-    return []
-  })
-
-  return messages.length > 0 ? messages : undefined
-}
-
-function hasErrorMessages(messages: string[] | undefined): boolean {
-  return Boolean(messages && messages.length > 0)
 }
 
 export function CreatePaymentForm({
@@ -103,12 +75,13 @@ export function CreatePaymentForm({
       <Flex direction="column" gap="3">
         <form.Field name="date">
           {(field) => {
+            const isValid = field.state.meta.isValid
             const errorMessages = getErrorMessages(field.state.meta.errors)
             return (
               <PaymentDateField
                 value={field.state.value}
                 onChange={(date) => field.handleChange(date)}
-                error={hasErrorMessages(errorMessages)}
+                error={!isValid}
                 messages={errorMessages}
               />
             )
@@ -116,12 +89,13 @@ export function CreatePaymentForm({
         </form.Field>
         <form.Field name="amount">
           {(field) => {
+            const isValid = field.state.meta.isValid
             const errorMessages = getErrorMessages(field.state.meta.errors)
             return (
               <AmountField
                 value={field.state.value}
                 onChange={(amount) => field.handleChange(amount)}
-                error={hasErrorMessages(errorMessages)}
+                error={!isValid}
                 messages={errorMessages}
                 autoFocus
               />
@@ -130,12 +104,13 @@ export function CreatePaymentForm({
         </form.Field>
         <form.Field name="category">
           {(field) => {
+            const isValid = field.state.meta.isValid
             const errorMessages = getErrorMessages(field.state.meta.errors)
             return (
               <CategoryField
                 value={field.state.value}
                 onChange={(category) => field.handleChange(category)}
-                error={hasErrorMessages(errorMessages)}
+                error={!isValid}
                 messages={errorMessages}
               />
             )
@@ -143,12 +118,13 @@ export function CreatePaymentForm({
         </form.Field>
         <form.Field name="note">
           {(field) => {
+            const isValid = field.state.meta.isValid
             const errorMessages = getErrorMessages(field.state.meta.errors)
             return (
               <NoteField
                 value={field.state.value}
                 onChange={(note) => field.handleChange(note)}
-                error={hasErrorMessages(errorMessages)}
+                error={!isValid}
                 messages={errorMessages}
               />
             )

--- a/apps/web/src/utils/getErrorMessages.test.ts
+++ b/apps/web/src/utils/getErrorMessages.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vite-plus/test"
+
+import { getErrorMessages } from "./getErrorMessages"
+
+describe("getErrorMessages", () => {
+  test("message を持つエラーオブジェクトから message を返す", () => {
+    expect(getErrorMessages([{ message: "Required" }, { message: "Invalid" }])).toEqual([
+      "Required",
+      "Invalid",
+    ])
+  })
+
+  test("undefined のエラーは無視する", () => {
+    expect(getErrorMessages([undefined, { message: "Invalid" }])).toEqual(["Invalid"])
+  })
+
+  test("抽出結果が空なら undefined を返す", () => {
+    expect(getErrorMessages([])).toBeUndefined()
+    expect(getErrorMessages([undefined])).toBeUndefined()
+  })
+
+  test("空文字は既存実装と同じく message として返す", () => {
+    expect(getErrorMessages([{ message: "" }])).toEqual([""])
+  })
+})

--- a/apps/web/src/utils/getErrorMessages.ts
+++ b/apps/web/src/utils/getErrorMessages.ts
@@ -1,0 +1,9 @@
+import type { StandardSchemaV1Issue } from "@tanstack/react-form"
+
+export function getErrorMessages(
+  errors: (StandardSchemaV1Issue | undefined)[],
+): string[] | undefined {
+  const messages = errors.map((e) => e?.message).filter((m): m is string => typeof m === "string")
+
+  return messages.length > 0 ? messages : undefined
+}


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- TanStack Form のフィールドエラーメッセージ取得を共通 util に集約
- 作成フォームの error 判定を field.state.meta.isValid に統一

## 動作確認

- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] pnpm --filter web test:unit
- [x] pnpm --filter web test:integration
- [x] pnpm --filter web test:storybook
