### PR TITLE
BookとBook memberのDBスキーマを追加する

### DIFF
--- a/apps/api/supabase/migrations/20260507011815_create_books_and_book_members_tables.sql
+++ b/apps/api/supabase/migrations/20260507011815_create_books_and_book_members_tables.sql
@@ -1,0 +1,42 @@
+create table books (
+    id bigint generated always as identity primary key,
+    name varchar(255) not null,
+    created_at timestamp with time zone default current_timestamp,
+    updated_at timestamp with time zone default current_timestamp
+);
+
+create table book_members (
+    id bigint generated always as identity primary key,
+    created_at timestamp with time zone default current_timestamp,
+    updated_at timestamp with time zone default current_timestamp,
+
+    book_id bigint not null references books(id) on delete cascade,
+    user_id bigint not null references users(id) on delete cascade,
+
+    constraint book_members_book_user_key
+        unique (book_id, user_id)
+);
+
+create index idx_book_members_user_book
+    on book_members (user_id, book_id);
+
+alter table books enable row level security;
+
+create policy "Users can read member books"
+  on books for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = books.id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );
+
+alter table book_members enable row level security;
+
+create policy "Users can read own book memberships"
+  on book_members for select
+  to authenticated
+  using (user_id = get_authenticated_user_id());

--- a/apps/api/supabase/migrations/20260507011815_create_books_and_book_members_tables.sql
+++ b/apps/api/supabase/migrations/20260507011815_create_books_and_book_members_tables.sql
@@ -30,7 +30,9 @@ create policy "Users can read member books"
       select 1
       from book_members
       where book_members.book_id = books.id
-        and book_members.user_id = get_authenticated_user_id()
+        and book_members.user_id in (
+          select id from users where external_id = auth.uid()::text
+        )
     )
   );
 
@@ -39,4 +41,8 @@ alter table book_members enable row level security;
 create policy "Users can read own book memberships"
   on book_members for select
   to authenticated
-  using (user_id = get_authenticated_user_id());
+  using (
+    user_id in (
+      select id from users where external_id = auth.uid()::text
+    )
+  );

--- a/apps/web/src/types/database.types.ts
+++ b/apps/web/src/types/database.types.ts
@@ -28,6 +28,66 @@ export type Database = {
   }
   public: {
     Tables: {
+      book_members: {
+        Row: {
+          book_id: number
+          created_at: string | null
+          id: number
+          updated_at: string | null
+          user_id: number
+        }
+        Insert: {
+          book_id: number
+          created_at?: string | null
+          id?: never
+          updated_at?: string | null
+          user_id: number
+        }
+        Update: {
+          book_id?: number
+          created_at?: string | null
+          id?: never
+          updated_at?: string | null
+          user_id?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "book_members_book_id_fkey"
+            columns: ["book_id"]
+            isOneToOne: false
+            referencedRelation: "books"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "book_members_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      books: {
+        Row: {
+          created_at: string | null
+          id: number
+          name: string
+          updated_at: string | null
+        }
+        Insert: {
+          created_at?: string | null
+          id?: never
+          name: string
+          updated_at?: string | null
+        }
+        Update: {
+          created_at?: string | null
+          id?: never
+          name?: string
+          updated_at?: string | null
+        }
+        Relationships: []
+      }
       categories: {
         Row: {
           created_at: string | null


### PR DESCRIPTION
## 関連Issue

- closes #1210

## 変更内容

- `books` と `book_members` のテーブルを追加
- book membership ベースで読める最小構成のRLSを追加
- Supabase生成型を新しいテーブル定義に同期

## 動作確認

- [x] `pnpm run api:migrations:up`
- [x] RLSスモーク確認
- [x] `pnpm run web:lint`
- [x] `pnpm run web:format-check`
- [x] `pnpm run web:typecheck`
- [x] `pnpm --filter web test:unit`
- [x] `pnpm --filter web test:integration`
- [x] `pnpm --filter web test:storybook`

## 補足

共有UI、招待、ロール細分化、既存データbackfill、既存テーブルのBook移行は対象外。