### PR TITLE
chore: vite-plus 系 Renovate 更新をグループ化

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -26,7 +26,6 @@
         "@voidzero-dev/vite-plus-test",
         "vite-plus",
       ],
-      matchSourceUrls: ["https://github.com/voidzero-dev/vite-plus"],
       groupName: "vite-plus monorepo",
     },
     {

--- a/renovate.json5
+++ b/renovate.json5
@@ -21,6 +21,15 @@
       automergeType: "pr",
     },
     {
+      matchPackageNames: [
+        "@voidzero-dev/vite-plus-core",
+        "@voidzero-dev/vite-plus-test",
+        "vite-plus",
+      ],
+      matchSourceUrls: ["https://github.com/voidzero-dev/vite-plus"],
+      groupName: "vite-plus monorepo",
+    },
+    {
       matchDatasources: ["github-digest"],
       matchManagers: ["github-actions"],
       minimumReleaseAge: null,


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- vite-plus、@voidzero-dev/vite-plus-core、@voidzero-dev/vite-plus-test を package name で Renovate の同一グループにまとめる設定を追加

## 動作確認

- [x] pnpm dlx --package renovate renovate-config-validator renovate.json5
- [ ] ローカルでの動作確認
- [ ] UIの確認（スクリーンショット等）

## 補足

Renovate 設定のみの変更です。