### PR TITLE
重複定義された小さなhelperを共通化

### DIFF
--- a/apps/web/src/app/routes/SettingsPage/SettingsPage.test.tsx
+++ b/apps/web/src/app/routes/SettingsPage/SettingsPage.test.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from "react"
 import { afterEach, describe, expect, test, vi } from "vite-plus/test"
 
 import { BudgetSettings } from "../../../features/budgets/budgetSettings/BudgetSettings"
-import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../features/budgets/createMonthlyBudget/monthlyBudgetCreateError"
 import { categoryBudgets } from "../../../test/data/categoryBudgets"
 import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
 import { renderWithRouter } from "../../../test/helpers/renderWithRouter"
@@ -11,6 +10,7 @@ import { createCategoryBudgetHandlers } from "../../../test/msw/handlers/categor
 import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
 import { server } from "../../../test/msw/server"
 import { screen, within } from "../../../test/test-utils"
+import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../utils/postgresError"
 import { SettingsPage } from "./SettingsPage"
 
 type SettingsBudgetsComponentType = () => ReactNode

--- a/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetForm/CreateCategoryBudgetForm.test.tsx
+++ b/apps/web/src/features/budgets/createCategoryBudget/CreateCategoryBudgetForm/CreateCategoryBudgetForm.test.tsx
@@ -6,8 +6,8 @@ import { createCategoryHandlers } from "../../../../test/msw/handlers/categories
 import { createCategoryBudgetHandlers } from "../../../../test/msw/handlers/categoryBudgets"
 import { server } from "../../../../test/msw/server"
 import { act, render, screen, waitFor } from "../../../../test/test-utils"
+import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../../utils/postgresError"
 import { fillCreateCategoryBudgetForm } from "../../test/utils/budgetCreationForm"
-import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../categoryBudgetCreateError"
 import * as stories from "./CreateCategoryBudgetForm.stories"
 
 const { Default } = composeStories(stories)

--- a/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetCreateError.test.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetCreateError.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, test } from "vite-plus/test"
 
-import {
-  POSTGRES_UNIQUE_VIOLATION_CODE,
-  toCategoryBudgetCreateErrorMessage,
-} from "./categoryBudgetCreateError"
+import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../utils/postgresError"
+import { toCategoryBudgetCreateErrorMessage } from "./categoryBudgetCreateError"
 
 describe("toCategoryBudgetCreateErrorMessage", () => {
   test("PostgreSQL unique_violationは重複カテゴリ年月メッセージに変換する", () => {

--- a/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetCreateError.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetCreateError.ts
@@ -1,5 +1,4 @@
-// PostgreSQL SQLSTATE 23505 means unique_violation.
-export const POSTGRES_UNIQUE_VIOLATION_CODE = "23505"
+import { isPostgresUniqueViolationError } from "../../../utils/postgresError"
 
 const DUPLICATE_CATEGORY_BUDGET_MESSAGE =
   "A category budget for this category and month already exists."
@@ -11,12 +10,4 @@ export function toCategoryBudgetCreateErrorMessage(error: unknown): string {
   }
 
   return GENERIC_CREATE_CATEGORY_BUDGET_MESSAGE
-}
-
-function isPostgresUniqueViolationError(error: unknown): boolean {
-  if (!error || typeof error !== "object" || !("code" in error)) {
-    return false
-  }
-
-  return error.code === POSTGRES_UNIQUE_VIOLATION_CODE
 }

--- a/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormMappers.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormMappers.ts
@@ -1,6 +1,7 @@
 import { format } from "date-fns"
 
 import type { TablesInsert } from "../../../types/database.types"
+import { toMonthStartDate } from "../utils/month"
 
 export interface CategoryBudgetWriteInput {
   categoryId: number
@@ -20,8 +21,4 @@ export function toCategoryBudgetInsert(value: CategoryBudgetWriteInput): Categor
     category_id: value.categoryId,
     effective_from: format(toMonthStartDate(value.targetMonth), "yyyy-MM-dd"),
   }
-}
-
-function toMonthStartDate(date: Date): Date {
-  return new Date(date.getFullYear(), date.getMonth(), 1)
 }

--- a/apps/web/src/features/budgets/createMonthlyBudget/CreateMonthlyBudgetForm/CreateMonthlyBudgetForm.test.tsx
+++ b/apps/web/src/features/budgets/createMonthlyBudget/CreateMonthlyBudgetForm/CreateMonthlyBudgetForm.test.tsx
@@ -4,8 +4,8 @@ import { describe, expect, test, vi } from "vite-plus/test"
 
 import { server } from "../../../../test/msw/server"
 import { act, render, screen, waitFor } from "../../../../test/test-utils"
+import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../../utils/postgresError"
 import { fillCreateMonthlyBudgetForm, selectBudgetMonth } from "../../test/utils/budgetCreationForm"
-import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../monthlyBudgetCreateError"
 import * as stories from "./CreateMonthlyBudgetForm.stories"
 
 const { Default } = composeStories(stories)

--- a/apps/web/src/features/budgets/createMonthlyBudget/CreateMonthlyBudgetModal/CreateMonthlyBudgetModal.test.tsx
+++ b/apps/web/src/features/budgets/createMonthlyBudget/CreateMonthlyBudgetModal/CreateMonthlyBudgetModal.test.tsx
@@ -4,8 +4,8 @@ import { afterEach, describe, expect, test, vi } from "vite-plus/test"
 
 import { server } from "../../../../test/msw/server"
 import { act, fireEvent, render, screen, waitFor, within } from "../../../../test/test-utils"
+import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../../utils/postgresError"
 import { fillCreateMonthlyBudgetForm } from "../../test/utils/budgetCreationForm"
-import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../monthlyBudgetCreateError"
 import * as stories from "./CreateMonthlyBudgetModal.stories"
 
 const { Default } = composeStories(stories)

--- a/apps/web/src/features/budgets/createMonthlyBudget/monthlyBudgetCreateError.test.ts
+++ b/apps/web/src/features/budgets/createMonthlyBudget/monthlyBudgetCreateError.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, test } from "vite-plus/test"
 
-import {
-  POSTGRES_UNIQUE_VIOLATION_CODE,
-  toMonthlyBudgetCreateErrorMessage,
-} from "./monthlyBudgetCreateError"
+import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../utils/postgresError"
+import { toMonthlyBudgetCreateErrorMessage } from "./monthlyBudgetCreateError"
 
 describe("toMonthlyBudgetCreateErrorMessage", () => {
   test("PostgreSQL unique_violationは重複年月メッセージに変換する", () => {

--- a/apps/web/src/features/budgets/createMonthlyBudget/monthlyBudgetCreateError.ts
+++ b/apps/web/src/features/budgets/createMonthlyBudget/monthlyBudgetCreateError.ts
@@ -1,5 +1,4 @@
-// PostgreSQL SQLSTATE 23505 means unique_violation.
-export const POSTGRES_UNIQUE_VIOLATION_CODE = "23505"
+import { isPostgresUniqueViolationError } from "../../../utils/postgresError"
 
 const DUPLICATE_MONTHLY_BUDGET_MESSAGE = "A monthly budget for this month already exists."
 const GENERIC_CREATE_MONTHLY_BUDGET_MESSAGE = "Failed to create monthly budget."
@@ -10,12 +9,4 @@ export function toMonthlyBudgetCreateErrorMessage(error: unknown): string {
   }
 
   return GENERIC_CREATE_MONTHLY_BUDGET_MESSAGE
-}
-
-function isPostgresUniqueViolationError(error: unknown): boolean {
-  if (!error || typeof error !== "object" || !("code" in error)) {
-    return false
-  }
-
-  return error.code === POSTGRES_UNIQUE_VIOLATION_CODE
 }

--- a/apps/web/src/features/budgets/createMonthlyBudget/monthlyBudgetFormMappers.ts
+++ b/apps/web/src/features/budgets/createMonthlyBudget/monthlyBudgetFormMappers.ts
@@ -1,6 +1,7 @@
 import { format } from "date-fns"
 
 import type { TablesInsert } from "../../../types/database.types"
+import { toMonthStartDate } from "../utils/month"
 
 export interface MonthlyBudgetWriteInput {
   targetMonth: Date
@@ -18,8 +19,4 @@ export function toMonthlyBudgetInsert(value: MonthlyBudgetWriteInput): MonthlyBu
     amount: value.amount,
     effective_from: format(toMonthStartDate(value.targetMonth), "yyyy-MM-dd"),
   }
-}
-
-function toMonthStartDate(date: Date): Date {
-  return new Date(date.getFullYear(), date.getMonth(), 1)
 }

--- a/apps/web/src/features/budgets/latestMonthlyBudget/LatestMonthlyBudget/LatestMonthlyBudget.test.tsx
+++ b/apps/web/src/features/budgets/latestMonthlyBudget/LatestMonthlyBudget/LatestMonthlyBudget.test.tsx
@@ -6,7 +6,7 @@ import { monthlyBudgets } from "../../../../test/data/monthlyBudgets"
 import { createMonthlyBudgetHandlers } from "../../../../test/msw/handlers/monthlyBudgets"
 import { server } from "../../../../test/msw/server"
 import { act, render, screen, waitFor, within } from "../../../../test/test-utils"
-import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../createMonthlyBudget/monthlyBudgetCreateError"
+import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../../utils/postgresError"
 import { fillCreateMonthlyBudgetForm } from "../../test/utils/budgetCreationForm"
 import * as stories from "./LatestMonthlyBudget.stories"
 

--- a/apps/web/src/features/budgets/utils/month.test.ts
+++ b/apps/web/src/features/budgets/utils/month.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vite-plus/test"
+
+import { toMonthStartDate } from "./month"
+
+describe("toMonthStartDate", () => {
+  test("月中の日付を同じ年月の月初日に丸める", () => {
+    expect(toMonthStartDate(new Date(2026, 2, 20))).toEqual(new Date(2026, 2, 1))
+  })
+
+  test("月末の日付を同じ年月の月初日に丸める", () => {
+    expect(toMonthStartDate(new Date(2025, 6, 31))).toEqual(new Date(2025, 6, 1))
+  })
+})

--- a/apps/web/src/features/budgets/utils/month.ts
+++ b/apps/web/src/features/budgets/utils/month.ts
@@ -13,6 +13,10 @@ export function toMonthEndIsoDate(date: Date): string {
   return format(endOfMonth(date), "yyyy-MM-dd")
 }
 
+export function toMonthStartDate(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1)
+}
+
 export function parseIsoDateOnlyToLocalDate(value: string): Date {
   const [year, month, day] = value.split("-").map(Number)
 

--- a/apps/web/src/features/payments/paymentDetails/AmountField/AmountField.tsx
+++ b/apps/web/src/features/payments/paymentDetails/AmountField/AmountField.tsx
@@ -1,14 +1,5 @@
 import { Flex, Text } from "@radix-ui/themes"
-import {
-  type KeyboardEvent,
-  type ReactNode,
-  type SubmitEvent,
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-} from "react"
+import { useCallback, useEffect, useId, useRef, useState } from "react"
 
 import { useSnackbar } from "../../../../providers/snackbar"
 import type { PaymentId } from "../../../../types/payment"
@@ -18,6 +9,7 @@ import { AmountInput } from "../../components/AmountInput"
 import { amountFieldSchema } from "../../paymentFormSchema"
 import { useUpdatePayment } from "../../updatePayment/useUpdatePayment"
 import { EditableField } from "../EditableField"
+import { InlineForm } from "../InlineForm"
 import { SubmitIconButton } from "../SubmitIconButton"
 
 interface AmountFieldProps {
@@ -145,36 +137,5 @@ export function AmountField({
         </InlineForm>
       }
     />
-  )
-}
-
-interface InlineFormProps {
-  children: ReactNode
-  onSubmit?: () => void | Promise<void>
-  onCancel?: () => void
-  saving?: boolean
-}
-
-function InlineForm({ children, onSubmit, onCancel, saving = false }: InlineFormProps) {
-  function handleKeyDown(event: KeyboardEvent<HTMLFormElement>) {
-    if (event.key !== "Escape") return
-
-    event.preventDefault()
-    event.stopPropagation()
-    if (!saving) {
-      onCancel?.()
-    }
-  }
-
-  function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
-    event.preventDefault()
-    event.stopPropagation()
-    void onSubmit?.()
-  }
-
-  return (
-    <form onKeyDownCapture={handleKeyDown} onSubmit={handleSubmit}>
-      {children}
-    </form>
   )
 }

--- a/apps/web/src/features/payments/paymentDetails/InlineForm/InlineForm.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/InlineForm/InlineForm.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, test, vi } from "vite-plus/test"
+
+import { fireEvent, render, screen } from "../../../../test/test-utils"
+import { InlineForm } from "./InlineForm"
+
+describe("InlineForm", () => {
+  test("children を描画する", () => {
+    render(
+      <InlineForm>
+        <button type="button">Edit content</button>
+      </InlineForm>,
+      { withProviders: false },
+    )
+
+    expect(screen.getByRole("button", { name: "Edit content" })).toBeInTheDocument()
+  })
+
+  test("submit は既定の送信を抑えて onSubmit を呼ぶ", () => {
+    const onSubmit = vi.fn()
+    render(
+      <InlineForm onSubmit={onSubmit}>
+        <button type="submit">Save</button>
+      </InlineForm>,
+      { withProviders: false },
+    )
+
+    const form = screen.getByRole("button", { name: "Save" }).closest("form")
+    expect(form).not.toBeNull()
+
+    const submitEvent = new Event("submit", { bubbles: true, cancelable: true })
+    fireEvent(form as HTMLFormElement, submitEvent)
+
+    expect(submitEvent.defaultPrevented).toBe(true)
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  test("Escape で onCancel を呼ぶ", async () => {
+    const onCancel = vi.fn()
+    const { user } = render(
+      <InlineForm onCancel={onCancel}>
+        <input aria-label="Memo" />
+      </InlineForm>,
+      { withProviders: false },
+    )
+
+    await user.click(screen.getByRole("textbox", { name: "Memo" }))
+    await user.keyboard("{Escape}")
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  test("saving 中の Escape では onCancel を呼ばない", async () => {
+    const onCancel = vi.fn()
+    const { user } = render(
+      <InlineForm onCancel={onCancel} saving>
+        <input aria-label="Memo" />
+      </InlineForm>,
+      { withProviders: false },
+    )
+
+    await user.click(screen.getByRole("textbox", { name: "Memo" }))
+    await user.keyboard("{Escape}")
+
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/payments/paymentDetails/InlineForm/InlineForm.tsx
+++ b/apps/web/src/features/payments/paymentDetails/InlineForm/InlineForm.tsx
@@ -1,0 +1,32 @@
+import type { KeyboardEvent, ReactNode, SubmitEvent } from "react"
+
+interface InlineFormProps {
+  children: ReactNode
+  onSubmit?: () => void | Promise<void>
+  onCancel?: () => void
+  saving?: boolean
+}
+
+export function InlineForm({ children, onSubmit, onCancel, saving = false }: InlineFormProps) {
+  function handleKeyDown(event: KeyboardEvent<HTMLFormElement>) {
+    if (event.key !== "Escape") return
+
+    event.preventDefault()
+    event.stopPropagation()
+    if (!saving) {
+      onCancel?.()
+    }
+  }
+
+  function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
+    event.preventDefault()
+    event.stopPropagation()
+    void onSubmit?.()
+  }
+
+  return (
+    <form onKeyDownCapture={handleKeyDown} onSubmit={handleSubmit}>
+      {children}
+    </form>
+  )
+}

--- a/apps/web/src/features/payments/paymentDetails/InlineForm/index.ts
+++ b/apps/web/src/features/payments/paymentDetails/InlineForm/index.ts
@@ -1,0 +1,1 @@
+export { InlineForm } from "./InlineForm"

--- a/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.tsx
+++ b/apps/web/src/features/payments/paymentDetails/NoteField/NoteField.tsx
@@ -1,14 +1,5 @@
 import { Flex, Text } from "@radix-ui/themes"
-import {
-  type KeyboardEvent,
-  type ReactNode,
-  type SubmitEvent,
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-} from "react"
+import { useCallback, useEffect, useId, useRef, useState } from "react"
 
 import { useSnackbar } from "../../../../providers/snackbar"
 import type { PaymentId } from "../../../../types/payment"
@@ -17,6 +8,7 @@ import { NoteInput } from "../../components/NoteInput"
 import { noteFieldSchema } from "../../paymentFormSchema"
 import { useUpdatePayment } from "../../updatePayment/useUpdatePayment"
 import { EditableField } from "../EditableField"
+import { InlineForm } from "../InlineForm"
 import { SubmitIconButton } from "../SubmitIconButton"
 
 const notePlaceholder = "No note"
@@ -153,36 +145,5 @@ export function NoteField({
         </InlineForm>
       }
     />
-  )
-}
-
-interface InlineFormProps {
-  children: ReactNode
-  onSubmit?: () => void | Promise<void>
-  onCancel?: () => void
-  saving?: boolean
-}
-
-function InlineForm({ children, onSubmit, onCancel, saving = false }: InlineFormProps) {
-  function handleKeyDown(event: KeyboardEvent<HTMLFormElement>) {
-    if (event.key !== "Escape") return
-
-    event.preventDefault()
-    event.stopPropagation()
-    if (!saving) {
-      onCancel?.()
-    }
-  }
-
-  function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
-    event.preventDefault()
-    event.stopPropagation()
-    void onSubmit?.()
-  }
-
-  return (
-    <form onKeyDownCapture={handleKeyDown} onSubmit={handleSubmit}>
-      {children}
-    </form>
   )
 }

--- a/apps/web/src/utils/postgresError.test.ts
+++ b/apps/web/src/utils/postgresError.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vite-plus/test"
+
+import { isPostgresUniqueViolationError, POSTGRES_UNIQUE_VIOLATION_CODE } from "./postgresError"
+
+describe("isPostgresUniqueViolationError", () => {
+  test("PostgreSQL unique_violation は true を返す", () => {
+    expect(isPostgresUniqueViolationError({ code: POSTGRES_UNIQUE_VIOLATION_CODE })).toBe(true)
+  })
+
+  test("code が異なる object は false を返す", () => {
+    expect(isPostgresUniqueViolationError({ code: "23503" })).toBe(false)
+  })
+
+  test("code がない object は false を返す", () => {
+    expect(isPostgresUniqueViolationError({ message: "network error" })).toBe(false)
+  })
+
+  test("undefined は false を返す", () => {
+    expect(isPostgresUniqueViolationError(undefined)).toBe(false)
+  })
+})

--- a/apps/web/src/utils/postgresError.ts
+++ b/apps/web/src/utils/postgresError.ts
@@ -1,0 +1,10 @@
+// PostgreSQL SQLSTATE 23505 means unique_violation.
+export const POSTGRES_UNIQUE_VIOLATION_CODE = "23505"
+
+export function isPostgresUniqueViolationError(error: unknown): boolean {
+  if (!error || typeof error !== "object" || !("code" in error)) {
+    return false
+  }
+
+  return error.code === POSTGRES_UNIQUE_VIOLATION_CODE
+}


### PR DESCRIPTION
## 関連Issue

- closes #1300

## 変更内容

- budgets の月初日変換 helper を共通 util 化
- PostgreSQL unique violation 判定を web 共通 util 化し、budget 作成エラー処理から参照
- paymentDetails の InlineForm を共通 component 化し、Amount/Note field で再利用

## 動作確認

- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] pnpm --filter web test:unit
- [x] pnpm --filter web test:integration
- [x] pnpm --filter web test:storybook