### PR TITLE
月額予算の更新処理を追加する

### DIFF
--- a/apps/web/src/features/budgets/updateMonthlyBudget/monthlyBudgetUpdateMappers.test.ts
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/monthlyBudgetUpdateMappers.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vite-plus/test"
+
+import { toMonthlyBudgetUpdate } from "./monthlyBudgetUpdateMappers"
+
+describe("toMonthlyBudgetUpdate", () => {
+  test("月予算更新用の値をmonthly_budgets update payloadに変換する", () => {
+    expect(
+      toMonthlyBudgetUpdate({
+        monthlyBudgetId: 42,
+        amount: 300000,
+      }),
+    ).toEqual({
+      amount: 300000,
+    })
+  })
+})

--- a/apps/web/src/features/budgets/updateMonthlyBudget/monthlyBudgetUpdateMappers.ts
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/monthlyBudgetUpdateMappers.ts
@@ -1,0 +1,14 @@
+import type { TablesUpdate } from "../../../types/database.types"
+
+export interface MonthlyBudgetUpdateInput {
+  monthlyBudgetId: number
+  amount: number
+}
+
+export type MonthlyBudgetUpdate = Pick<TablesUpdate<"monthly_budgets">, "amount">
+
+export function toMonthlyBudgetUpdate(value: MonthlyBudgetUpdateInput): MonthlyBudgetUpdate {
+  return {
+    amount: value.amount,
+  }
+}

--- a/apps/web/src/features/budgets/updateMonthlyBudget/updateMonthlyBudget.test.ts
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/updateMonthlyBudget.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { updateMonthlyBudget } from "./updateMonthlyBudget"
+
+const mockEq = vi.fn()
+const mockUpdate = vi.fn(() => ({ eq: mockEq }))
+const mockFrom = vi.fn(() => ({ update: mockUpdate }))
+
+vi.mock("../../../lib/supabase", () => ({
+  getSupabaseClient: () => ({ from: mockFrom }),
+}))
+
+describe("updateMonthlyBudget", () => {
+  beforeEach(() => {
+    mockEq.mockReset()
+    mockFrom.mockClear()
+    mockUpdate.mockClear()
+  })
+
+  it("monthly_budgetsテーブルの指定IDレコードのamountを更新する", async () => {
+    mockEq.mockResolvedValue({ error: null })
+
+    await updateMonthlyBudget({
+      monthlyBudgetId: 42,
+      amount: 300000,
+    })
+
+    expect(mockFrom).toHaveBeenCalledWith("monthly_budgets")
+    expect(mockUpdate).toHaveBeenCalledWith({
+      amount: 300000,
+    })
+    expect(mockEq).toHaveBeenCalledWith("id", 42)
+  })
+
+  it("Supabaseがエラーを返した場合にthrowする", async () => {
+    const supabaseError = { message: "更新に失敗しました", code: "42501" }
+    mockEq.mockResolvedValue({ error: supabaseError })
+
+    await expect(
+      updateMonthlyBudget({
+        monthlyBudgetId: 1,
+        amount: 300000,
+      }),
+    ).rejects.toEqual(supabaseError)
+  })
+})

--- a/apps/web/src/features/budgets/updateMonthlyBudget/updateMonthlyBudget.ts
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/updateMonthlyBudget.ts
@@ -1,0 +1,15 @@
+import { getSupabaseClient } from "../../../lib/supabase"
+import { type MonthlyBudgetUpdateInput, toMonthlyBudgetUpdate } from "./monthlyBudgetUpdateMappers"
+
+export async function updateMonthlyBudget(value: MonthlyBudgetUpdateInput): Promise<void> {
+  const supabase = getSupabaseClient()
+  const payload = toMonthlyBudgetUpdate(value)
+  const { error } = await supabase
+    .from("monthly_budgets")
+    .update(payload)
+    .eq("id", value.monthlyBudgetId)
+
+  if (error) {
+    throw error
+  }
+}

--- a/apps/web/src/features/budgets/updateMonthlyBudget/useUpdateMonthlyBudget.test.tsx
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/useUpdateMonthlyBudget.test.tsx
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { act, createTestQueryClient, renderHook } from "../../../test/test-utils"
+import { useUpdateMonthlyBudget } from "./useUpdateMonthlyBudget"
+
+const { mockUpdateMonthlyBudget } = vi.hoisted(() => ({
+  mockUpdateMonthlyBudget: vi.fn(),
+}))
+
+vi.mock("./updateMonthlyBudget", () => ({
+  updateMonthlyBudget: mockUpdateMonthlyBudget,
+}))
+
+describe("useUpdateMonthlyBudget", () => {
+  beforeEach(() => {
+    mockUpdateMonthlyBudget.mockReset()
+  })
+
+  it("成功時にmonthlyBudgets queryをinvalidateしてresolveする", async () => {
+    const queryClient = createTestQueryClient()
+    const invalidateQueries = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined)
+    const input = {
+      monthlyBudgetId: 42,
+      amount: 300000,
+    }
+    mockUpdateMonthlyBudget.mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useUpdateMonthlyBudget(), {
+      queryClient,
+    })
+
+    await act(async () => {
+      const promise = result.current.updateMonthlyBudget(input)
+
+      expect(promise).toBeInstanceOf(Promise)
+      await promise
+    })
+
+    expect(mockUpdateMonthlyBudget).toHaveBeenCalledTimes(1)
+    expect(mockUpdateMonthlyBudget.mock.calls[0]?.[0]).toBe(input)
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["monthlyBudgets"] })
+    expect(invalidateQueries).toHaveBeenCalledTimes(1)
+  })
+
+  it("失敗時にmonthlyBudgets queryをinvalidateせずrejectする", async () => {
+    const queryClient = createTestQueryClient()
+    const invalidateQueries = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined)
+    const error = { message: "更新に失敗しました", code: "42501" }
+    mockUpdateMonthlyBudget.mockRejectedValue(error)
+
+    const { result } = renderHook(() => useUpdateMonthlyBudget(), {
+      queryClient,
+    })
+
+    await act(async () => {
+      await expect(
+        result.current.updateMonthlyBudget({
+          monthlyBudgetId: 42,
+          amount: 300000,
+        }),
+      ).rejects.toEqual(error)
+    })
+
+    expect(invalidateQueries).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/budgets/updateMonthlyBudget/useUpdateMonthlyBudget.ts
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/useUpdateMonthlyBudget.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useCallback } from "react"
+
+import type { MonthlyBudgetUpdateInput } from "./monthlyBudgetUpdateMappers"
+import { updateMonthlyBudget as updateMonthlyBudgetRecord } from "./updateMonthlyBudget"
+
+interface UseUpdateMonthlyBudgetReturn {
+  updateMonthlyBudget: (value: MonthlyBudgetUpdateInput) => Promise<void>
+  isPending: boolean
+}
+
+export function useUpdateMonthlyBudget(): UseUpdateMonthlyBudgetReturn {
+  const queryClient = useQueryClient()
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: updateMonthlyBudgetRecord,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["monthlyBudgets"] })
+    },
+  })
+
+  const updateMonthlyBudget = useCallback(
+    async (value: MonthlyBudgetUpdateInput) => {
+      return mutateAsync(value)
+    },
+    [mutateAsync],
+  )
+
+  return { updateMonthlyBudget, isPending }
+}


### PR DESCRIPTION
## 関連Issue

- closes #1264
- #1261

## 変更内容

- monthly_budgets を id 指定で amount 更新する処理を追加
- 更新成功時に monthlyBudgets query を invalidate する hook を追加
- 更新 payload、Supabase error、query invalidation の単体テストを追加

## 動作確認

- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] pnpm --filter web test:unit
- [x] pnpm --filter web test:integration
- [x] pnpm --filter web test:storybook
