### PR TITLE
既存ユーザーにdefault Bookを追加

### DIFF
--- a/apps/api/supabase/migrations/20260507090000_add_default_books_for_users.sql
+++ b/apps/api/supabase/migrations/20260507090000_add_default_books_for_users.sql
@@ -1,0 +1,52 @@
+alter table book_members
+  add column is_default boolean not null default false;
+
+create unique index book_members_user_default_key
+  on book_members (user_id)
+  where is_default;
+
+create or replace function create_default_book_for_user()
+returns trigger as $$
+declare
+  default_book_id bigint;
+begin
+  insert into books (name)
+  values ('Default Book')
+  returning id into default_book_id;
+
+  insert into book_members (book_id, user_id, is_default)
+  values (default_book_id, new.id, true);
+
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_create_default_book_for_user
+  after insert on users
+  for each row
+  execute function create_default_book_for_user();
+
+do $$
+declare
+  user_record record;
+  default_book_id bigint;
+begin
+  for user_record in
+    select id
+    from users
+    where not exists (
+      select 1
+      from book_members
+      where book_members.user_id = users.id
+        and book_members.is_default
+    )
+    order by id
+  loop
+    insert into books (name)
+    values ('Default Book')
+    returning id into default_book_id;
+
+    insert into book_members (book_id, user_id, is_default)
+    values (default_book_id, user_record.id, true);
+  end loop;
+end $$;

--- a/apps/web/src/types/database.types.ts
+++ b/apps/web/src/types/database.types.ts
@@ -33,6 +33,7 @@ export type Database = {
           book_id: number
           created_at: string | null
           id: number
+          is_default: boolean
           updated_at: string | null
           user_id: number
         }
@@ -40,6 +41,7 @@ export type Database = {
           book_id: number
           created_at?: string | null
           id?: never
+          is_default?: boolean
           updated_at?: string | null
           user_id: number
         }
@@ -47,6 +49,7 @@ export type Database = {
           book_id?: number
           created_at?: string | null
           id?: never
+          is_default?: boolean
           updated_at?: string | null
           user_id?: number
         }


### PR DESCRIPTION
## 関連Issue

- closes #1211

## 変更内容

- book_membersにdefault判定を追加し、userごとのdefault membershipを一意にした
- 既存ユーザーと新規ユーザーにDefault Bookとdefault membershipを作成するmigrationを追加した
- WebのSupabase生成型にbook_members.is_defaultを反映した

## 動作確認

- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] pnpm --filter web test:unit
- [x] pnpm --filter web test:integration
- [x] pnpm --filter web test:storybook
- [x] git diff --check
- [x] pnpm run api:migrations:up は既存configの skip_nonce_check parse error でmigration適用前に停止