### PR TITLE
最新月額予算を編集できるようにする

### DIFF
--- a/apps/web/src/features/budgets/latestMonthlyBudget/LatestMonthlyBudget/LatestMonthlyBudget.test.tsx
+++ b/apps/web/src/features/budgets/latestMonthlyBudget/LatestMonthlyBudget/LatestMonthlyBudget.test.tsx
@@ -44,6 +44,7 @@ describe("LatestMonthlyBudget", () => {
 
     expect(await screen.findByText("Monthly Budgets")).toBeInTheDocument()
     expect(await screen.findByText("￥75,000")).toBeInTheDocument()
+    expect(await screen.findByRole("button", { name: "Edit budget" })).toBeInTheDocument()
     expect(screen.queryByText("￥62,000")).not.toBeInTheDocument()
   })
 
@@ -131,6 +132,58 @@ describe("LatestMonthlyBudget", () => {
       await within(dialog).findByText("A monthly budget for this month already exists."),
     ).toBeInTheDocument()
     expect(screen.getByRole("dialog", { name: "Create monthly budget" })).toBeInTheDocument()
+  })
+
+  test("編集成功後に最新の月予算表示を更新する", async () => {
+    server.resetHandlers(
+      ...createMonthlyBudgetHandlers({
+        list: { response: [monthlyBudgets[3], monthlyBudgets[2]] },
+      }),
+    )
+
+    const { user } = await renderLatestMonthlyBudget(<Default />)
+
+    await user.click(await screen.findByRole("button", { name: "Edit budget" }))
+    const dialog = await screen.findByRole("dialog", { name: "Edit monthly budget" })
+    const amountInput = within(dialog).getByRole("textbox", { name: /amount/i })
+
+    expect(within(dialog).getByText("Update the latest monthly budget amount.")).toBeInTheDocument()
+    expect(within(dialog).getByText("2025/07")).toBeInTheDocument()
+    expect(amountInput).toHaveValue("75000")
+
+    await user.clear(amountInput)
+    await user.type(amountInput, "82000")
+    await user.click(within(dialog).getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Edit monthly budget" })).not.toBeInTheDocument()
+    })
+    expect(await screen.findByText("￥82,000")).toBeInTheDocument()
+    expect(screen.queryByText("￥75,000")).not.toBeInTheDocument()
+  })
+
+  test("編集失敗時はエラー表示を維持してダイアログを閉じない", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    server.resetHandlers(
+      ...createMonthlyBudgetHandlers({
+        list: { response: [monthlyBudgets[3], monthlyBudgets[2]] },
+        update: { error: true },
+      }),
+    )
+
+    const { user } = await renderLatestMonthlyBudget(<Default />)
+
+    await user.click(await screen.findByRole("button", { name: "Edit budget" }))
+    const dialog = await screen.findByRole("dialog", { name: "Edit monthly budget" })
+    const amountInput = within(dialog).getByRole("textbox", { name: /amount/i })
+
+    await user.clear(amountInput)
+    await user.type(amountInput, "82000")
+    await user.click(within(dialog).getByRole("button", { name: "Save" }))
+
+    expect(await within(dialog).findByText("Failed to update monthly budget.")).toBeInTheDocument()
+    expect(screen.getByRole("dialog", { name: "Edit monthly budget" })).toBeInTheDocument()
+    expect(screen.getByText("￥75,000")).toBeInTheDocument()
   })
 
   test("取得中はスケルトンを表示する", async () => {

--- a/apps/web/src/features/budgets/latestMonthlyBudget/LatestMonthlyBudget/LatestMonthlyBudget.tsx
+++ b/apps/web/src/features/budgets/latestMonthlyBudget/LatestMonthlyBudget/LatestMonthlyBudget.tsx
@@ -1,4 +1,4 @@
-import { PlusIcon } from "@radix-ui/react-icons"
+import { Pencil1Icon, PlusIcon } from "@radix-ui/react-icons"
 import { Button, Flex, Skeleton, Text } from "@radix-ui/themes"
 import { Suspense, use } from "react"
 import { ErrorBoundary } from "react-error-boundary"
@@ -7,6 +7,7 @@ import { toCurrency } from "../../../../utils/toCurrency"
 import { CreateMonthlyBudgetModal } from "../../createMonthlyBudget"
 import { useMonthlyBudgets } from "../../listMonthlyBudget/useMonthlyBudgets"
 import type { MonthlyBudget } from "../../types"
+import { UpdateMonthlyBudgetModal } from "../../updateMonthlyBudget/UpdateMonthlyBudgetModal"
 
 const latestMonthlyBudgetLimit = 1
 
@@ -65,6 +66,14 @@ function LatestMonthlyBudgetRow({ monthlyBudget }: { monthlyBudget: MonthlyBudge
   return (
     <Flex align="center" justify="between" gap="3">
       <Text>{toCurrency(monthlyBudget.amount)}</Text>
+      <UpdateMonthlyBudgetModal
+        monthlyBudget={monthlyBudget}
+        trigger={
+          <Button variant="soft">
+            <Pencil1Icon /> Edit budget
+          </Button>
+        }
+      />
     </Flex>
   )
 }

--- a/apps/web/src/features/budgets/updateMonthlyBudget/UpdateMonthlyBudgetForm/UpdateMonthlyBudgetForm.tsx
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/UpdateMonthlyBudgetForm/UpdateMonthlyBudgetForm.tsx
@@ -1,0 +1,137 @@
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons"
+import { Callout, Flex, Text } from "@radix-ui/themes"
+import { useForm } from "@tanstack/react-form"
+import { useCallback, useId, useState } from "react"
+import * as z from "zod"
+
+import { CancelButton } from "../../../../components/buttons/CancelButton"
+import { SubmitButton } from "../../../../components/buttons/SubmitButton"
+import { AmountInput } from "../../../../components/inputs/AmountInput"
+import { BaseField, FieldLabel, FieldMessages } from "../../../../components/inputs/BaseField"
+import { getErrorMessages } from "../../../../utils/getErrorMessages"
+import { monthlyBudgetAmountFieldSchema } from "../../createMonthlyBudget/monthlyBudgetFormSchema"
+import type { MonthlyBudget } from "../../types"
+import { useUpdateMonthlyBudget } from "../useUpdateMonthlyBudget"
+
+const UPDATE_MONTHLY_BUDGET_ERROR_MESSAGE = "Failed to update monthly budget."
+
+const updateMonthlyBudgetFormSubmitSchema = z.object({
+  amount: monthlyBudgetAmountFieldSchema,
+})
+
+interface UpdateMonthlyBudgetFormValues {
+  amount: number | undefined
+}
+
+interface UpdateMonthlyBudgetFormProps {
+  monthlyBudget: MonthlyBudget
+  onSuccess?: () => void
+  onCancel: () => void
+}
+
+export function UpdateMonthlyBudgetForm({
+  monthlyBudget,
+  onSuccess,
+  onCancel,
+}: UpdateMonthlyBudgetFormProps) {
+  const amountInputId = useId()
+  const { updateMonthlyBudget, isPending } = useUpdateMonthlyBudget()
+  const [submitErrorMessage, setSubmitErrorMessage] = useState<string | undefined>()
+  const defaultValues: UpdateMonthlyBudgetFormValues = {
+    amount: monthlyBudget.amount,
+  }
+
+  const form = useForm({
+    defaultValues,
+    validators: {
+      onSubmit: updateMonthlyBudgetFormSubmitSchema,
+    },
+    onSubmit: async ({ value }) => {
+      if (isPending) return
+
+      const parsedValue = updateMonthlyBudgetFormSubmitSchema.parse(value)
+
+      try {
+        setSubmitErrorMessage(undefined)
+        await updateMonthlyBudget({
+          monthlyBudgetId: monthlyBudget.id,
+          amount: parsedValue.amount,
+        })
+        onSuccess?.()
+      } catch {
+        setSubmitErrorMessage(UPDATE_MONTHLY_BUDGET_ERROR_MESSAGE)
+      }
+    },
+  })
+
+  const handleCancel = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+      if (isPending) return
+
+      onCancel()
+    },
+    [isPending, onCancel],
+  )
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        setSubmitErrorMessage(undefined)
+        void form.handleSubmit()
+      }}
+    >
+      <Flex direction="column" gap="4">
+        {submitErrorMessage ? (
+          <Callout.Root aria-live="polite" role="alert" color="red" variant="surface" size="1">
+            <Callout.Icon>
+              <ExclamationTriangleIcon />
+            </Callout.Icon>
+            <Callout.Text>{submitErrorMessage}</Callout.Text>
+          </Callout.Root>
+        ) : null}
+        <Flex direction="column" gap="3">
+          <BaseField>
+            <FieldLabel>Month</FieldLabel>
+            <Text>{formatMonthlyBudgetMonth(monthlyBudget)}</Text>
+          </BaseField>
+          <form.Field name="amount">
+            {(field) => {
+              const isValid = field.state.meta.isValid
+              const errorMessages = getErrorMessages(field.state.meta.errors)
+
+              return (
+                <BaseField>
+                  <FieldLabel htmlFor={amountInputId} required>
+                    Amount
+                  </FieldLabel>
+                  <AmountInput
+                    id={amountInputId}
+                    value={field.state.value}
+                    onChange={(amount) => {
+                      field.handleChange(amount)
+                      setSubmitErrorMessage(undefined)
+                    }}
+                    autoFocus
+                    disabled={isPending}
+                  />
+                  <FieldMessages error={!isValid} messages={errorMessages} />
+                </BaseField>
+              )
+            }}
+          </form.Field>
+        </Flex>
+        <Flex gap="3" justify="end">
+          <CancelButton disabled={isPending} onClick={handleCancel} />
+          <SubmitButton loading={isPending}>Save</SubmitButton>
+        </Flex>
+      </Flex>
+    </form>
+  )
+}
+
+function formatMonthlyBudgetMonth(monthlyBudget: MonthlyBudget): string {
+  return `${monthlyBudget.effectiveYear}/${String(monthlyBudget.effectiveMonth).padStart(2, "0")}`
+}

--- a/apps/web/src/features/budgets/updateMonthlyBudget/UpdateMonthlyBudgetForm/index.ts
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/UpdateMonthlyBudgetForm/index.ts
@@ -1,0 +1,1 @@
+export { UpdateMonthlyBudgetForm } from "./UpdateMonthlyBudgetForm"

--- a/apps/web/src/features/budgets/updateMonthlyBudget/UpdateMonthlyBudgetModal/UpdateMonthlyBudgetModal.tsx
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/UpdateMonthlyBudgetModal/UpdateMonthlyBudgetModal.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@radix-ui/themes"
+import { useCallback, type ReactElement } from "react"
+
+import { ResponsiveOverlay } from "../../../../components/overlay/ResponsiveOverlay"
+import { useDialog } from "../../../../utils/useDialog"
+import type { MonthlyBudget } from "../../types"
+import { UpdateMonthlyBudgetForm } from "../UpdateMonthlyBudgetForm"
+
+interface UpdateMonthlyBudgetModalProps {
+  monthlyBudget: MonthlyBudget
+  trigger?: ReactElement
+}
+
+export function UpdateMonthlyBudgetModal({
+  monthlyBudget,
+  trigger = <Button>Edit budget</Button>,
+}: UpdateMonthlyBudgetModalProps) {
+  const { open, closeDialog, onOpenChange } = useDialog()
+
+  const handleSuccess = useCallback(() => {
+    closeDialog()
+  }, [closeDialog])
+
+  const handleCancel = useCallback(() => {
+    closeDialog()
+  }, [closeDialog])
+
+  return (
+    <ResponsiveOverlay
+      open={open}
+      onOpenChange={onOpenChange}
+      dismissible={false}
+      trigger={trigger}
+      title="Edit monthly budget"
+      description="Update the latest monthly budget amount."
+    >
+      <UpdateMonthlyBudgetForm
+        monthlyBudget={monthlyBudget}
+        onSuccess={handleSuccess}
+        onCancel={handleCancel}
+      />
+    </ResponsiveOverlay>
+  )
+}

--- a/apps/web/src/features/budgets/updateMonthlyBudget/UpdateMonthlyBudgetModal/index.ts
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/UpdateMonthlyBudgetModal/index.ts
@@ -1,0 +1,1 @@
+export { UpdateMonthlyBudgetModal } from "./UpdateMonthlyBudgetModal"

--- a/apps/web/src/features/budgets/updateMonthlyBudget/updateMonthlyBudget.test.ts
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/updateMonthlyBudget.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import { updateMonthlyBudget } from "./updateMonthlyBudget"
 
+const mockSingle = vi.fn()
+const mockSelect = vi.fn(() => ({ single: mockSingle }))
 const mockEq = vi.fn()
 const mockUpdate = vi.fn(() => ({ eq: mockEq }))
 const mockFrom = vi.fn(() => ({ update: mockUpdate }))
@@ -13,12 +15,15 @@ vi.mock("../../../lib/supabase", () => ({
 describe("updateMonthlyBudget", () => {
   beforeEach(() => {
     mockEq.mockReset()
+    mockSelect.mockClear()
+    mockSingle.mockReset()
     mockFrom.mockClear()
     mockUpdate.mockClear()
   })
 
   it("monthly_budgetsテーブルの指定IDレコードのamountを更新する", async () => {
-    mockEq.mockResolvedValue({ error: null })
+    mockEq.mockReturnValue({ select: mockSelect })
+    mockSingle.mockResolvedValue({ data: { id: 42 }, error: null })
 
     await updateMonthlyBudget({
       monthlyBudgetId: 42,
@@ -30,11 +35,14 @@ describe("updateMonthlyBudget", () => {
       amount: 300000,
     })
     expect(mockEq).toHaveBeenCalledWith("id", 42)
+    expect(mockSelect).toHaveBeenCalledWith("id")
+    expect(mockSingle).toHaveBeenCalledTimes(1)
   })
 
   it("Supabaseがエラーを返した場合にthrowする", async () => {
     const supabaseError = { message: "更新に失敗しました", code: "42501" }
-    mockEq.mockResolvedValue({ error: supabaseError })
+    mockEq.mockReturnValue({ select: mockSelect })
+    mockSingle.mockResolvedValue({ data: null, error: supabaseError })
 
     await expect(
       updateMonthlyBudget({
@@ -42,5 +50,17 @@ describe("updateMonthlyBudget", () => {
         amount: 300000,
       }),
     ).rejects.toEqual(supabaseError)
+  })
+
+  it("更新対象が返らない場合にthrowする", async () => {
+    mockEq.mockReturnValue({ select: mockSelect })
+    mockSingle.mockResolvedValue({ data: null, error: null })
+
+    await expect(
+      updateMonthlyBudget({
+        monthlyBudgetId: 999,
+        amount: 300000,
+      }),
+    ).rejects.toThrow("Monthly budget was not updated.")
   })
 })

--- a/apps/web/src/features/budgets/updateMonthlyBudget/updateMonthlyBudget.ts
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/updateMonthlyBudget.ts
@@ -4,12 +4,18 @@ import { type MonthlyBudgetUpdateInput, toMonthlyBudgetUpdate } from "./monthlyB
 export async function updateMonthlyBudget(value: MonthlyBudgetUpdateInput): Promise<void> {
   const supabase = getSupabaseClient()
   const payload = toMonthlyBudgetUpdate(value)
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from("monthly_budgets")
     .update(payload)
     .eq("id", value.monthlyBudgetId)
+    .select("id")
+    .single()
 
   if (error) {
     throw error
+  }
+
+  if (!data) {
+    throw new Error("Monthly budget was not updated.")
   }
 }

--- a/apps/web/src/test/msw/handlers/monthlyBudgets.ts
+++ b/apps/web/src/test/msw/handlers/monthlyBudgets.ts
@@ -24,10 +24,16 @@ interface CreateMonthlyBudgetOptions extends BaseOptions {
   errorResponse?: unknown
 }
 
+interface UpdateMonthlyBudgetOptions extends BaseOptions {
+  response?: MonthlyBudgetRow
+  errorResponse?: unknown
+}
+
 interface CreateMonthlyBudgetHandlersOptions {
   get?: GetMonthlyBudgetOptions
   list?: ListMonthlyBudgetOptions
   create?: CreateMonthlyBudgetOptions
+  update?: UpdateMonthlyBudgetOptions
 }
 
 const createMonthlyBudgetBodySchema = z.object({
@@ -35,12 +41,19 @@ const createMonthlyBudgetBodySchema = z.object({
   effective_from: z.string(),
 })
 
+const updateMonthlyBudgetBodySchema = z.object({
+  amount: z.number(),
+})
+
 type CreateMonthlyBudgetBody = z.infer<typeof createMonthlyBudgetBodySchema>
+type UpdateMonthlyBudgetBody = z.infer<typeof updateMonthlyBudgetBodySchema>
 
 export function createMonthlyBudgetHandlers(options: CreateMonthlyBudgetHandlersOptions = {}) {
   const get = options.get ?? {}
   const list = options.list ?? {}
   const create = options.create ?? {}
+  const update = options.update ?? {}
+  let listRows = list.response ? [...list.response] : [...monthlyBudgets]
 
   const monthlyBudgetsHandler = http.get(REST_URL, async ({ request }) => {
     const shouldReturnSingle = shouldReturnSingleObject(request)
@@ -56,7 +69,7 @@ export function createMonthlyBudgetHandlers(options: CreateMonthlyBudgetHandlers
       ? get.response === undefined
         ? monthlyBudgets[2]
         : get.response
-      : (list.response ?? monthlyBudgets)
+      : listRows
 
     return HttpResponse.json(response)
   })
@@ -82,7 +95,29 @@ export function createMonthlyBudgetHandlers(options: CreateMonthlyBudgetHandlers
     return HttpResponse.json([newRow], { status: 201 })
   })
 
-  return [monthlyBudgetsHandler, createMonthlyBudgetHandler]
+  const updateMonthlyBudgetHandler = http.patch(REST_URL, async ({ request }) => {
+    await delay(update.durationOrMode)
+
+    if (update.error) {
+      return HttpResponse.json(
+        update.errorResponse ?? { message: "Failed to update monthly budget." },
+        { status: 500 },
+      )
+    }
+
+    const body = await request.json()
+    const parsedBody = updateMonthlyBudgetBodySchema.parse(body)
+    const id = parseUpdateMonthlyBudgetId(request.url)
+    const updatedRow = update.response ?? buildUpdatedMonthlyBudgetRow(id, parsedBody, listRows)
+
+    if (updatedRow) {
+      listRows = listRows.map((row) => (row.id === updatedRow.id ? updatedRow : row))
+    }
+
+    return HttpResponse.json(updatedRow ? { id: updatedRow.id } : null)
+  })
+
+  return [monthlyBudgetsHandler, createMonthlyBudgetHandler, updateMonthlyBudgetHandler]
 }
 
 function shouldReturnSingleObject(request: Request): boolean {
@@ -107,6 +142,37 @@ function buildMonthlyBudgetRow(
     effective_year: year,
     updated_at: now,
     user_id: 100,
+  }
+}
+
+function parseUpdateMonthlyBudgetId(url: string): number | undefined {
+  const searchParams = new URL(url).searchParams
+  const idParam = searchParams.get("id")
+
+  if (!idParam?.startsWith("eq.")) {
+    return undefined
+  }
+
+  const id = Number(idParam.slice(3))
+
+  return Number.isInteger(id) ? id : undefined
+}
+
+function buildUpdatedMonthlyBudgetRow(
+  id: number | undefined,
+  body: UpdateMonthlyBudgetBody,
+  rows: MonthlyBudgetRow[],
+): MonthlyBudgetRow | undefined {
+  const row = rows.find((monthlyBudget) => monthlyBudget.id === id)
+
+  if (!row) {
+    return undefined
+  }
+
+  return {
+    ...row,
+    amount: body.amount,
+    updated_at: new Date().toISOString(),
   }
 }
 


### PR DESCRIPTION
## 関連Issue

- closes #1265

## 変更内容

- Settings > Budgets の最新月額予算に編集導線と編集モーダルを追加
- 保存後に表示金額を更新し、0件更新は保存失敗として扱う
- 編集成功・失敗と更新処理のテストを追加

## 動作確認

- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] pnpm --filter web test:unit
- [x] pnpm --filter web test:integration
- [x] pnpm --filter web test:storybook