### PR TITLE
Payment作成時のuser_id補完をDBに寄せる

### DIFF
--- a/apps/api/supabase/migrations/20260506170000_align_payment_user_id_default.sql
+++ b/apps/api/supabase/migrations/20260506170000_align_payment_user_id_default.sql
@@ -1,0 +1,10 @@
+alter table payments
+  alter column user_id set default get_authenticated_user_id();
+
+create or replace function set_payment_user_id()
+returns trigger as $$
+begin
+  new.user_id := get_authenticated_user_id();
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;

--- a/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.test.tsx
+++ b/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.test.tsx
@@ -112,6 +112,7 @@ describe("CreatePaymentForm", () => {
       category_id: null,
       note: null,
     })
+    expect(requestBody).not.toHaveProperty("user_id")
     expect(requestBody?.date).toEqual(expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/))
   })
 
@@ -144,6 +145,7 @@ describe("CreatePaymentForm", () => {
       category_id: 10,
       note: "dinner",
     })
+    expect(requestBody).not.toHaveProperty("user_id")
     expect(requestBody?.date).toEqual(expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/))
   })
 })

--- a/apps/web/src/features/payments/createPayment/useCreatePayment.ts
+++ b/apps/web/src/features/payments/createPayment/useCreatePayment.ts
@@ -2,20 +2,12 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
 import { getSupabaseClient } from "../../../lib/supabase"
-import type { TablesInsert } from "../../../types/database.types"
 import { type PaymentWriteInput, toPaymentWriteInsert } from "../paymentFormMappers"
-
-// user_id は DB のデフォルト値（auth.uid()）で自動設定されるため FE から渡さない
-type PaymentInsert = Omit<TablesInsert<"payments">, "user_id">
 
 async function postPayment(value: PaymentWriteInput): Promise<void> {
   const supabase = getSupabaseClient()
-  const row: PaymentInsert = toPaymentWriteInsert(value)
-  const { error } = await supabase
-    .from("payments")
-    // FIXME: database.types.ts で user_id が必須だが、DB デフォルト値で設定されるため除外している。型定義の再生成で解消したらアサーションを削除する
-    // oxlint-disable-next-line typescript/consistent-type-assertions
-    .insert(row as TablesInsert<"payments">)
+  const row = toPaymentWriteInsert(value)
+  const { error } = await supabase.from("payments").insert(row)
 
   if (error) {
     throw error

--- a/apps/web/src/features/payments/paymentFormMappers.test.ts
+++ b/apps/web/src/features/payments/paymentFormMappers.test.ts
@@ -59,12 +59,15 @@ describe("toPaymentWriteInsert", () => {
       amount: 1080,
     }
 
-    expect(toPaymentWriteInsert(value)).toEqual({
+    const row = toPaymentWriteInsert(value)
+
+    expect(row).toEqual({
       date: "2024-09-22",
       category_id: 11,
       note: "dinner",
       amount: 1080,
     })
+    expect(row).not.toHaveProperty("user_id")
   })
 
   test("空文字は null に正規化する", () => {
@@ -97,17 +100,18 @@ describe("toPaymentWriteInsert", () => {
 
 describe("toPaymentWriteUpdate", () => {
   test("partial update を write contract 向けに変換する", () => {
-    expect(
-      toPaymentWriteUpdate({
-        date: new Date(2024, 8, 22, 12, 34, 56),
-        categoryId: "11",
-        note: "dinner",
-      }),
-    ).toEqual({
+    const payload = toPaymentWriteUpdate({
+      date: new Date(2024, 8, 22, 12, 34, 56),
+      categoryId: "11",
+      note: "dinner",
+    })
+
+    expect(payload).toEqual({
       date: "2024-09-22",
       category_id: 11,
       note: "dinner",
     })
+    expect(payload).not.toHaveProperty("user_id")
   })
 
   test("空文字は null に正規化する", () => {

--- a/apps/web/src/features/payments/updatePayment/updatePayment.test.ts
+++ b/apps/web/src/features/payments/updatePayment/updatePayment.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vite-plus/test"
 import { updatePayment } from "./updatePayment"
 
 const mockEq = vi.fn()
-const mockUpdate = vi.fn(() => ({ eq: mockEq }))
+const mockUpdate = vi.fn((_payload: Record<string, unknown>) => ({ eq: mockEq }))
 const mockFrom = vi.fn(() => ({ update: mockUpdate }))
 
 vi.mock("../../../lib/supabase", () => ({
@@ -28,6 +28,7 @@ describe("updatePayment", () => {
       category_id: 11,
       date: "2024-09-22",
     })
+    expect(mockUpdate.mock.calls[0]?.[0]).not.toHaveProperty("user_id")
     expect(mockEq).toHaveBeenCalledWith("id", 42)
   })
 

--- a/apps/web/src/types/database.types.ts
+++ b/apps/web/src/types/database.types.ts
@@ -199,7 +199,7 @@ export type Database = {
           id?: never
           note?: string | null
           updated_at?: string | null
-          user_id: number
+          user_id?: number
         }
         Update: {
           amount?: number


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- payments.user_id に認証ユーザー由来のデフォルト値を追加
- Payment 作成時の型アサーションを削除し、user_id を送らない insert に変更
- Payment 作成・更新 payload に user_id が含まれないことをテストで確認

## 動作確認

- [x] ローカルでの動作確認
- [x] テストの実行
- [ ] UIの確認（スクリーンショット等）

- `pnpm run web:lint`
- `pnpm run web:format-check`
- `pnpm run web:typecheck`
- `pnpm --filter web test:unit`
- `pnpm --filter web test:integration`
- `pnpm --filter web test:storybook`
- `pnpm run api:migrations:up`
