### PR TITLE
カテゴリをBook所有へ移行する

### DIFF
--- a/apps/api/supabase/migrations/20260507130000_migrate_categories_to_book_ownership.sql
+++ b/apps/api/supabase/migrations/20260507130000_migrate_categories_to_book_ownership.sql
@@ -1,0 +1,206 @@
+alter table categories
+  drop constraint if exists categories_name_key;
+
+alter table categories
+  add column book_id bigint references books(id) on delete cascade,
+  add column migration_old_category_id bigint;
+
+insert into categories (name, created_at, updated_at, book_id, migration_old_category_id)
+select
+  categories.name,
+  categories.created_at,
+  categories.updated_at,
+  default_books.book_id,
+  categories.id
+from categories
+cross join (
+  select distinct book_id
+  from book_members
+  where is_default
+) default_books
+where categories.book_id is null
+order by categories.id, default_books.book_id;
+
+update payments
+set category_id = new_categories.id
+from categories old_categories, categories new_categories
+where payments.category_id = old_categories.id
+  and old_categories.book_id is null
+  and new_categories.migration_old_category_id = old_categories.id
+  and new_categories.book_id = payments.book_id;
+
+update category_budgets
+set category_id = new_categories.id
+from categories old_categories, categories new_categories, book_members
+where category_budgets.category_id = old_categories.id
+  and old_categories.book_id is null
+  and book_members.user_id = category_budgets.user_id
+  and book_members.is_default
+  and new_categories.migration_old_category_id = old_categories.id
+  and new_categories.book_id = book_members.book_id;
+
+update category_pins
+set category_id = new_categories.id
+from categories old_categories, categories new_categories, book_members
+where category_pins.category_id = old_categories.id
+  and old_categories.book_id is null
+  and book_members.user_id = category_pins.user_id
+  and book_members.is_default
+  and new_categories.migration_old_category_id = old_categories.id
+  and new_categories.book_id = book_members.book_id;
+
+do $$
+begin
+  if exists (
+    select 1
+    from payments
+    join categories on categories.id = payments.category_id
+    where categories.book_id is null
+  ) then
+    raise exception 'Book-owned category backfill is missing for existing payments.';
+  end if;
+
+  if exists (
+    select 1
+    from category_budgets
+    join categories on categories.id = category_budgets.category_id
+    where categories.book_id is null
+  ) then
+    raise exception 'Book-owned category backfill is missing for existing category budgets.';
+  end if;
+
+  if exists (
+    select 1
+    from category_pins
+    join categories on categories.id = category_pins.category_id
+    where categories.book_id is null
+  ) then
+    raise exception 'Book-owned category backfill is missing for existing category pins.';
+  end if;
+end $$;
+
+delete from categories
+where book_id is null;
+
+alter table categories
+  drop column migration_old_category_id,
+  alter column book_id set not null;
+
+alter table categories
+  add constraint categories_book_name_key
+    unique (book_id, name);
+
+create or replace function ensure_payment_category_book()
+returns trigger as $$
+begin
+  if new.category_id is null then
+    return new;
+  end if;
+
+  if not exists (
+    select 1
+    from categories
+    where categories.id = new.category_id
+      and categories.book_id = new.book_id
+  ) then
+    raise exception 'Payment category must belong to the same book.';
+  end if;
+
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_validate_payment_category_book
+  before insert or update of book_id, category_id on payments
+  for each row
+  execute function ensure_payment_category_book();
+
+create or replace function ensure_category_budget_category_membership()
+returns trigger as $$
+begin
+  if not exists (
+    select 1
+    from categories
+    join book_members on book_members.book_id = categories.book_id
+    where categories.id = new.category_id
+      and book_members.user_id = new.user_id
+  ) then
+    raise exception 'Category budget category must belong to a member book.';
+  end if;
+
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_validate_category_budget_category_membership
+  before insert or update of user_id, category_id on category_budgets
+  for each row
+  execute function ensure_category_budget_category_membership();
+
+create or replace function ensure_category_pin_category_membership()
+returns trigger as $$
+begin
+  if not exists (
+    select 1
+    from categories
+    join book_members on book_members.book_id = categories.book_id
+    where categories.id = new.category_id
+      and book_members.user_id = new.user_id
+  ) then
+    raise exception 'Category pin category must belong to a member book.';
+  end if;
+
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_validate_category_pin_category_membership
+  before insert or update of user_id, category_id on category_pins
+  for each row
+  execute function ensure_category_pin_category_membership();
+
+drop policy "Authenticated users can read all categories" on categories;
+
+create policy "Users can read member book categories"
+  on categories for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = categories.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );
+
+drop policy "Users can insert own category budgets" on category_budgets;
+
+create policy "Users can insert member book category budgets"
+  on category_budgets for insert
+  to authenticated
+  with check (
+    user_id = get_authenticated_user_id()
+    and exists (
+      select 1
+      from categories
+      join book_members on book_members.book_id = categories.book_id
+      where categories.id = category_budgets.category_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );
+
+drop policy "Users can insert own category pins" on category_pins;
+
+create policy "Users can insert member book category pins"
+  on category_pins for insert
+  to authenticated
+  with check (
+    user_id = get_authenticated_user_id()
+    and exists (
+      select 1
+      from categories
+      join book_members on book_members.book_id = categories.book_id
+      where categories.id = category_pins.category_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );

--- a/apps/api/supabase/seed/categories.sql
+++ b/apps/api/supabase/seed/categories.sql
@@ -1,16 +1,26 @@
-insert into categories (name) values
-('食費'),
-('外食'),
-('日用品'),
-('娯楽品'),
-('遊び'),
-('交通費'),
-('衣類・美容'),
-('薬・病院'),
-('書籍'),
-('交際費'),
-('ギャンブル'),
-('税金'),
-('固定費'),
-('その他')
-on conflict (name) do nothing;
+with seed_categories (name) as (
+  values
+    ('食費'),
+    ('外食'),
+    ('日用品'),
+    ('娯楽品'),
+    ('遊び'),
+    ('交通費'),
+    ('衣類・美容'),
+    ('薬・病院'),
+    ('書籍'),
+    ('交際費'),
+    ('ギャンブル'),
+    ('税金'),
+    ('固定費'),
+    ('その他')
+)
+insert into categories (book_id, name)
+select default_books.book_id, seed_categories.name
+from (
+  select distinct book_id
+  from book_members
+  where is_default
+) default_books
+cross join seed_categories
+on conflict (book_id, name) do nothing;

--- a/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormMappers.test.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormMappers.test.ts
@@ -4,17 +4,18 @@ import { toCategoryBudgetInsert } from "./categoryBudgetFormMappers"
 
 describe("toCategoryBudgetInsert", () => {
   test("カテゴリ別予算作成用の値をcategory_budgets insert payloadに変換する", () => {
-    expect(
-      toCategoryBudgetInsert({
-        categoryId: 10,
-        targetMonth: new Date(2026, 2, 20),
-        amount: 50000,
-      }),
-    ).toEqual({
+    const row = toCategoryBudgetInsert({
+      categoryId: 10,
+      targetMonth: new Date(2026, 2, 20),
+      amount: 50000,
+    })
+
+    expect(row).toEqual({
       amount: 50000,
       category_id: 10,
       effective_from: "2026-03-01",
     })
+    expect(row).not.toHaveProperty("book_id")
   })
 
   test("選択日の年月を使い、日付は月初日に丸める", () => {

--- a/apps/web/src/features/budgets/listCategoryBudget/fetchCategoryBudgets.integration.test.ts
+++ b/apps/web/src/features/budgets/listCategoryBudget/fetchCategoryBudgets.integration.test.ts
@@ -158,6 +158,37 @@ describe("fetchCategoryBudgets", () => {
     expect(budgets.find((budget) => budget.categoryId === 20)?.id).toBe(4)
   })
 
+  it("同じbookに属さないカテゴリ名はカテゴリ別予算に結合しない", async () => {
+    server.resetHandlers(
+      ...createCategoryBudgetHandlers({
+        get: {
+          rows: [
+            {
+              id: 5,
+              amount: 8000,
+              category_id: 40,
+              created_at: "2025-05-01T00:00:00.000Z",
+              effective_from: "2025-05-01",
+              effective_month: 5,
+              effective_year: 2025,
+              updated_at: "2025-05-01T00:00:00.000Z",
+              user_id: 100,
+            },
+          ],
+        },
+      }),
+    )
+
+    const budgets = await fetchCategoryBudgets()
+
+    expect(budgets).toHaveLength(1)
+    expect(budgets[0]).toMatchObject({
+      id: 5,
+      categoryId: 40,
+      categoryName: "Unknown",
+    })
+  })
+
   it("カテゴリ別予算とカテゴリ名を取得する query を送る", async () => {
     const requestCapture: { url: URL | null } = { url: null }
 

--- a/apps/web/src/features/categories/listCategory/fetchCategories.integration.test.ts
+++ b/apps/web/src/features/categories/listCategory/fetchCategories.integration.test.ts
@@ -1,5 +1,8 @@
+import { HttpResponse, http } from "msw"
 import { describe, expect, it, vi } from "vite-plus/test"
 
+import { createCategoryHandlers } from "../../../test/msw/handlers/categories"
+import { server } from "../../../test/msw/server"
 import { supabaseTestClient } from "../../../test/utils/createSupabaseTestClient"
 import { fetchCategories } from "./fetchCategories"
 
@@ -14,18 +17,21 @@ describe("fetchCategories", () => {
     expect(categories).toHaveLength(3)
     expect(categories[0]).toEqual({
       id: 10,
+      bookId: 1,
       name: "Food",
       createdDate: new Date("2025-01-01T00:00:00.000Z"),
       updatedDate: new Date("2025-01-01T00:00:00.000Z"),
     })
     expect(categories[1]).toEqual({
       id: 20,
+      bookId: 1,
       name: "Daily Necessities",
       createdDate: new Date("2025-01-01T00:00:00.000Z"),
       updatedDate: new Date("2025-01-01T00:00:00.000Z"),
     })
     expect(categories[2]).toEqual({
       id: 30,
+      bookId: 1,
       name: "Entertainment",
       createdDate: new Date("2025-01-01T00:00:00.000Z"),
       updatedDate: new Date("2025-01-01T00:00:00.000Z"),
@@ -39,5 +45,45 @@ describe("fetchCategories", () => {
       expect(category.createdDate).toBeInstanceOf(Date)
       expect(category.updatedDate).toBeInstanceOf(Date)
     }
+  })
+
+  it("member book RLS 後のカテゴリだけを取得する", async () => {
+    server.resetHandlers(
+      ...createCategoryHandlers({
+        get: {
+          currentBookId: 2,
+        },
+      }),
+    )
+
+    const categories = await fetchCategories()
+
+    expect(categories).toEqual([
+      {
+        id: 40,
+        bookId: 2,
+        name: "Food",
+        createdDate: new Date("2025-01-01T00:00:00.000Z"),
+        updatedDate: new Date("2025-01-01T00:00:00.000Z"),
+      },
+    ])
+  })
+
+  it("book_idを取得し、Webからbook_id条件は送らない", async () => {
+    const requestCapture: { url: URL | null } = { url: null }
+    server.use(
+      http.get("*/rest/v1/categories*", ({ request }) => {
+        requestCapture.url = new URL(request.url)
+
+        return HttpResponse.json([])
+      }),
+    )
+
+    await fetchCategories()
+
+    expect(requestCapture.url?.searchParams.get("select")).toBe(
+      "id,name,book_id,created_at,updated_at",
+    )
+    expect(requestCapture.url?.searchParams.has("book_id")).toBe(false)
   })
 })

--- a/apps/web/src/features/categories/listCategory/fetchCategories.ts
+++ b/apps/web/src/features/categories/listCategory/fetchCategories.ts
@@ -4,6 +4,7 @@ import type { Category, CategoryRow } from "../../../types/category"
 function toCategoryFromRow(row: CategoryRow): Category {
   return {
     id: row.id,
+    bookId: row.book_id,
     name: row.name,
     createdDate: row.created_at ? new Date(row.created_at) : new Date(),
     updatedDate: row.updated_at ? new Date(row.updated_at) : new Date(),
@@ -14,7 +15,7 @@ export async function fetchCategories(): Promise<Category[]> {
   const supabase = getSupabaseClient()
   const { data, error } = await supabase
     .from("categories")
-    .select("*")
+    .select("id, name, book_id, created_at, updated_at")
     .order("id", { ascending: true })
 
   if (error) {

--- a/apps/web/src/features/categories/unknownCategory.ts
+++ b/apps/web/src/features/categories/unknownCategory.ts
@@ -2,6 +2,7 @@ import type { Category } from "../../types/category"
 
 export const unknownCategory: Category = {
   id: -1,
+  bookId: 0,
   name: "Unknown",
   createdDate: new Date(),
   updatedDate: new Date(),

--- a/apps/web/src/features/payments/paymentDetails/fetchPaymentDetails.integration.test.ts
+++ b/apps/web/src/features/payments/paymentDetails/fetchPaymentDetails.integration.test.ts
@@ -50,6 +50,24 @@ describe("fetchPaymentDetails", () => {
     expect(payment?.category).toBeNull()
   })
 
+  it("同じbookに属さないカテゴリは支払い詳細のcategoryに結合しない", async () => {
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        initialRows: [
+          {
+            ...mapPaymentToRow(payments[0]),
+            category_id: 40,
+          },
+        ],
+      }),
+    )
+
+    const payment = await fetchPaymentDetails(1)
+
+    expect(payment).not.toBeNull()
+    expect(payment?.category).toBeNull()
+  })
+
   it("対象が存在しないときは null を返す", async () => {
     const payment = await fetchPaymentDetails(999)
 

--- a/apps/web/src/test/data/categories.ts
+++ b/apps/web/src/test/data/categories.ts
@@ -2,6 +2,7 @@ import type { Category } from "../../types/category"
 
 export const foodCat: Category = {
   id: 10,
+  bookId: 1,
   name: "Food",
   createdDate: new Date(),
   updatedDate: new Date(),
@@ -9,6 +10,7 @@ export const foodCat: Category = {
 
 export const dailyNecessitiesCat: Category = {
   id: 20,
+  bookId: 1,
   name: "Daily Necessities",
   createdDate: new Date(),
   updatedDate: new Date(),
@@ -16,9 +18,19 @@ export const dailyNecessitiesCat: Category = {
 
 export const entertainmentCat: Category = {
   id: 30,
+  bookId: 1,
   name: "Entertainment",
   createdDate: new Date(),
   updatedDate: new Date(),
 }
 
+export const otherBookFoodCat: Category = {
+  id: 40,
+  bookId: 2,
+  name: "Food",
+  createdDate: new Date(),
+  updatedDate: new Date(),
+}
+
 export const categories: Category[] = [foodCat, dailyNecessitiesCat, entertainmentCat]
+export const allCategories: Category[] = [...categories, otherBookFoodCat]

--- a/apps/web/src/test/msw/handlers/categories.ts
+++ b/apps/web/src/test/msw/handlers/categories.ts
@@ -1,25 +1,38 @@
 import { HttpResponse, http } from "msw"
 
 import type { CategoryRow } from "../../../types/category"
+import { otherBookFoodCat } from "../../data/categories"
+
+const CURRENT_BOOK_ID = 1
 
 const REST_URL = "*/rest/v1/categories*"
 
 const initialCategoryRows: CategoryRow[] = [
   {
     id: 10,
+    book_id: 1,
     name: "Food",
     created_at: "2025-01-01T00:00:00.000Z",
     updated_at: "2025-01-01T00:00:00.000Z",
   },
   {
     id: 20,
+    book_id: 1,
     name: "Daily Necessities",
     created_at: "2025-01-01T00:00:00.000Z",
     updated_at: "2025-01-01T00:00:00.000Z",
   },
   {
     id: 30,
+    book_id: 1,
     name: "Entertainment",
+    created_at: "2025-01-01T00:00:00.000Z",
+    updated_at: "2025-01-01T00:00:00.000Z",
+  },
+  {
+    id: otherBookFoodCat.id,
+    book_id: otherBookFoodCat.bookId,
+    name: otherBookFoodCat.name,
     created_at: "2025-01-01T00:00:00.000Z",
     updated_at: "2025-01-01T00:00:00.000Z",
   },
@@ -27,11 +40,13 @@ const initialCategoryRows: CategoryRow[] = [
 
 interface GetCategoriesHandlerOptions {
   response?: CategoryRow[]
+  currentBookId?: number
   error?: boolean
 }
 
 export function getCategoriesHandler({
   response = initialCategoryRows,
+  currentBookId = CURRENT_BOOK_ID,
   error = false,
 }: GetCategoriesHandlerOptions = {}) {
   return http.get(REST_URL, () => {
@@ -39,7 +54,7 @@ export function getCategoriesHandler({
       return HttpResponse.json({ message: "Failed to fetch categories." }, { status: 500 })
     }
 
-    return HttpResponse.json(response)
+    return HttpResponse.json(response.filter((row) => row.book_id === currentBookId))
   })
 }
 

--- a/apps/web/src/test/msw/handlers/categoryBudgets.ts
+++ b/apps/web/src/test/msw/handlers/categoryBudgets.ts
@@ -2,10 +2,11 @@ import { type DelayMode, HttpResponse, delay, http } from "msw"
 import * as z from "zod"
 
 import type { CategoryBudgetRow } from "../../../features/budgets/types"
-import { categories } from "../../data/categories"
+import { allCategories } from "../../data/categories"
 import { categoryBudgets } from "../../data/categoryBudgets"
 
 const REST_URL = "*/rest/v1/category_budgets*"
+const CURRENT_BOOK_ID = 1
 
 interface CategoryBudgetResponseRow extends CategoryBudgetRow {
   category: {
@@ -20,6 +21,7 @@ interface BaseOptions {
 }
 
 interface GetCategoryBudgetsOptions extends BaseOptions {
+  rows?: CategoryBudgetRow[]
   response?: CategoryBudgetResponseRow[]
 }
 
@@ -29,6 +31,7 @@ interface CreateCategoryBudgetOptions extends BaseOptions {
 }
 
 interface CreateCategoryBudgetHandlersOptions {
+  currentBookId?: number
   get?: GetCategoryBudgetsOptions
   create?: CreateCategoryBudgetOptions
 }
@@ -41,8 +44,20 @@ const createCategoryBudgetBodySchema = z.object({
 
 type CreateCategoryBudgetBody = z.infer<typeof createCategoryBudgetBodySchema>
 
-const defaultCategoryBudgetRows: CategoryBudgetResponseRow[] = categoryBudgets.map((row) => {
-  const category = categories.find((candidate) => candidate.id === row.category_id)
+function toCategoryBudgetResponseRows(
+  rows: CategoryBudgetRow[],
+  currentBookId: number,
+): CategoryBudgetResponseRow[] {
+  return rows.map((row) => toCategoryBudgetResponseRow(row, currentBookId))
+}
+
+function toCategoryBudgetResponseRow(
+  row: CategoryBudgetRow,
+  currentBookId: number,
+): CategoryBudgetResponseRow {
+  const category = allCategories.find(
+    (candidate) => candidate.id === row.category_id && candidate.bookId === currentBookId,
+  )
 
   return {
     ...row,
@@ -51,12 +66,16 @@ const defaultCategoryBudgetRows: CategoryBudgetResponseRow[] = categoryBudgets.m
       name: category?.name ?? "Unknown",
     },
   }
-})
+}
 
 export function createCategoryBudgetHandlers({
+  currentBookId = CURRENT_BOOK_ID,
   get = {},
   create = {},
 }: CreateCategoryBudgetHandlersOptions = {}) {
+  const getRows =
+    get.response ?? toCategoryBudgetResponseRows(get.rows ?? categoryBudgets, currentBookId)
+
   const categoryBudgetsHandler = http.get(REST_URL, async () => {
     await delay(get.durationOrMode)
 
@@ -64,7 +83,7 @@ export function createCategoryBudgetHandlers({
       return HttpResponse.json({ message: "Failed to fetch category budgets." }, { status: 500 })
     }
 
-    return HttpResponse.json(get.response ?? defaultCategoryBudgetRows)
+    return HttpResponse.json(getRows)
   })
 
   const createCategoryBudgetHandler = http.post(REST_URL, async ({ request }) => {
@@ -83,7 +102,7 @@ export function createCategoryBudgetHandlers({
 
     const body = await request.json()
     const parsedBody = createCategoryBudgetBodySchema.parse(body)
-    const newRow = buildCategoryBudgetRow(parsedBody, get.response ?? defaultCategoryBudgetRows)
+    const newRow = buildCategoryBudgetRow(parsedBody, getRows, currentBookId)
 
     return HttpResponse.json([newRow], { status: 201 })
   })
@@ -94,10 +113,13 @@ export function createCategoryBudgetHandlers({
 function buildCategoryBudgetRow(
   body: CreateCategoryBudgetBody,
   rows: CategoryBudgetResponseRow[],
+  currentBookId: number,
 ): CategoryBudgetResponseRow {
   const [year, month] = body.effective_from.split("-").map((value) => Number.parseInt(value, 10))
   const now = new Date().toISOString()
-  const category = categories.find((candidate) => candidate.id === body.category_id)
+  const category = allCategories.find(
+    (candidate) => candidate.id === body.category_id && candidate.bookId === currentBookId,
+  )
 
   return {
     id: Math.max(0, ...rows.map((row) => row.id)) + 1,

--- a/apps/web/src/test/msw/handlers/payments.ts
+++ b/apps/web/src/test/msw/handlers/payments.ts
@@ -3,7 +3,7 @@ import z from "zod"
 
 import type { CategoryRow } from "../../../types/category"
 import type { PaymentRow } from "../../../types/payment"
-import { categories } from "../../data/categories"
+import { allCategories } from "../../data/categories"
 import { payments } from "../../data/payments"
 import { mapPaymentToRow } from "../../utils/mapPaymentToRow"
 
@@ -12,8 +12,9 @@ const MONTHLY_TOTAL_AMOUNT_REST_URL = "*/rest/v1/rpc/get_monthly_total_amount"
 const CURRENT_BOOK_ID = 1
 
 const initialPaymentRows: PaymentRow[] = payments.map(mapPaymentToRow)
-const initialCategoryRows: CategoryRow[] = categories.map((category) => ({
+const initialCategoryRows: CategoryRow[] = allCategories.map((category) => ({
   id: category.id,
+  book_id: category.bookId,
   name: category.name,
   created_at: category.createdDate.toISOString(),
   updated_at: category.updatedDate.toISOString(),
@@ -110,7 +111,9 @@ function shouldReturnSingleObject(request: Request): boolean {
 }
 
 function toPaymentDetailsRow(row: PaymentRow, categoryRows: CategoryRow[]): PaymentDetailsRow {
-  const category = categoryRows.find((candidate) => candidate.id === row.category_id)
+  const category = categoryRows.find(
+    (candidate) => candidate.id === row.category_id && candidate.book_id === row.book_id,
+  )
 
   return {
     id: row.id,

--- a/apps/web/src/types/category.ts
+++ b/apps/web/src/types/category.ts
@@ -4,6 +4,7 @@ export type CategoryRow = Tables<"categories">
 
 export interface Category {
   id: number
+  bookId: number
   name: string
   createdDate: Date
   updatedDate: Date

--- a/apps/web/src/types/database.types.ts
+++ b/apps/web/src/types/database.types.ts
@@ -93,24 +93,35 @@ export type Database = {
       }
       categories: {
         Row: {
+          book_id: number
           created_at: string | null
           id: number
           name: string
           updated_at: string | null
         }
         Insert: {
+          book_id: number
           created_at?: string | null
           id?: never
           name: string
           updated_at?: string | null
         }
         Update: {
+          book_id?: number
           created_at?: string | null
           id?: never
           name?: string
           updated_at?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "categories_book_id_fkey"
+            columns: ["book_id"]
+            isOneToOne: false
+            referencedRelation: "books"
+            referencedColumns: ["id"]
+          },
+        ]
       }
       category_budgets: {
         Row: {


### PR DESCRIPTION
## 関連Issue

- closes #1213

## 変更内容

- categories を book 所有へ移行する migration を追加し、既存カテゴリ参照を book 内カテゴリへ backfill
- categories の RLS と category 参照の guard を book member 前提へ更新
- Web の Category 型、カテゴリ取得、MSW fixture/test を book 所有前提へ同期

## 動作確認

- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] pnpm --filter web test:unit
- [x] pnpm --filter web test:integration
- [x] pnpm --filter web test:storybook

## 補足

API は専用 verification command が未定義のため、migration SQL はレビューで確認しています。