### PR TITLE
monthly_budgets を更新できるようにする

### DIFF
--- a/apps/api/supabase/migrations/20260506153115_add_monthly_budgets_update_policy.sql
+++ b/apps/api/supabase/migrations/20260506153115_add_monthly_budgets_update_policy.sql
@@ -1,0 +1,18 @@
+create policy "Users can update own monthly budgets"
+  on monthly_budgets for update
+  to authenticated
+  using (user_id in (select id from users where external_id = auth.uid()::text))
+  with check (user_id in (select id from users where external_id = auth.uid()::text));
+
+create or replace function update_monthly_budget_updated_at()
+returns trigger as $$
+begin
+  new.updated_at := current_timestamp;
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_update_monthly_budget_updated_at
+  before update on monthly_budgets
+  for each row
+  execute function update_monthly_budget_updated_at();


### PR DESCRIPTION
## 関連Issue

- closes #1263

## 変更内容

- monthly_budgets に authenticated user 向け update policy を追加しました。
- monthly_budgets の更新時に updated_at を current_timestamp へ更新する trigger を追加しました。

## 動作確認

- [x] migration SQL の内容確認
- [x] git diff --check
- [ ] ローカル migration 適用（既存 config の auth.external[google].skip_nonce_check が bool parse できず、migration 適用前に停止）

## 補足

- API 専用の必須 verification command は現時点で未定義です。