### PR TITLE
設定画面向けカテゴリ一覧を追加

### DIFF
--- a/apps/web/src/app/routes/SettingsPage/SettingsPage.stories.tsx
+++ b/apps/web/src/app/routes/SettingsPage/SettingsPage.stories.tsx
@@ -5,6 +5,7 @@ import { expect, within } from "storybook/test"
 import { BookSettings } from "../../../features/books/bookSettings/BookSettings"
 import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
 import { createStoryRouter } from "../../../test/helpers/routerDecorator"
+import { createCategorySettingsHandlers } from "../../../test/msw/handlers/categorySettings"
 import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
 import { SettingsPage } from "./SettingsPage"
 
@@ -52,6 +53,7 @@ export const BookManagement: Story = {
         ...createMonthlyBudgetHandlers({
           list: { response: [monthlyBudgets[3]] },
         }),
+        ...createCategorySettingsHandlers(),
       ],
     },
   },
@@ -60,7 +62,10 @@ export const BookManagement: Story = {
 
     expect(await canvas.findByText("Monthly Budgets")).toBeInTheDocument()
     expect(await canvas.findByText("Categories")).toBeInTheDocument()
-    expect(await canvas.findByText("Monthly budget")).toBeInTheDocument()
-    expect(await canvas.findByText("Pin")).toBeInTheDocument()
+    expect(await canvas.findByText("Food")).toBeInTheDocument()
+    expect(await canvas.findByText("￥50,000")).toBeInTheDocument()
+    expect(await canvas.findByText("Name")).toBeInTheDocument()
+    expect(await canvas.findAllByText("Monthly budget")).not.toHaveLength(0)
+    expect(await canvas.findAllByText("Pin")).not.toHaveLength(0)
   },
 }

--- a/apps/web/src/app/routes/SettingsPage/SettingsPage.test.tsx
+++ b/apps/web/src/app/routes/SettingsPage/SettingsPage.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, test, vi } from "vite-plus/test"
 import { BookSettings } from "../../../features/books/bookSettings/BookSettings"
 import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
 import { renderWithRouter } from "../../../test/helpers/renderWithRouter"
+import { createCategorySettingsHandlers } from "../../../test/msw/handlers/categorySettings"
 import { createMonthlyBudgetHandlers } from "../../../test/msw/handlers/monthlyBudgets"
 import { server } from "../../../test/msw/server"
 import { screen, within } from "../../../test/test-utils"
@@ -82,6 +83,7 @@ describe("SettingsPage", () => {
       ...createMonthlyBudgetHandlers({
         list: { response: [monthlyBudgets[3], monthlyBudgets[2]] },
       }),
+      ...createCategorySettingsHandlers(),
     )
 
     renderSettingsPage("/settings/book")
@@ -90,8 +92,12 @@ describe("SettingsPage", () => {
     expect(await screen.findByText("￥75,000")).toBeInTheDocument()
     expect(screen.queryByText("￥62,000")).not.toBeInTheDocument()
     expect(await screen.findByText("Categories")).toBeInTheDocument()
-    expect(await screen.findByText("Monthly budget")).toBeInTheDocument()
-    expect(await screen.findByText("Pin")).toBeInTheDocument()
+    expect(await screen.findByText("Food")).toBeInTheDocument()
+    expect(await screen.findByText("￥50,000")).toBeInTheDocument()
+    expect(await screen.findByText("Name")).toBeInTheDocument()
+    expect(await screen.findAllByText("Monthly budget")).not.toHaveLength(0)
+    expect(await screen.findAllByText("Pin")).not.toHaveLength(0)
+    expect(screen.queryByText("Not pinned")).not.toBeInTheDocument()
     expect(screen.queryByText("Category Budgets")).not.toBeInTheDocument()
   })
 
@@ -100,6 +106,7 @@ describe("SettingsPage", () => {
       ...createMonthlyBudgetHandlers({
         list: { response: [] },
       }),
+      ...createCategorySettingsHandlers(),
     )
 
     renderSettingsPage("/settings/book")
@@ -121,6 +128,7 @@ describe("SettingsPage", () => {
           },
         },
       }),
+      ...createCategorySettingsHandlers(),
     )
 
     const { user, baseElement } = renderSettingsPage("/settings/book")

--- a/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.stories.tsx
+++ b/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.stories.tsx
@@ -1,11 +1,17 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
+import { createCategorySettingsHandlers } from "../../../../test/msw/handlers/categorySettings"
 import { CategorySettingsList } from "./CategorySettingsList"
 
 const meta = {
   title: "Features/Categories/Components/CategorySettingsList",
   component: CategorySettingsList,
   tags: ["autodocs"],
+  parameters: {
+    msw: {
+      handlers: createCategorySettingsHandlers(),
+    },
+  },
 } satisfies Meta<typeof CategorySettingsList>
 
 export default meta

--- a/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.test.tsx
+++ b/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.test.tsx
@@ -1,18 +1,71 @@
 import { composeStories } from "@storybook/react-vite"
-import { describe, expect, test } from "vite-plus/test"
+import type { ReactElement } from "react"
+import { beforeEach, describe, expect, test } from "vite-plus/test"
 
-import { render, screen } from "../../../../test/test-utils"
+import { createCategorySettingsHandlers } from "../../../../test/msw/handlers/categorySettings"
+import { server } from "../../../../test/msw/server"
+import { act, render, screen, within } from "../../../../test/test-utils"
 import * as stories from "./CategorySettingsList.stories"
 
 const { Default } = composeStories(stories)
 
-describe("CategorySettingsList", () => {
-  test("カテゴリ設定の列構造を表示する", () => {
-    render(<Default />)
+async function renderCategorySettingsList(story: ReactElement) {
+  return await act(async () => {
+    return render(story)
+  })
+}
 
-    expect(screen.getByText("Categories")).toBeInTheDocument()
+describe("CategorySettingsList", () => {
+  beforeEach(() => {
+    server.resetHandlers(...createCategorySettingsHandlers())
+  })
+
+  test("カテゴリ名、月予算、ピン状態を表示する", async () => {
+    await renderCategorySettingsList(<Default />)
+
+    expect(await screen.findByText("Categories")).toBeInTheDocument()
     expect(screen.getByText("Name")).toBeInTheDocument()
-    expect(screen.getByText("Monthly budget")).toBeInTheDocument()
-    expect(screen.getByText("Pin")).toBeInTheDocument()
+    expect(screen.getAllByText("Monthly budget").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("Pin").length).toBeGreaterThan(0)
+    expect(await screen.findByText("Food")).toBeInTheDocument()
+    expect(screen.getByText("Daily Necessities")).toBeInTheDocument()
+    expect(screen.getByText("Entertainment")).toBeInTheDocument()
+    expect(screen.getByText("￥50,000")).toBeInTheDocument()
+    expect(screen.getAllByText("Not set")).toHaveLength(1)
+    expect(
+      within(screen.getByLabelText("Food category settings")).getAllByText("Pin").length,
+    ).toBeGreaterThan(0)
+    expect(
+      within(screen.getByLabelText("Daily Necessities category settings")).queryByText("Pin"),
+    ).not.toBeInTheDocument()
+    expect(
+      within(screen.getByLabelText("Entertainment category settings")).queryByText("Pin"),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByText("Pinned")).not.toBeInTheDocument()
+    expect(screen.queryByText("Not pinned")).not.toBeInTheDocument()
+  })
+
+  test("カテゴリ設定取得中は loading を表示する", async () => {
+    server.resetHandlers(...createCategorySettingsHandlers({ durationOrMode: "infinite" }))
+
+    await renderCategorySettingsList(<Default />)
+
+    expect(await screen.findByLabelText("loading category settings")).toBeInTheDocument()
+  })
+
+  test("カテゴリ設定取得失敗時は error を表示する", async () => {
+    server.resetHandlers(...createCategorySettingsHandlers({ error: true }))
+
+    await renderCategorySettingsList(<Default />)
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Could not load categories.")
+  })
+
+  test("カテゴリがない場合は empty を表示する", async () => {
+    server.resetHandlers(...createCategorySettingsHandlers({ response: [] }))
+
+    await renderCategorySettingsList(<Default />)
+
+    expect(await screen.findByText("No categories.")).toBeInTheDocument()
   })
 })

--- a/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.tsx
+++ b/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.tsx
@@ -1,5 +1,5 @@
-import { Badge, Box, Flex, Grid, Skeleton, Text } from "@radix-ui/themes"
-import { Suspense, use } from "react"
+import { Badge, Box, Flex, Grid, Separator, Skeleton, Text } from "@radix-ui/themes"
+import { Fragment, Suspense, use } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 
 import { toCurrency } from "../../../../utils/toCurrency"
@@ -44,7 +44,10 @@ function CategorySettingsListContent({ promise }: CategorySettingsListContentPro
     <Flex direction="column" gap="2">
       <CategorySettingsHeader />
       {items.map((item) => (
-        <CategorySettingsRow item={item} key={item.category.id} />
+        <Fragment key={item.category.id}>
+          <Separator orientation="horizontal" size="4" />
+          <CategorySettingsRow item={item} />
+        </Fragment>
       ))}
     </Flex>
   )
@@ -66,14 +69,7 @@ function CategorySettingsLoadingRows() {
   return (
     <Flex aria-label="loading category settings" direction="column" gap="2">
       <CategorySettingsHeader />
-      <Grid
-        columns={{ initial: "1fr", sm: "1fr minmax(120px, auto) minmax(56px, auto)" }}
-        gap="2"
-        style={{
-          borderTop: "1px solid var(--gray-a5)",
-          paddingBlock: "var(--space-2)",
-        }}
-      >
+      <Grid columns={{ initial: "1fr", sm: "1fr minmax(120px, auto) minmax(56px, auto)" }} gap="2">
         <Skeleton loading>
           <Text>Category name</Text>
         </Skeleton>
@@ -99,10 +95,6 @@ function CategorySettingsRow({ item }: { item: CategorySettingsItem }) {
       aria-label={`${item.category.name} category settings`}
       columns={{ initial: "1fr", sm: "1fr minmax(120px, auto) minmax(56px, auto)" }}
       gap="2"
-      style={{
-        borderTop: "1px solid var(--gray-a5)",
-        paddingBlock: "var(--space-2)",
-      }}
     >
       <Flex align="center" gap="2" justify="between">
         <Text>{item.category.name}</Text>

--- a/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.tsx
+++ b/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.tsx
@@ -1,16 +1,130 @@
-import { Flex, Grid, Text } from "@radix-ui/themes"
+import { Badge, Box, Flex, Grid, Skeleton, Text } from "@radix-ui/themes"
+import { Suspense, use } from "react"
+import { ErrorBoundary } from "react-error-boundary"
+
+import { toCurrency } from "../../../../utils/toCurrency"
+import type { CategorySettingsItem } from "../../listCategorySettings/types"
+import { useCategorySettingsItems } from "../../listCategorySettings/useCategorySettingsItems"
 
 export function CategorySettingsList() {
+  const { promise } = useCategorySettingsItems()
+
   return (
     <Flex direction="column" gap="3">
       <Text as="p" size="4" weight="medium">
         Categories
       </Text>
-      <Grid columns={{ initial: "1fr", sm: "1fr minmax(120px, auto) minmax(72px, auto)" }} gap="3">
+      <ErrorBoundary
+        fallback={
+          <Text color="red" role="alert">
+            Could not load categories.
+          </Text>
+        }
+      >
+        <Suspense fallback={<CategorySettingsLoadingRows />}>
+          <CategorySettingsListContent promise={promise} />
+        </Suspense>
+      </ErrorBoundary>
+    </Flex>
+  )
+}
+
+interface CategorySettingsListContentProps {
+  promise: Promise<CategorySettingsItem[]>
+}
+
+function CategorySettingsListContent({ promise }: CategorySettingsListContentProps) {
+  const items = use(promise)
+
+  if (items.length === 0) {
+    return <Text color="gray">No categories.</Text>
+  }
+
+  return (
+    <Flex direction="column" gap="2">
+      <CategorySettingsHeader />
+      {items.map((item) => (
+        <CategorySettingsRow item={item} key={item.category.id} />
+      ))}
+    </Flex>
+  )
+}
+
+function CategorySettingsHeader() {
+  return (
+    <Box display={{ initial: "none", sm: "block" }}>
+      <Grid columns="1fr minmax(120px, auto) minmax(56px, auto)" gap="3">
         <Text color="gray">Name</Text>
         <Text color="gray">Monthly budget</Text>
         <Text color="gray">Pin</Text>
       </Grid>
+    </Box>
+  )
+}
+
+function CategorySettingsLoadingRows() {
+  return (
+    <Flex aria-label="loading category settings" direction="column" gap="2">
+      <CategorySettingsHeader />
+      <Grid
+        columns={{ initial: "1fr", sm: "1fr minmax(120px, auto) minmax(56px, auto)" }}
+        gap="2"
+        style={{
+          borderTop: "1px solid var(--gray-a5)",
+          paddingBlock: "var(--space-2)",
+        }}
+      >
+        <Skeleton loading>
+          <Text>Category name</Text>
+        </Skeleton>
+        <Skeleton loading>
+          <Text>Monthly budget ￥000,000</Text>
+        </Skeleton>
+        <Skeleton loading>
+          <Text>Pin</Text>
+        </Skeleton>
+      </Grid>
     </Flex>
+  )
+}
+
+function CategorySettingsRow({ item }: { item: CategorySettingsItem }) {
+  const budgetText = item.latestCategoryBudget
+    ? toCurrency(item.latestCategoryBudget.amount)
+    : "Not set"
+
+  return (
+    <Grid
+      align="center"
+      aria-label={`${item.category.name} category settings`}
+      columns={{ initial: "1fr", sm: "1fr minmax(120px, auto) minmax(56px, auto)" }}
+      gap="2"
+      style={{
+        borderTop: "1px solid var(--gray-a5)",
+        paddingBlock: "var(--space-2)",
+      }}
+    >
+      <Flex align="center" gap="2" justify="between">
+        <Text>{item.category.name}</Text>
+        <Box display={{ initial: "block", sm: "none" }}>{item.pinned && <PinBadge />}</Box>
+      </Flex>
+      <Flex align="center" gap="3" justify={{ initial: "between", sm: "start" }}>
+        <Box display={{ initial: "block", sm: "none" }}>
+          <Text color="gray" size="2">
+            Monthly budget
+          </Text>
+        </Box>
+        <Text color={item.latestCategoryBudget ? undefined : "gray"}>{budgetText}</Text>
+      </Flex>
+      <Box display={{ initial: "none", sm: "block" }}>{item.pinned && <PinBadge />}</Box>
+    </Grid>
+  )
+}
+
+function PinBadge() {
+  return (
+    <Badge color="blue" variant="soft">
+      Pin
+    </Badge>
   )
 }

--- a/apps/web/src/features/categories/listCategorySettings/fetchCategorySettingsItems.integration.test.ts
+++ b/apps/web/src/features/categories/listCategorySettings/fetchCategorySettingsItems.integration.test.ts
@@ -1,0 +1,137 @@
+import { HttpResponse, http } from "msw"
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { createCategorySettingsHandlers } from "../../../test/msw/handlers/categorySettings"
+import { server } from "../../../test/msw/server"
+import { supabaseTestClient } from "../../../test/utils/createSupabaseTestClient"
+import { fetchCategorySettingsItems } from "./fetchCategorySettingsItems"
+
+vi.mock("../../../lib/supabase", () => ({
+  getSupabaseClient: () => supabaseTestClient,
+}))
+
+const foodCategoryWithBudgets = {
+  id: 10,
+  book_id: 1,
+  name: "Food",
+  category_budgets: [
+    {
+      id: 3,
+      amount: 50000,
+      effective_from: "2025-03-01",
+      effective_year: 2025,
+      effective_month: 3,
+    },
+  ],
+  category_pins: [{ id: 100, category_id: 10 }],
+}
+
+const dailyNecessitiesCategoryWithoutBudget = {
+  id: 20,
+  book_id: 1,
+  name: "Daily Necessities",
+  category_budgets: [],
+  category_pins: [],
+}
+
+describe("fetchCategorySettingsItems", () => {
+  beforeEach(() => {
+    server.resetHandlers(...createCategorySettingsHandlers())
+  })
+
+  it("カテゴリ設定行を取得してカテゴリ別月予算とピン状態を正規化する", async () => {
+    server.resetHandlers(
+      ...createCategorySettingsHandlers({
+        response: [foodCategoryWithBudgets, dailyNecessitiesCategoryWithoutBudget],
+      }),
+    )
+
+    const items = await fetchCategorySettingsItems()
+
+    expect(items).toEqual([
+      {
+        category: {
+          id: 10,
+          bookId: 1,
+          name: "Food",
+        },
+        latestCategoryBudget: {
+          id: 3,
+          amount: 50000,
+          effectiveFrom: new Date(2025, 2, 1),
+          effectiveYear: 2025,
+          effectiveMonth: 3,
+        },
+        pinned: true,
+      },
+      {
+        category: {
+          id: 20,
+          bookId: 1,
+          name: "Daily Necessities",
+        },
+        latestCategoryBudget: null,
+        pinned: false,
+      },
+    ])
+  })
+
+  it("カテゴリ起点の1 requestで必要な読み取り列を取得する", async () => {
+    const requestCapture: { url: URL | null } = { url: null }
+    let requestCount = 0
+
+    server.use(
+      http.get("*/rest/v1/categories*", ({ request }) => {
+        requestCount += 1
+        requestCapture.url = new URL(request.url)
+
+        return HttpResponse.json([])
+      }),
+    )
+
+    await fetchCategorySettingsItems()
+
+    expect(requestCount).toBe(1)
+    const select = requestCapture.url?.searchParams.get("select")
+    expect(select).toContain("id")
+    expect(select).toContain("book_id")
+    expect(select).toContain("name")
+    expect(select).toContain("category_budgets:category_budgets!category_budgets_category_id_fkey")
+    expect(select).toContain("category_pins:category_pins!category_pins_category_id_fkey")
+    expect(requestCapture.url?.searchParams.get("order")).toBe("id.asc")
+    expect(requestCapture.url?.searchParams.get("category_budgets.order")).toBe(
+      "effective_from.desc,id.desc",
+    )
+    expect(requestCapture.url?.searchParams.get("category_budgets.limit")).toBe("1")
+    expect(requestCapture.url?.searchParams.get("category_pins.limit")).toBe("1")
+    expect(requestCapture.url?.searchParams.has("book_id")).toBe(false)
+  })
+
+  it("Supabase がエラーを返した場合に throw する", async () => {
+    server.resetHandlers(
+      ...createCategorySettingsHandlers({
+        error: true,
+      }),
+    )
+
+    await expect(fetchCategorySettingsItems()).rejects.toThrow("Failed to fetch category settings.")
+  })
+
+  it("レスポンス shape が不正ならエラーにする", async () => {
+    server.use(
+      http.get("*/rest/v1/categories*", () => {
+        return HttpResponse.json([
+          {
+            id: "invalid",
+            book_id: 1,
+            name: "Food",
+            category_budgets: [],
+            category_pins: [],
+          },
+        ])
+      }),
+    )
+
+    await expect(fetchCategorySettingsItems()).rejects.toThrow("Invalid category settings response")
+  })
+})

--- a/apps/web/src/features/categories/listCategorySettings/fetchCategorySettingsItems.ts
+++ b/apps/web/src/features/categories/listCategorySettings/fetchCategorySettingsItems.ts
@@ -1,0 +1,98 @@
+import * as z from "zod"
+
+import { getSupabaseClient } from "../../../lib/supabase"
+import { parseIsoDateOnlyToLocalDate } from "../../budgets/utils/month"
+import type { CategorySettingsBudget, CategorySettingsItem } from "./types"
+
+const categorySettingsColumns = `
+  id,
+  book_id,
+  name,
+  category_budgets:category_budgets!category_budgets_category_id_fkey (
+    id,
+    amount,
+    effective_from,
+    effective_year,
+    effective_month
+  ),
+  category_pins:category_pins!category_pins_category_id_fkey (
+    id,
+    category_id
+  )
+`
+
+const categorySettingsBudgetRowSchema = z.object({
+  id: z.number(),
+  amount: z.number(),
+  effective_from: z.string(),
+  effective_year: z.number(),
+  effective_month: z.number(),
+})
+
+const categoryPinRowSchema = z.object({
+  id: z.number(),
+  category_id: z.number(),
+})
+
+const categorySettingsRowSchema = z.object({
+  id: z.number(),
+  book_id: z.number(),
+  name: z.string(),
+  category_budgets: z.array(categorySettingsBudgetRowSchema).nullable(),
+  category_pins: z.array(categoryPinRowSchema).nullable(),
+})
+
+type CategorySettingsRow = z.infer<typeof categorySettingsRowSchema>
+type CategorySettingsBudgetRow = z.infer<typeof categorySettingsBudgetRowSchema>
+
+export async function fetchCategorySettingsItems(): Promise<CategorySettingsItem[]> {
+  const supabase = getSupabaseClient()
+  const { data, error } = await supabase
+    .from("categories")
+    .select(categorySettingsColumns)
+    .order("id", { ascending: true })
+    .order("effective_from", { referencedTable: "category_budgets", ascending: false })
+    .order("id", { referencedTable: "category_budgets", ascending: false })
+    .limit(1, { referencedTable: "category_budgets" })
+    .limit(1, { referencedTable: "category_pins" })
+
+  if (error) {
+    throw error
+  }
+
+  return normalizeCategorySettingsRows(data ?? []).map(toCategorySettingsItem)
+}
+
+function normalizeCategorySettingsRows(value: unknown): CategorySettingsRow[] {
+  const result = z.array(categorySettingsRowSchema).safeParse(value)
+
+  if (!result.success) {
+    throw new Error("Invalid category settings response")
+  }
+
+  return result.data
+}
+
+function toCategorySettingsItem(row: CategorySettingsRow): CategorySettingsItem {
+  const latestBudget = row.category_budgets?.[0] ?? null
+
+  return {
+    category: {
+      id: row.id,
+      bookId: row.book_id,
+      name: row.name,
+    },
+    latestCategoryBudget: latestBudget ? toCategorySettingsBudget(latestBudget) : null,
+    pinned: (row.category_pins ?? []).some((pin) => pin.category_id === row.id),
+  }
+}
+
+function toCategorySettingsBudget(row: CategorySettingsBudgetRow): CategorySettingsBudget {
+  return {
+    id: row.id,
+    amount: row.amount,
+    effectiveFrom: parseIsoDateOnlyToLocalDate(row.effective_from),
+    effectiveYear: row.effective_year,
+    effectiveMonth: row.effective_month,
+  }
+}

--- a/apps/web/src/features/categories/listCategorySettings/types.ts
+++ b/apps/web/src/features/categories/listCategorySettings/types.ts
@@ -1,0 +1,17 @@
+export interface CategorySettingsBudget {
+  id: number
+  amount: number
+  effectiveFrom: Date
+  effectiveYear: number
+  effectiveMonth: number
+}
+
+export interface CategorySettingsItem {
+  category: {
+    id: number
+    bookId: number
+    name: string
+  }
+  latestCategoryBudget: CategorySettingsBudget | null
+  pinned: boolean
+}

--- a/apps/web/src/features/categories/listCategorySettings/useCategorySettingsItems.test.tsx
+++ b/apps/web/src/features/categories/listCategorySettings/useCategorySettingsItems.test.tsx
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { renderHook } from "../../../test/test-utils"
+import type { CategorySettingsItem } from "./types"
+import { useCategorySettingsItems } from "./useCategorySettingsItems"
+
+const { mockFetchCategorySettingsItems } = vi.hoisted(() => ({
+  mockFetchCategorySettingsItems: vi.fn(),
+}))
+
+vi.mock("./fetchCategorySettingsItems", () => ({
+  fetchCategorySettingsItems: mockFetchCategorySettingsItems,
+}))
+
+function buildCategorySettingsItem(id: number): CategorySettingsItem {
+  return {
+    category: {
+      id,
+      bookId: 1,
+      name: `Category ${id}`,
+    },
+    latestCategoryBudget: null,
+    pinned: false,
+  }
+}
+
+describe("useCategorySettingsItems", () => {
+  beforeEach(() => {
+    mockFetchCategorySettingsItems.mockReset()
+  })
+
+  it("カテゴリ設定行を取得する", async () => {
+    const items = [buildCategorySettingsItem(10), buildCategorySettingsItem(20)]
+    mockFetchCategorySettingsItems.mockResolvedValue(items)
+
+    const { result } = renderHook(() => useCategorySettingsItems())
+
+    await expect(result.current.promise).resolves.toEqual(items)
+    expect(mockFetchCategorySettingsItems).toHaveBeenCalledTimes(1)
+  })
+
+  it("取得に失敗した場合は promise を reject する", async () => {
+    const error = new Error("failed")
+    mockFetchCategorySettingsItems.mockRejectedValue(error)
+
+    const { result } = renderHook(() => useCategorySettingsItems())
+
+    await expect(result.current.promise).rejects.toBe(error)
+  })
+})

--- a/apps/web/src/features/categories/listCategorySettings/useCategorySettingsItems.ts
+++ b/apps/web/src/features/categories/listCategorySettings/useCategorySettingsItems.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query"
+
+import { fetchCategorySettingsItems } from "./fetchCategorySettingsItems"
+import type { CategorySettingsItem } from "./types"
+
+interface UseCategorySettingsItemsReturn {
+  promise: Promise<CategorySettingsItem[]>
+}
+
+export function useCategorySettingsItems(): UseCategorySettingsItemsReturn {
+  const query = useQuery({
+    queryKey: ["categorySettingsItems"],
+    queryFn: async () => fetchCategorySettingsItems(),
+    staleTime: 3000,
+  })
+
+  return { promise: query.promise }
+}

--- a/apps/web/src/test/msw/handlers/categorySettings.ts
+++ b/apps/web/src/test/msw/handlers/categorySettings.ts
@@ -1,0 +1,98 @@
+import { type DelayMode, HttpResponse, delay, http } from "msw"
+
+import { allCategories } from "../../data/categories"
+import { categoryBudgets } from "../../data/categoryBudgets"
+
+const REST_URL = "*/rest/v1/categories*"
+const CURRENT_BOOK_ID = 1
+
+export interface CategorySettingsBudgetResponseRow {
+  id: number
+  amount: number
+  effective_from: string
+  effective_year: number
+  effective_month: number
+}
+
+export interface CategorySettingsPinResponseRow {
+  id: number
+  category_id: number
+}
+
+export interface CategorySettingsResponseRow {
+  id: number
+  book_id: number
+  name: string
+  category_budgets: CategorySettingsBudgetResponseRow[]
+  category_pins: CategorySettingsPinResponseRow[]
+}
+
+interface GetCategorySettingsOptions {
+  response?: CategorySettingsResponseRow[]
+  currentBookId?: number
+  pinnedCategoryIds?: number[]
+  error?: boolean
+  durationOrMode?: number | DelayMode | undefined
+}
+
+export function createCategorySettingsHandlers({
+  response,
+  currentBookId = CURRENT_BOOK_ID,
+  pinnedCategoryIds = [10],
+  error = false,
+  durationOrMode,
+}: GetCategorySettingsOptions = {}) {
+  return [
+    http.get(REST_URL, async () => {
+      await delay(durationOrMode)
+
+      if (error) {
+        return HttpResponse.json({ message: "Failed to fetch category settings." }, { status: 500 })
+      }
+
+      return HttpResponse.json(
+        response ?? buildCategorySettingsResponse(currentBookId, pinnedCategoryIds),
+      )
+    }),
+  ]
+}
+
+function buildCategorySettingsResponse(
+  currentBookId: number,
+  pinnedCategoryIds: number[],
+): CategorySettingsResponseRow[] {
+  return allCategories
+    .filter((category) => category.bookId === currentBookId)
+    .map((category) => ({
+      id: category.id,
+      book_id: category.bookId,
+      name: category.name,
+      category_budgets: categoryBudgets
+        .filter((budget) => budget.book_id === currentBookId && budget.category_id === category.id)
+        .sort((a, b) => {
+          if (a.effective_from !== b.effective_from) {
+            return b.effective_from.localeCompare(a.effective_from)
+          }
+
+          return b.id - a.id
+        })
+        .slice(0, 1)
+        .map((budget) => ({
+          id: budget.id,
+          amount: budget.amount,
+          effective_from: budget.effective_from,
+          effective_year: budget.effective_year,
+          effective_month: budget.effective_month,
+        })),
+      category_pins: pinnedCategoryIds.includes(category.id)
+        ? [
+            {
+              id: category.id,
+              category_id: category.id,
+            },
+          ]
+        : [],
+    }))
+}
+
+export const categorySettingsHandlers = createCategorySettingsHandlers()


### PR DESCRIPTION
## 関連Issue

- closes #1281

## 変更内容

- 設定画面向けのカテゴリ読み取りモデルを追加し、カテゴリ名・最新カテゴリ別月予算・ピン状態を1 requestで取得するようにしました。
- `CategorySettingsList` を Suspense ベースの取得に変更し、loading / empty / error とレスポンシブ表示を一覧内で扱うようにしました。
- MSW、unit / integration / Storybook test を設定画面用の response と表示内容に合わせました。

## 動作確認

- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] pnpm --filter web test:unit
- [x] pnpm --filter web test:integration
- [x] pnpm --filter web test:storybook
