### PR TITLE
支払い情報をBook所有へ移行する

### DIFF
--- a/apps/api/supabase/migrations/20260507120000_migrate_payments_to_book_ownership.sql
+++ b/apps/api/supabase/migrations/20260507120000_migrate_payments_to_book_ownership.sql
@@ -1,0 +1,159 @@
+alter table payments
+  add column book_id bigint references books(id) on delete cascade;
+
+update payments
+set book_id = book_members.book_id
+from book_members
+where book_members.user_id = payments.user_id
+  and book_members.is_default;
+
+do $$
+begin
+  if exists (select 1 from payments where book_id is null) then
+    raise exception 'Default book is missing for existing payments.';
+  end if;
+end $$;
+
+create or replace function get_authenticated_default_book_id()
+returns bigint as $$
+declare
+  authenticated_default_book_id bigint;
+begin
+  select book_members.book_id into authenticated_default_book_id
+  from book_members
+  where book_members.user_id = get_authenticated_user_id()
+    and book_members.is_default;
+
+  if authenticated_default_book_id is null then
+    raise exception 'Default book not found for auth.uid: %', auth.uid();
+  end if;
+
+  return authenticated_default_book_id;
+end;
+$$ language plpgsql security invoker stable set search_path = public;
+
+revoke all on function public.get_authenticated_default_book_id() from public;
+revoke all on function public.get_authenticated_default_book_id() from anon;
+grant execute on function public.get_authenticated_default_book_id() to authenticated;
+grant execute on function public.get_authenticated_default_book_id() to service_role;
+
+alter table payments
+  alter column book_id set not null,
+  alter column book_id set default get_authenticated_default_book_id();
+
+create index idx_payments_book_date_category_created
+    on payments (book_id, date, category_id, created_at);
+
+drop trigger if exists trg_set_payment_user_id on payments;
+drop function if exists set_payment_user_id();
+
+create or replace function set_payment_ownership()
+returns trigger as $$
+begin
+  new.user_id := get_authenticated_user_id();
+
+  if new.book_id is null then
+    new.book_id := get_authenticated_default_book_id();
+  end if;
+
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_set_payment_ownership
+  before insert on payments
+  for each row
+  execute function set_payment_ownership();
+
+create or replace function keep_payment_book_id()
+returns trigger as $$
+begin
+  new.book_id := old.book_id;
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_keep_payment_book_id
+  before update on payments
+  for each row
+  execute function keep_payment_book_id();
+
+drop policy "Users can read own payments" on payments;
+drop policy "Users can insert own payments" on payments;
+drop policy "Users can update own payments" on payments;
+drop policy "Users can delete own payments" on payments;
+
+create policy "Users can read member book payments"
+  on payments for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = payments.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );
+
+create policy "Users can insert member book payments"
+  on payments for insert
+  to authenticated
+  with check (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = payments.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );
+
+create policy "Users can update member book payments"
+  on payments for update
+  to authenticated
+  using (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = payments.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = payments.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );
+
+create policy "Users can delete member book payments"
+  on payments for delete
+  to authenticated
+  using (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = payments.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );
+
+create or replace function public.get_monthly_total_amount(
+    p_month text
+)
+returns numeric
+language sql
+stable
+as $$
+    select coalesce(sum(p.amount), 0)
+    from public.payments p
+    where exists (
+      select 1
+      from public.book_members bm
+      where bm.book_id = p.book_id
+        and bm.user_id = public.get_authenticated_user_id()
+    )
+      and p.date >= to_date(p_month || '-01', 'YYYY-MM-DD')
+      and p.date < (to_date(p_month || '-01', 'YYYY-MM-DD') + interval '1 month')::date;
+$$;

--- a/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
@@ -40,6 +40,7 @@ const createdPayment = mapPaymentToRow({
   note: createdPaymentFormInput.note,
   amount: createdPaymentFormInput.amount,
   date: new Date("2025-06-15T00:00:00+09:00"),
+  bookId: 1,
   userId: 100,
   createdDate: new Date("2025-06-15T12:00:00+09:00"),
   updatedDate: new Date("2025-06-15T12:00:00+09:00"),

--- a/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.test.tsx
+++ b/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.test.tsx
@@ -113,6 +113,7 @@ describe("CreatePaymentForm", () => {
       note: null,
     })
     expect(requestBody).not.toHaveProperty("user_id")
+    expect(requestBody).not.toHaveProperty("book_id")
     expect(requestBody?.date).toEqual(expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/))
   })
 
@@ -146,6 +147,7 @@ describe("CreatePaymentForm", () => {
       note: "dinner",
     })
     expect(requestBody).not.toHaveProperty("user_id")
+    expect(requestBody).not.toHaveProperty("book_id")
     expect(requestBody?.date).toEqual(expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/))
   })
 })

--- a/apps/web/src/features/payments/listPayment/fetchPayments.integration.test.ts
+++ b/apps/web/src/features/payments/listPayment/fetchPayments.integration.test.ts
@@ -1,8 +1,11 @@
 import { HttpResponse, http } from "msw"
-import { describe, expect, it, vi } from "vite-plus/test"
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
+import { payments } from "../../../test/data/payments"
+import { createPaymentHandlers } from "../../../test/msw/handlers/payments"
 import { server } from "../../../test/msw/server"
 import { supabaseTestClient } from "../../../test/utils/createSupabaseTestClient"
+import { mapPaymentToRow } from "../../../test/utils/mapPaymentToRow"
 import { fetchPayments } from "./fetchPayments"
 
 vi.mock("../../../lib/supabase", () => ({
@@ -10,6 +13,10 @@ vi.mock("../../../lib/supabase", () => ({
 }))
 
 describe("fetchPayments", () => {
+  beforeEach(() => {
+    server.resetHandlers(...createPaymentHandlers())
+  })
+
   it("date, createdDate, updatedDateをDateオブジェクトに変換する", async () => {
     const payments = await fetchPayments([null, null])
 
@@ -34,6 +41,25 @@ describe("fetchPayments", () => {
     for (const payment of payments) {
       expect(typeof payment.note).toBe("string")
     }
+  })
+
+  it("現在のbookに属する支払いのみ返す", async () => {
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        initialRows: [
+          mapPaymentToRow(payments[0]),
+          {
+            ...mapPaymentToRow(payments[1]),
+            book_id: 2,
+          },
+        ],
+      }),
+    )
+
+    const fetchedPayments = await fetchPayments([null, null])
+
+    expect(fetchedPayments).toHaveLength(1)
+    expect(fetchedPayments[0]?.bookId).toBe(1)
   })
 
   it("startDateを指定するとそれ以降の支払いのみ返す", async () => {

--- a/apps/web/src/features/payments/listPayment/fetchPayments.ts
+++ b/apps/web/src/features/payments/listPayment/fetchPayments.ts
@@ -14,7 +14,7 @@ export async function fetchPayments(
   const supabase = getSupabaseClient()
   let query = supabase
     .from("payments")
-    .select("id, note, amount, date, created_at, updated_at, category_id, user_id")
+    .select("id, note, amount, date, created_at, updated_at, book_id, category_id, user_id")
     .order("date", { ascending: false })
     .order("id", { ascending: false })
 
@@ -43,6 +43,7 @@ export async function fetchPayments(
     note: row.note ?? "",
     amount: row.amount,
     date: new Date(row.date),
+    bookId: row.book_id,
     userId: row.user_id,
     createdDate: row.created_at ? new Date(row.created_at) : new Date(),
     updatedDate: row.updated_at ? new Date(row.updated_at) : new Date(),

--- a/apps/web/src/features/payments/listPayment/usePayments.test.tsx
+++ b/apps/web/src/features/payments/listPayment/usePayments.test.tsx
@@ -25,6 +25,7 @@ function buildPayment(id: number): Payment {
     categoryId: 10,
     date: new Date(2025, 5, id),
     note: `payment ${id}`,
+    bookId: 1,
     userId: 100,
     createdDate: new Date("2025-06-01T00:00:00.000Z"),
     updatedDate: new Date("2025-06-01T00:00:00.000Z"),

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.test.tsx
@@ -261,6 +261,7 @@ describe("PaymentDetailsOverlay", () => {
           id: "invalid",
           amount: 1000,
           date: "2025-06-02",
+          book_id: 1,
           user_id: 100,
           category: null,
         })

--- a/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
+++ b/apps/web/src/features/payments/paymentDetails/PaymentDetailsOverlay/PaymentDetailsOverlay.tsx
@@ -147,6 +147,7 @@ function toPayment(payment: PaymentDetails): Payment {
     note: payment.note,
     amount: payment.amount,
     date: payment.date,
+    bookId: payment.bookId,
     userId: payment.userId,
     createdDate: payment.createdDate,
     updatedDate: payment.updatedDate,

--- a/apps/web/src/features/payments/paymentDetails/fetchPaymentDetails.integration.test.ts
+++ b/apps/web/src/features/payments/paymentDetails/fetchPaymentDetails.integration.test.ts
@@ -22,6 +22,7 @@ describe("fetchPaymentDetails", () => {
 
     expect(payment).not.toBeNull()
     expect(payment?.id).toBe(1)
+    expect(payment?.bookId).toBe(1)
     expect(payment?.date).toBeInstanceOf(Date)
     expect(payment?.createdDate).toBeInstanceOf(Date)
     expect(payment?.updatedDate).toBeInstanceOf(Date)
@@ -62,6 +63,7 @@ describe("fetchPaymentDetails", () => {
           id: "invalid",
           amount: 1000,
           date: "2025-06-02",
+          book_id: 1,
           user_id: 100,
           category: null,
         })
@@ -69,5 +71,22 @@ describe("fetchPaymentDetails", () => {
     )
 
     await expect(fetchPaymentDetails(1)).rejects.toThrow("Invalid payment details response")
+  })
+
+  it("現在のbookに属さない支払いは null を返す", async () => {
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        initialRows: [
+          {
+            ...mapPaymentToRow(payments[0]),
+            book_id: 2,
+          },
+        ],
+      }),
+    )
+
+    const payment = await fetchPaymentDetails(1)
+
+    expect(payment).toBeNull()
   })
 })

--- a/apps/web/src/features/payments/paymentDetails/fetchPaymentDetails.ts
+++ b/apps/web/src/features/payments/paymentDetails/fetchPaymentDetails.ts
@@ -17,6 +17,7 @@ const paymentDetailsRowSchema = z.object({
   date: z.string(),
   created_at: z.string().nullable(),
   updated_at: z.string().nullable(),
+  book_id: z.number(),
   user_id: z.number(),
   category: paymentCategorySchema,
 })
@@ -35,6 +36,7 @@ export async function fetchPaymentDetails(paymentId: PaymentId): Promise<Payment
         date,
         created_at,
         updated_at,
+        book_id,
         user_id,
         category:categories!payments_category_id_fkey (
           id,
@@ -60,6 +62,7 @@ export async function fetchPaymentDetails(paymentId: PaymentId): Promise<Payment
     note: row.note ?? "",
     amount: row.amount,
     date: new Date(row.date),
+    bookId: row.book_id,
     userId: row.user_id,
     createdDate: row.created_at ? new Date(row.created_at) : new Date(),
     updatedDate: row.updated_at ? new Date(row.updated_at) : new Date(),

--- a/apps/web/src/features/payments/paymentFormMappers.test.ts
+++ b/apps/web/src/features/payments/paymentFormMappers.test.ts
@@ -15,6 +15,7 @@ function createPaymentFixture(overrides: Partial<Payment> = {}): Payment {
     note: "lunch",
     amount: 1200,
     date: new Date(2024, 8, 22),
+    bookId: 1,
     userId: 10,
     createdDate: new Date(2024, 8, 22, 0, 0, 0),
     updatedDate: new Date(2024, 8, 22, 0, 0, 0),
@@ -68,6 +69,7 @@ describe("toPaymentWriteInsert", () => {
       amount: 1080,
     })
     expect(row).not.toHaveProperty("user_id")
+    expect(row).not.toHaveProperty("book_id")
   })
 
   test("空文字は null に正規化する", () => {
@@ -112,6 +114,7 @@ describe("toPaymentWriteUpdate", () => {
       note: "dinner",
     })
     expect(payload).not.toHaveProperty("user_id")
+    expect(payload).not.toHaveProperty("book_id")
   })
 
   test("空文字は null に正規化する", () => {

--- a/apps/web/src/features/payments/paymentFormMappers.ts
+++ b/apps/web/src/features/payments/paymentFormMappers.ts
@@ -4,8 +4,11 @@ import type { TablesInsert, TablesUpdate } from "../../types/database.types"
 import type { Payment } from "../../types/payment"
 import { noteFieldSchema, type PaymentFormValues } from "./paymentFormSchema"
 
-type PaymentInsert = Omit<TablesInsert<"payments">, "user_id">
-type PaymentUpdate = Omit<TablesUpdate<"payments">, "user_id" | "id" | "created_at" | "updated_at">
+type PaymentInsert = Omit<TablesInsert<"payments">, "book_id" | "user_id">
+type PaymentUpdate = Omit<
+  TablesUpdate<"payments">,
+  "book_id" | "user_id" | "id" | "created_at" | "updated_at"
+>
 
 export interface PaymentWriteInput {
   categoryId?: string

--- a/apps/web/src/features/payments/updatePayment/updatePayment.test.ts
+++ b/apps/web/src/features/payments/updatePayment/updatePayment.test.ts
@@ -29,6 +29,7 @@ describe("updatePayment", () => {
       date: "2024-09-22",
     })
     expect(mockUpdate.mock.calls[0]?.[0]).not.toHaveProperty("user_id")
+    expect(mockUpdate.mock.calls[0]?.[0]).not.toHaveProperty("book_id")
     expect(mockEq).toHaveBeenCalledWith("id", 42)
   })
 

--- a/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.test.tsx
+++ b/apps/web/src/features/summaryByMonth/MonthlyTotals/MonthlyTotals.test.tsx
@@ -2,10 +2,12 @@ import { composeStories } from "@storybook/react-vite"
 import { afterEach, describe, expect, test, vi } from "vite-plus/test"
 
 import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
+import { payments } from "../../../test/data/payments"
 import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
 import { createPaymentHandlers } from "../../../test/msw/handlers/payments"
 import { server } from "../../../test/msw/server"
 import { render, screen, waitFor } from "../../../test/test-utils"
+import { mapPaymentToRow } from "../../../test/utils/mapPaymentToRow"
 import * as stories from "./MonthlyTotals.stories"
 
 const { Default } = composeStories(stories)
@@ -82,5 +84,25 @@ describe("MonthlyTotals", () => {
 
     expect(await screen.findByText("￥10,000")).toBeInTheDocument()
     expect(await screen.findByText("Could not get the budget")).toBeInTheDocument()
+  })
+
+  test("月次合計は現在のbookに属する支払いのみで計算する", async () => {
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        initialRows: [
+          mapPaymentToRow(payments[0]),
+          {
+            ...mapPaymentToRow(payments[1]),
+            book_id: 2,
+          },
+        ],
+      }),
+      ...createMonthlyBudgetHandlers({
+        get: { response: { ...monthlyBudgets[2], amount: 30000 } },
+      }),
+    )
+    renderStory()
+
+    expect(await screen.findByText("￥1,000")).toBeInTheDocument()
   })
 })

--- a/apps/web/src/test/data/payments.ts
+++ b/apps/web/src/test/data/payments.ts
@@ -3,6 +3,7 @@ import type { Payment } from "../../types/payment"
 export const longPayment: Payment = {
   id: 99,
   categoryId: 30,
+  bookId: 1,
   userId: 100,
   date: new Date(1999, 2, 1),
   note: "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
@@ -15,6 +16,7 @@ export const payments: Payment[] = [
   {
     id: 1,
     categoryId: 10,
+    bookId: 1,
     userId: 100,
     date: new Date(2025, 5, 2),
     note: "コンビニ",
@@ -25,6 +27,7 @@ export const payments: Payment[] = [
   {
     id: 2,
     categoryId: 20,
+    bookId: 1,
     userId: 100,
     date: new Date(2025, 5, 3),
     note: "コンビニ",
@@ -35,6 +38,7 @@ export const payments: Payment[] = [
   {
     id: 3,
     categoryId: 10,
+    bookId: 1,
     userId: 100,
     date: new Date(2025, 3, 1),
     note: "スーパー",
@@ -45,6 +49,7 @@ export const payments: Payment[] = [
   {
     id: 4,
     categoryId: 30,
+    bookId: 1,
     userId: 100,
     date: new Date(2025, 2, 1),
     note: "コンビニ",

--- a/apps/web/src/test/msw/handlers/payments.ts
+++ b/apps/web/src/test/msw/handlers/payments.ts
@@ -9,6 +9,7 @@ import { mapPaymentToRow } from "../../utils/mapPaymentToRow"
 
 const REST_URL = "*/rest/v1/payments*"
 const MONTHLY_TOTAL_AMOUNT_REST_URL = "*/rest/v1/rpc/get_monthly_total_amount"
+const CURRENT_BOOK_ID = 1
 
 const initialPaymentRows: PaymentRow[] = payments.map(mapPaymentToRow)
 const initialCategoryRows: CategoryRow[] = categories.map((category) => ({
@@ -52,6 +53,7 @@ interface GetMonthlyTotalAmountOptions extends BaseOptions {
 
 interface CreatePaymentHandlersOptions {
   initialRows?: PaymentRow[]
+  currentBookId?: number
   get?: GetPaymentsOptions
   create?: CreatePaymentOptions
   update?: UpdatePaymentOptions
@@ -59,7 +61,11 @@ interface CreatePaymentHandlersOptions {
   getMonthlyTotalAmount?: GetMonthlyTotalAmountOptions
 }
 
-function filterAndSortPayments(rows: PaymentRow[], request: Request): PaymentRow[] {
+function filterAndSortPayments(
+  rows: PaymentRow[],
+  request: Request,
+  currentBookId: number,
+): PaymentRow[] {
   const url = new URL(request.url)
   const dateFilters = url.searchParams.getAll("date")
   const idFilter = url.searchParams.get("id")
@@ -69,6 +75,7 @@ function filterAndSortPayments(rows: PaymentRow[], request: Request): PaymentRow
   const id = idFilter?.startsWith("eq.") ? idFilter.replace("eq.", "") : null
 
   return rows
+    .filter((row) => row.book_id === currentBookId)
     .filter((row) => {
       if (id && String(row.id) !== id) {
         return false
@@ -112,6 +119,7 @@ function toPaymentDetailsRow(row: PaymentRow, categoryRows: CategoryRow[]): Paym
     date: row.date,
     created_at: row.created_at,
     updated_at: row.updated_at,
+    book_id: row.book_id,
     user_id: row.user_id,
     category: category
       ? {
@@ -142,7 +150,11 @@ const getMonthlyTotalAmountRequestBodySchema = z.object({
   p_month: z.string().optional(),
 })
 
-function buildPaymentRow(body: CreatePaymentBody, paymentRows: PaymentRow[]): PaymentRow {
+function buildPaymentRow(
+  body: CreatePaymentBody,
+  paymentRows: PaymentRow[],
+  currentBookId: number,
+): PaymentRow {
   const now = new Date().toISOString()
 
   return {
@@ -152,23 +164,31 @@ function buildPaymentRow(body: CreatePaymentBody, paymentRows: PaymentRow[]): Pa
     date: body.date,
     created_at: now,
     updated_at: now,
+    book_id: currentBookId,
     category_id: body.category_id,
     user_id: 100,
   }
 }
 
-function calculateMonthlyTotalAmount(paymentRows: PaymentRow[], month?: string): number {
+function calculateMonthlyTotalAmount(
+  paymentRows: PaymentRow[],
+  currentBookId: number,
+  month?: string,
+): number {
+  const currentBookPaymentRows = paymentRows.filter((row) => row.book_id === currentBookId)
+
   if (!month) {
-    return paymentRows.reduce((sum, row) => sum + row.amount, 0)
+    return currentBookPaymentRows.reduce((sum, row) => sum + row.amount, 0)
   }
 
-  return paymentRows
+  return currentBookPaymentRows
     .filter((row) => row.date.startsWith(`${month}-`))
     .reduce((sum, row) => sum + row.amount, 0)
 }
 
 export function createPaymentHandlers({
   initialRows = initialPaymentRows,
+  currentBookId = CURRENT_BOOK_ID,
   get = {},
   create = {},
   update = {},
@@ -185,7 +205,7 @@ export function createPaymentHandlers({
       return HttpResponse.json({ message: "Failed to fetch payments." }, { status: 500 })
     }
 
-    const filteredRows = filterAndSortPayments(rows, request)
+    const filteredRows = filterAndSortPayments(rows, request, currentBookId)
 
     if (shouldIncludeCategory(request)) {
       const detailsRows = filteredRows.map((row) => toPaymentDetailsRow(row, categoryRows))
@@ -217,7 +237,7 @@ export function createPaymentHandlers({
 
     const body = await request.json()
     const parsedBody = createPaymentBodySchema.parse(body)
-    const newRow = buildPaymentRow(parsedBody, rows)
+    const newRow = buildPaymentRow(parsedBody, rows, currentBookId)
 
     return HttpResponse.json([newRow], { status: 201 })
   })
@@ -263,7 +283,7 @@ export function createPaymentHandlers({
 
       const body = await request.json()
       const parsedBody = getMonthlyTotalAmountRequestBodySchema.parse(body)
-      return HttpResponse.json(calculateMonthlyTotalAmount(rows, parsedBody.p_month))
+      return HttpResponse.json(calculateMonthlyTotalAmount(rows, currentBookId, parsedBody.p_month))
     },
   )
 

--- a/apps/web/src/test/utils/mapPaymentToRow.ts
+++ b/apps/web/src/test/utils/mapPaymentToRow.ts
@@ -14,6 +14,7 @@ export function mapPaymentToRow(payment: Payment): PaymentRow {
     date: format(payment.date, "yyyy-MM-dd"),
     created_at: payment.createdDate.toISOString(),
     updated_at: payment.updatedDate.toISOString(),
+    book_id: payment.bookId,
     category_id: payment.categoryId,
     user_id: payment.userId,
   }

--- a/apps/web/src/types/database.types.ts
+++ b/apps/web/src/types/database.types.ts
@@ -246,6 +246,7 @@ export type Database = {
       payments: {
         Row: {
           amount: number
+          book_id: number
           category_id: number | null
           created_at: string | null
           date: string
@@ -256,6 +257,7 @@ export type Database = {
         }
         Insert: {
           amount: number
+          book_id?: number
           category_id?: number | null
           created_at?: string | null
           date: string
@@ -266,6 +268,7 @@ export type Database = {
         }
         Update: {
           amount?: number
+          book_id?: number
           category_id?: number | null
           created_at?: string | null
           date?: string
@@ -275,6 +278,13 @@ export type Database = {
           user_id?: number
         }
         Relationships: [
+          {
+            foreignKeyName: "payments_book_id_fkey"
+            columns: ["book_id"]
+            isOneToOne: false
+            referencedRelation: "books"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "payments_category_id_fkey"
             columns: ["category_id"]
@@ -323,6 +333,7 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      get_authenticated_default_book_id: { Args: never; Returns: number }
       get_authenticated_user_id: { Args: never; Returns: number }
       get_monthly_total_amount: { Args: { p_month: string }; Returns: number }
     }

--- a/apps/web/src/types/payment.ts
+++ b/apps/web/src/types/payment.ts
@@ -8,6 +8,7 @@ export interface Payment {
   note: string
   amount: number
   date: Date
+  bookId: number
   userId: number
   createdDate: Date
   updatedDate: Date


### PR DESCRIPTION
## 関連Issue

- closes #1212

## 変更内容

- payments に book_id を追加し、既存 payment を各 user の default Book へ backfill
- 支払いの RLS と月次合計 RPC を Book member 前提に更新
- Web の支払い取得・詳細取得・型・MSW・テストを book_id に同期

## 動作確認

- [x] pnpm --filter api exec supabase db reset
- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] pnpm --filter web test:unit
- [x] pnpm --filter web test:integration
- [x] pnpm --filter web test:storybook

## 補足

- user_id の FK / cascade の扱いは別途対応
