### PR TITLE
カテゴリピン留めテーブルを追加

### DIFF
--- a/apps/api/supabase/migrations/20260505212554_create_category_pins_table.sql
+++ b/apps/api/supabase/migrations/20260505212554_create_category_pins_table.sql
@@ -1,0 +1,41 @@
+create table category_pins (
+    id bigint generated always as identity primary key,
+    created_at timestamp with time zone default current_timestamp,
+    updated_at timestamp with time zone default current_timestamp,
+
+    user_id bigint not null default get_authenticated_user_id() references users(id) on delete cascade,
+    category_id bigint not null references categories(id) on delete cascade,
+
+    constraint category_pins_user_category_key
+        unique (user_id, category_id)
+);
+
+alter table category_pins enable row level security;
+
+create policy "Users can read own category pins"
+  on category_pins for select
+  to authenticated
+  using (user_id in (select id from users where external_id = auth.uid()::text));
+
+create policy "Users can insert own category pins"
+  on category_pins for insert
+  to authenticated
+  with check (user_id in (select id from users where external_id = auth.uid()::text));
+
+create policy "Users can delete own category pins"
+  on category_pins for delete
+  to authenticated
+  using (user_id in (select id from users where external_id = auth.uid()::text));
+
+create or replace function set_category_pin_user_id()
+returns trigger as $$
+begin
+  new.user_id := get_authenticated_user_id();
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_set_category_pin_user_id
+  before insert on category_pins
+  for each row
+  execute function set_category_pin_user_id();

--- a/apps/web/src/types/database.types.ts
+++ b/apps/web/src/types/database.types.ts
@@ -100,6 +100,45 @@ export type Database = {
           },
         ]
       }
+      category_pins: {
+        Row: {
+          category_id: number
+          created_at: string | null
+          id: number
+          updated_at: string | null
+          user_id: number
+        }
+        Insert: {
+          category_id: number
+          created_at?: string | null
+          id?: never
+          updated_at?: string | null
+          user_id?: number
+        }
+        Update: {
+          category_id?: number
+          created_at?: string | null
+          id?: never
+          updated_at?: string | null
+          user_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "category_pins_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "category_pins_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       monthly_budgets: {
         Row: {
           amount: number


### PR DESCRIPTION
## 関連Issue

- closes #1216

## 変更内容

- category_pins テーブルを追加し、行の存在でカテゴリのピン留め状態を表すようにした
- 自分のピン留め行だけを扱える RLS と insert 時の user_id 設定 trigger を追加した
- Web 側の Supabase 型を category_pins に同期した

## 動作確認

- [x] pnpm run web:typecheck
- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm --filter web test:unit
- [x] pnpm --filter web test:integration
- [x] pnpm --filter web test:storybook
- [x] pnpm run api:migrations:up

## 補足

- Issue本文では category_display_settings としていたが、ピン留め専用責務に合わせて category_pins として実装した
