### PR TITLE
予算系データをBook所有へ移行

### DIFF
--- a/apps/api/supabase/migrations/20260507140000_migrate_budgets_to_book_ownership.sql
+++ b/apps/api/supabase/migrations/20260507140000_migrate_budgets_to_book_ownership.sql
@@ -1,0 +1,251 @@
+alter table monthly_budgets
+  add column book_id bigint references books(id) on delete cascade;
+
+alter table category_budgets
+  add column book_id bigint references books(id) on delete cascade;
+
+update monthly_budgets
+set book_id = book_members.book_id
+from book_members
+where book_members.user_id = monthly_budgets.user_id
+  and book_members.is_default;
+
+update category_budgets
+set book_id = book_members.book_id
+from book_members
+where book_members.user_id = category_budgets.user_id
+  and book_members.is_default;
+
+do $$
+begin
+  if exists (select 1 from monthly_budgets where book_id is null) then
+    raise exception 'Default book is missing for existing monthly budgets.';
+  end if;
+
+  if exists (select 1 from category_budgets where book_id is null) then
+    raise exception 'Default book is missing for existing category budgets.';
+  end if;
+
+  if exists (
+    select 1
+    from category_budgets
+    join categories on categories.id = category_budgets.category_id
+    where categories.book_id <> category_budgets.book_id
+  ) then
+    raise exception 'Category budget category must belong to the same book.';
+  end if;
+end $$;
+
+alter table monthly_budgets
+  alter column book_id set not null,
+  alter column book_id set default get_authenticated_default_book_id();
+
+alter table category_budgets
+  alter column book_id set not null,
+  alter column book_id set default get_authenticated_default_book_id();
+
+alter table monthly_budgets
+  drop constraint monthly_budgets_user_effective_year_month_key,
+  add constraint monthly_budgets_book_effective_year_month_key
+    unique (book_id, effective_year, effective_month);
+
+alter table category_budgets
+  drop constraint category_budgets_user_category_effective_year_month_key,
+  add constraint category_budgets_book_category_effective_year_month_key
+    unique (book_id, category_id, effective_year, effective_month);
+
+drop index if exists idx_monthly_budgets_user_effective_from;
+drop index if exists idx_category_budgets_user_category_effective_from;
+
+create index idx_monthly_budgets_book_effective_from
+    on monthly_budgets (book_id, effective_from desc);
+
+create index idx_category_budgets_book_category_effective_from
+    on category_budgets (book_id, category_id, effective_from desc);
+
+drop trigger if exists trg_set_monthly_budget_user_id on monthly_budgets;
+drop function if exists set_monthly_budget_user_id();
+
+create or replace function set_monthly_budget_ownership()
+returns trigger as $$
+begin
+  new.user_id := get_authenticated_user_id();
+
+  if new.book_id is null then
+    new.book_id := get_authenticated_default_book_id();
+  end if;
+
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_set_monthly_budget_ownership
+  before insert on monthly_budgets
+  for each row
+  execute function set_monthly_budget_ownership();
+
+create or replace function keep_monthly_budget_book_id()
+returns trigger as $$
+begin
+  new.book_id := old.book_id;
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_keep_monthly_budget_book_id
+  before update on monthly_budgets
+  for each row
+  execute function keep_monthly_budget_book_id();
+
+drop trigger if exists trg_set_category_budget_user_id on category_budgets;
+drop function if exists set_category_budget_user_id();
+
+create or replace function set_category_budget_ownership()
+returns trigger as $$
+begin
+  new.user_id := get_authenticated_user_id();
+
+  if new.book_id is null then
+    new.book_id := get_authenticated_default_book_id();
+  end if;
+
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_set_category_budget_ownership
+  before insert on category_budgets
+  for each row
+  execute function set_category_budget_ownership();
+
+create or replace function keep_category_budget_book_id()
+returns trigger as $$
+begin
+  new.book_id := old.book_id;
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_keep_category_budget_book_id
+  before update on category_budgets
+  for each row
+  execute function keep_category_budget_book_id();
+
+drop trigger if exists trg_validate_category_budget_category_membership on category_budgets;
+drop function if exists ensure_category_budget_category_membership();
+
+create or replace function ensure_category_budget_category_book()
+returns trigger as $$
+begin
+  if not exists (
+    select 1
+    from categories
+    where categories.id = new.category_id
+      and categories.book_id = new.book_id
+  ) then
+    raise exception 'Category budget category must belong to the same book.';
+  end if;
+
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_validate_category_budget_category_book
+  before insert or update of book_id, category_id on category_budgets
+  for each row
+  execute function ensure_category_budget_category_book();
+
+drop policy "Users can read own monthly budgets" on monthly_budgets;
+drop policy "Users can insert own monthly budgets" on monthly_budgets;
+drop policy "Users can update own monthly budgets" on monthly_budgets;
+
+create policy "Users can read member book monthly budgets"
+  on monthly_budgets for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = monthly_budgets.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );
+
+create policy "Users can insert member book monthly budgets"
+  on monthly_budgets for insert
+  to authenticated
+  with check (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = monthly_budgets.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );
+
+create policy "Users can update member book monthly budgets"
+  on monthly_budgets for update
+  to authenticated
+  using (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = monthly_budgets.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = monthly_budgets.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );
+
+drop policy "Users can read own category budgets" on category_budgets;
+drop policy "Users can insert member book category budgets" on category_budgets;
+
+create policy "Users can read member book category budgets"
+  on category_budgets for select
+  to authenticated
+  using (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = category_budgets.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );
+
+create policy "Users can insert member book category budgets"
+  on category_budgets for insert
+  to authenticated
+  with check (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = category_budgets.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );
+
+create policy "Users can update member book category budgets"
+  on category_budgets for update
+  to authenticated
+  using (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = category_budgets.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = category_budgets.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );

--- a/apps/web/src/features/budgets/categoryBudgetMappers.ts
+++ b/apps/web/src/features/budgets/categoryBudgetMappers.ts
@@ -5,6 +5,7 @@ import { parseIsoDateOnlyToLocalDate } from "./utils/month"
 
 const categoryBudgetRowSchema = z.object({
   id: z.number(),
+  book_id: z.number(),
   category_id: z.number(),
   amount: z.number(),
   effective_from: z.string(),
@@ -34,6 +35,7 @@ export function normalizeCategoryBudgetRows(value: unknown): NormalizedCategoryB
 export function toCategoryBudget(row: NormalizedCategoryBudgetRow): CategoryBudget {
   return {
     id: row.id,
+    bookId: row.book_id,
     categoryId: row.category_id,
     categoryName: row.category.name,
     amount: row.amount,

--- a/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormMappers.test.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormMappers.test.ts
@@ -16,6 +16,7 @@ describe("toCategoryBudgetInsert", () => {
       effective_from: "2026-03-01",
     })
     expect(row).not.toHaveProperty("book_id")
+    expect(row).not.toHaveProperty("user_id")
   })
 
   test("選択日の年月を使い、日付は月初日に丸める", () => {

--- a/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormMappers.ts
+++ b/apps/web/src/features/budgets/createCategoryBudget/categoryBudgetFormMappers.ts
@@ -9,10 +9,10 @@ export interface CategoryBudgetWriteInput {
   amount: number
 }
 
-// user_id は DB のデフォルト値（auth.uid()）で自動設定されるため FE から渡さない
+// book_id と user_id は DB のデフォルト値で自動設定されるため FE から渡さない
 export type CategoryBudgetInsert = Omit<
   TablesInsert<"category_budgets">,
-  "user_id" | "effective_year" | "effective_month"
+  "book_id" | "user_id" | "effective_year" | "effective_month"
 >
 
 export function toCategoryBudgetInsert(value: CategoryBudgetWriteInput): CategoryBudgetInsert {

--- a/apps/web/src/features/budgets/createMonthlyBudget/monthlyBudgetFormMappers.test.ts
+++ b/apps/web/src/features/budgets/createMonthlyBudget/monthlyBudgetFormMappers.test.ts
@@ -13,6 +13,18 @@ describe("toMonthlyBudgetInsert", () => {
       amount: 300000,
       effective_from: "2026-03-01",
     })
+    expect(
+      toMonthlyBudgetInsert({
+        targetMonth: new Date(2026, 2, 20),
+        amount: 300000,
+      }),
+    ).not.toHaveProperty("book_id")
+    expect(
+      toMonthlyBudgetInsert({
+        targetMonth: new Date(2026, 2, 20),
+        amount: 300000,
+      }),
+    ).not.toHaveProperty("user_id")
   })
 
   test("選択日の年月を使い、日付は月初日に丸める", () => {

--- a/apps/web/src/features/budgets/createMonthlyBudget/monthlyBudgetFormMappers.ts
+++ b/apps/web/src/features/budgets/createMonthlyBudget/monthlyBudgetFormMappers.ts
@@ -8,10 +8,10 @@ export interface MonthlyBudgetWriteInput {
   amount: number
 }
 
-// user_id は DB のデフォルト値（auth.uid()）で自動設定されるため FE から渡さない
+// book_id と user_id は DB のデフォルト値で自動設定されるため FE から渡さない
 export type MonthlyBudgetInsert = Omit<
   TablesInsert<"monthly_budgets">,
-  "user_id" | "effective_year" | "effective_month"
+  "book_id" | "user_id" | "effective_year" | "effective_month"
 >
 
 export function toMonthlyBudgetInsert(value: MonthlyBudgetWriteInput): MonthlyBudgetInsert {

--- a/apps/web/src/features/budgets/getMonthlyBudget/fetchEffectiveMonthlyBudget.integration.test.ts
+++ b/apps/web/src/features/budgets/getMonthlyBudget/fetchEffectiveMonthlyBudget.integration.test.ts
@@ -21,6 +21,7 @@ describe("fetchEffectiveMonthlyBudget", () => {
 
     expect(budget).not.toBeNull()
     expect(budget?.id).toBe(2)
+    expect(budget?.bookId).toBe(1)
     expect(budget?.amount).toBe(62000)
     expect(budget?.effectiveFrom).toEqual(new Date(2025, 2, 30))
     expect(budget?.effectiveYear).toBe(2025)
@@ -48,6 +49,7 @@ describe("fetchEffectiveMonthlyBudget", () => {
       http.get("*/rest/v1/monthly_budgets*", () => {
         return HttpResponse.json({
           id: "invalid",
+          book_id: 1,
           amount: 62000,
           effective_from: "2025-03-30",
           effective_year: 2025,

--- a/apps/web/src/features/budgets/getMonthlyBudget/fetchEffectiveMonthlyBudget.ts
+++ b/apps/web/src/features/budgets/getMonthlyBudget/fetchEffectiveMonthlyBudget.ts
@@ -8,7 +8,7 @@ export async function fetchEffectiveMonthlyBudget(targetDate: Date): Promise<Mon
   const { data, error } = await supabase
     .from("monthly_budgets")
     .select(
-      "id, amount, effective_from, effective_year, effective_month, user_id, created_at, updated_at",
+      "id, book_id, amount, effective_from, effective_year, effective_month, user_id, created_at, updated_at",
     )
     .lte("effective_from", toMonthEndIsoDate(targetDate))
     .order("effective_from", { ascending: false })

--- a/apps/web/src/features/budgets/latestMonthlyBudget/LatestMonthlyBudget/LatestMonthlyBudget.test.tsx
+++ b/apps/web/src/features/budgets/latestMonthlyBudget/LatestMonthlyBudget/LatestMonthlyBudget.test.tsx
@@ -13,6 +13,7 @@ import * as stories from "./LatestMonthlyBudget.stories"
 const { Default, Empty, FetchError, Loading } = composeStories(stories)
 const createdMonthlyBudget = {
   id: 999,
+  book_id: 1,
   amount: 300000,
   created_at: "2026-03-01T00:00:00.000Z",
   effective_from: "2026-03-01",

--- a/apps/web/src/features/budgets/listCategoryBudget/fetchCategoryBudgets.integration.test.ts
+++ b/apps/web/src/features/budgets/listCategoryBudget/fetchCategoryBudgets.integration.test.ts
@@ -12,6 +12,7 @@ vi.mock("../../../lib/supabase", () => ({
 
 const foodBudgetOld = {
   id: 1,
+  book_id: 1,
   amount: 30000,
   category_id: 10,
   created_at: "2025-01-01T00:00:00.000Z",
@@ -28,6 +29,7 @@ const foodBudgetOld = {
 
 const foodBudgetLatestSameDay = {
   id: 3,
+  book_id: 1,
   amount: 50000,
   category_id: 10,
   created_at: "2025-03-02T00:00:00.000Z",
@@ -44,6 +46,7 @@ const foodBudgetLatestSameDay = {
 
 const foodBudgetOlderSameDay = {
   id: 2,
+  book_id: 1,
   amount: 45000,
   category_id: 10,
   created_at: "2025-03-01T00:00:00.000Z",
@@ -60,6 +63,7 @@ const foodBudgetOlderSameDay = {
 
 const dailyNecessitiesFutureBudget = {
   id: 4,
+  book_id: 1,
   amount: 12000,
   category_id: 20,
   created_at: "2099-04-01T00:00:00.000Z",
@@ -93,6 +97,7 @@ describe("fetchCategoryBudgets", () => {
     expect(budgets).toHaveLength(2)
     expect(budgets[0]).toMatchObject({
       id: 3,
+      bookId: 1,
       amount: 50000,
       categoryId: 10,
       categoryName: "Food",
@@ -165,6 +170,7 @@ describe("fetchCategoryBudgets", () => {
           rows: [
             {
               id: 5,
+              book_id: 2,
               amount: 8000,
               category_id: 40,
               created_at: "2025-05-01T00:00:00.000Z",
@@ -204,6 +210,7 @@ describe("fetchCategoryBudgets", () => {
 
     const select = requestCapture.url?.searchParams.get("select")
     expect(select).toContain("id")
+    expect(select).toContain("book_id")
     expect(select).toContain("category_id")
     expect(select).toContain("amount")
     expect(select).toContain("effective_from")
@@ -237,6 +244,7 @@ describe("fetchCategoryBudgets", () => {
         return HttpResponse.json([
           {
             id: "invalid",
+            book_id: 1,
             amount: 50000,
             category_id: 10,
             effective_from: "2025-03-01",

--- a/apps/web/src/features/budgets/listCategoryBudget/fetchCategoryBudgets.ts
+++ b/apps/web/src/features/budgets/listCategoryBudget/fetchCategoryBudgets.ts
@@ -8,6 +8,7 @@ import type { CategoryBudget } from "../types"
 
 const categoryBudgetColumns = `
   id,
+  book_id,
   category_id,
   amount,
   effective_from,

--- a/apps/web/src/features/budgets/listCategoryBudget/useCategoryBudgets.test.tsx
+++ b/apps/web/src/features/budgets/listCategoryBudget/useCategoryBudgets.test.tsx
@@ -15,6 +15,7 @@ vi.mock("./fetchCategoryBudgets", () => ({
 function buildCategoryBudget(id: number): CategoryBudget {
   return {
     id,
+    bookId: 1,
     amount: 50000 + id,
     categoryId: 10 + id,
     categoryName: `Category ${id}`,

--- a/apps/web/src/features/budgets/listMonthlyBudget/fetchMonthlyBudgets.integration.test.ts
+++ b/apps/web/src/features/budgets/listMonthlyBudget/fetchMonthlyBudgets.integration.test.ts
@@ -31,6 +31,7 @@ describe("fetchMonthlyBudgets", () => {
     expect(budgets[0]).toMatchObject({
       id: 3,
       amount: 75000,
+      bookId: 1,
       effectiveYear: 2025,
       effectiveMonth: 7,
       userId: 100,
@@ -67,6 +68,7 @@ describe("fetchMonthlyBudgets", () => {
 
     const select = requestCapture.url?.searchParams.get("select")
     expect(select).toContain("id")
+    expect(select).toContain("book_id")
     expect(select).toContain("amount")
     expect(select).toContain("effective_from")
     expect(select).toContain("effective_year")
@@ -84,6 +86,7 @@ describe("fetchMonthlyBudgets", () => {
         return HttpResponse.json([
           {
             id: "invalid",
+            book_id: 1,
             amount: 62000,
             effective_from: "2025-03-30",
             effective_year: 2025,

--- a/apps/web/src/features/budgets/listMonthlyBudget/fetchMonthlyBudgets.ts
+++ b/apps/web/src/features/budgets/listMonthlyBudget/fetchMonthlyBudgets.ts
@@ -5,7 +5,7 @@ import { normalizeMonthlyBudgetRows, toMonthlyBudget } from "../monthlyBudgetMap
 import type { MonthlyBudget } from "../types"
 
 const monthlyBudgetColumns =
-  "id, amount, effective_from, effective_year, effective_month, user_id, created_at, updated_at"
+  "id, book_id, amount, effective_from, effective_year, effective_month, user_id, created_at, updated_at"
 const monthlyBudgetLimitSchema = z.number().int().positive()
 
 export async function fetchMonthlyBudgets(limit: number): Promise<MonthlyBudget[]> {

--- a/apps/web/src/features/budgets/listMonthlyBudget/useMonthlyBudgets.test.tsx
+++ b/apps/web/src/features/budgets/listMonthlyBudget/useMonthlyBudgets.test.tsx
@@ -15,6 +15,7 @@ vi.mock("./fetchMonthlyBudgets", () => ({
 function buildMonthlyBudget(id: number): MonthlyBudget {
   return {
     id,
+    bookId: 1,
     amount: 50000 + id,
     effectiveFrom: new Date(2025, id, 1),
     effectiveYear: 2025,

--- a/apps/web/src/features/budgets/monthlyBudgetMappers.ts
+++ b/apps/web/src/features/budgets/monthlyBudgetMappers.ts
@@ -5,6 +5,7 @@ import { parseIsoDateOnlyToLocalDate } from "./utils/month"
 
 const monthlyBudgetRowSchema = z.object({
   id: z.number(),
+  book_id: z.number(),
   amount: z.number(),
   effective_from: z.string(),
   effective_year: z.number(),
@@ -39,6 +40,7 @@ export function normalizeMonthlyBudgetRows(value: unknown): NormalizedMonthlyBud
 export function toMonthlyBudget(row: NormalizedMonthlyBudgetRow): MonthlyBudget {
   return {
     id: row.id,
+    bookId: row.book_id,
     amount: row.amount,
     effectiveFrom: parseIsoDateOnlyToLocalDate(row.effective_from),
     effectiveYear: row.effective_year,

--- a/apps/web/src/features/budgets/types/index.ts
+++ b/apps/web/src/features/budgets/types/index.ts
@@ -5,6 +5,7 @@ export type CategoryBudgetRow = Tables<"category_budgets">
 
 export interface MonthlyBudget {
   id: number
+  bookId: number
   amount: number
   effectiveFrom: Date
   effectiveYear: number
@@ -16,6 +17,7 @@ export interface MonthlyBudget {
 
 export interface CategoryBudget {
   id: number
+  bookId: number
   categoryId: number
   categoryName: string
   amount: number

--- a/apps/web/src/test/data/categoryBudgets.ts
+++ b/apps/web/src/test/data/categoryBudgets.ts
@@ -3,6 +3,7 @@ import type { CategoryBudgetRow } from "../../features/budgets/types"
 export const categoryBudgets: CategoryBudgetRow[] = [
   {
     id: 1,
+    book_id: 1,
     amount: 30000,
     category_id: 10,
     created_at: "2025-01-01T00:00:00.000Z",
@@ -14,6 +15,7 @@ export const categoryBudgets: CategoryBudgetRow[] = [
   },
   {
     id: 2,
+    book_id: 1,
     amount: 45000,
     category_id: 10,
     created_at: "2025-03-01T00:00:00.000Z",
@@ -25,6 +27,7 @@ export const categoryBudgets: CategoryBudgetRow[] = [
   },
   {
     id: 3,
+    book_id: 1,
     amount: 50000,
     category_id: 10,
     created_at: "2025-03-02T00:00:00.000Z",
@@ -36,6 +39,7 @@ export const categoryBudgets: CategoryBudgetRow[] = [
   },
   {
     id: 4,
+    book_id: 1,
     amount: 12000,
     category_id: 20,
     created_at: "2026-04-01T00:00:00.000Z",

--- a/apps/web/src/test/data/monthlyBudgets.ts
+++ b/apps/web/src/test/data/monthlyBudgets.ts
@@ -3,6 +3,7 @@ import type { MonthlyBudgetRow } from "../../features/budgets/types"
 export const monthlyBudgets: MonthlyBudgetRow[] = [
   {
     id: 4,
+    book_id: 1,
     amount: 42000,
     created_at: "2024-12-01T00:00:00.000Z",
     effective_from: "2024-12-01",
@@ -13,6 +14,7 @@ export const monthlyBudgets: MonthlyBudgetRow[] = [
   },
   {
     id: 1,
+    book_id: 1,
     amount: 50000,
     created_at: "2025-01-01T00:00:00.000Z",
     effective_from: "2025-01-01",
@@ -23,6 +25,7 @@ export const monthlyBudgets: MonthlyBudgetRow[] = [
   },
   {
     id: 2,
+    book_id: 1,
     amount: 62000,
     created_at: "2025-03-30T00:00:00.000Z",
     effective_from: "2025-03-30",
@@ -33,6 +36,7 @@ export const monthlyBudgets: MonthlyBudgetRow[] = [
   },
   {
     id: 3,
+    book_id: 1,
     amount: 75000,
     created_at: "2025-07-01T00:00:00.000Z",
     effective_from: "2025-07-01",

--- a/apps/web/src/test/msw/handlers/categoryBudgets.ts
+++ b/apps/web/src/test/msw/handlers/categoryBudgets.ts
@@ -123,6 +123,7 @@ function buildCategoryBudgetRow(
 
   return {
     id: Math.max(0, ...rows.map((row) => row.id)) + 1,
+    book_id: currentBookId,
     amount: body.amount,
     category_id: body.category_id,
     created_at: now,

--- a/apps/web/src/test/msw/handlers/monthlyBudgets.ts
+++ b/apps/web/src/test/msw/handlers/monthlyBudgets.ts
@@ -135,6 +135,7 @@ function buildMonthlyBudgetRow(
 
   return {
     id: Math.max(0, ...rows.map((row) => row.id)) + 1,
+    book_id: 1,
     amount: body.amount,
     created_at: now,
     effective_from: body.effective_from,

--- a/apps/web/src/types/database.types.ts
+++ b/apps/web/src/types/database.types.ts
@@ -126,6 +126,7 @@ export type Database = {
       category_budgets: {
         Row: {
           amount: number
+          book_id: number
           category_id: number
           created_at: string | null
           effective_from: string
@@ -137,6 +138,7 @@ export type Database = {
         }
         Insert: {
           amount: number
+          book_id?: number
           category_id: number
           created_at?: string | null
           effective_from: string
@@ -148,6 +150,7 @@ export type Database = {
         }
         Update: {
           amount?: number
+          book_id?: number
           category_id?: number
           created_at?: string | null
           effective_from?: string
@@ -158,6 +161,13 @@ export type Database = {
           user_id?: number
         }
         Relationships: [
+          {
+            foreignKeyName: "category_budgets_book_id_fkey"
+            columns: ["book_id"]
+            isOneToOne: false
+            referencedRelation: "books"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "category_budgets_category_id_fkey"
             columns: ["category_id"]
@@ -216,6 +226,7 @@ export type Database = {
       monthly_budgets: {
         Row: {
           amount: number
+          book_id: number
           created_at: string | null
           effective_from: string
           effective_month: number
@@ -226,6 +237,7 @@ export type Database = {
         }
         Insert: {
           amount: number
+          book_id?: number
           created_at?: string | null
           effective_from: string
           effective_month?: number
@@ -236,6 +248,7 @@ export type Database = {
         }
         Update: {
           amount?: number
+          book_id?: number
           created_at?: string | null
           effective_from?: string
           effective_month?: number
@@ -245,6 +258,13 @@ export type Database = {
           user_id?: number
         }
         Relationships: [
+          {
+            foreignKeyName: "monthly_budgets_book_id_fkey"
+            columns: ["book_id"]
+            isOneToOne: false
+            referencedRelation: "books"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "monthly_budgets_user_id_fkey"
             columns: ["user_id"]


### PR DESCRIPTION
## 関連Issue

- closes #1214

## 変更内容

- 月予算とカテゴリ別予算に book_id を追加し、既存データを default book に backfill する migration を追加
- 予算系テーブルの一意制約、index、RLS、trigger を Book 所有前提へ更新
- Web 側の型、取得 query、mapper、MSW fixture、テストデータを book_id ありの形に同期

## 動作確認

- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] pnpm --filter web test:unit
- [x] pnpm --filter web test:integration
- [x] pnpm --filter web test:storybook
- [x] git diff --check

## 補足

- apps/api は専用 verification command が未定義のため、Supabase migration 適用コマンドは未実行です。
