### PR TITLE
エラー表示の初期整備

### DIFF
--- a/apps/web/src/app/routes/ErrorPage/ErrorPage.stories.tsx
+++ b/apps/web/src/app/routes/ErrorPage/ErrorPage.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { expect, within } from "storybook/test"
 
+import { createStoryRouter } from "../../../test/helpers/routerDecorator"
 import { ErrorPage } from "./ErrorPage"
 
 const meta = {
@@ -10,6 +11,7 @@ const meta = {
     layout: "centered",
   },
   tags: ["autodocs", "browser-test"],
+  decorators: [createStoryRouter("/")],
   args: {
     error: new Error("Storybook root error"),
     info: {

--- a/apps/web/src/app/routes/ErrorPage/ErrorPage.stories.tsx
+++ b/apps/web/src/app/routes/ErrorPage/ErrorPage.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { expect, within } from "storybook/test"
+
+import { ErrorPage } from "./ErrorPage"
+
+const meta = {
+  title: "Pages/ErrorPage",
+  component: ErrorPage,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs", "browser-test"],
+  args: {
+    error: new Error("Storybook root error"),
+    info: {
+      componentStack: "",
+    },
+    reset: () => {},
+  },
+} satisfies Meta<typeof ErrorPage>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    expect(canvas.getByRole("heading", { name: "Something went wrong" })).toBeInTheDocument()
+    expect(canvas.getByRole("button", { name: "Reload page" })).toBeInTheDocument()
+    expect(canvas.getByRole("link", { name: "Go home" })).toHaveAttribute("href", "/")
+    expect(canvas.queryByText("Storybook root error")).not.toBeInTheDocument()
+  },
+}

--- a/apps/web/src/app/routes/ErrorPage/ErrorPage.test.tsx
+++ b/apps/web/src/app/routes/ErrorPage/ErrorPage.test.tsx
@@ -1,0 +1,26 @@
+import { composeStories } from "@storybook/react-vite"
+import { describe, expect, test, vi } from "vite-plus/test"
+
+import { render, screen } from "../../../test/test-utils"
+import * as stories from "./ErrorPage.stories"
+
+const { Default } = composeStories(stories)
+
+describe("ErrorPage", () => {
+  test("汎用エラー表示と復帰導線を表示する", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+
+    render(<Default />, { withProviders: false })
+
+    expect(screen.getByRole("heading", { name: "Something went wrong" })).toBeInTheDocument()
+    expect(
+      screen.getByText("The page could not be displayed. Try reloading the page, or go back home."),
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Reload page" })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Go home" })).toHaveAttribute("href", "/")
+    expect(screen.queryByText("Storybook root error")).not.toBeInTheDocument()
+    expect(consoleError).toHaveBeenCalledWith(expect.any(Error))
+
+    consoleError.mockRestore()
+  })
+})

--- a/apps/web/src/app/routes/ErrorPage/ErrorPage.test.tsx
+++ b/apps/web/src/app/routes/ErrorPage/ErrorPage.test.tsx
@@ -1,25 +1,49 @@
-import { composeStories } from "@storybook/react-vite"
+import { createRoute } from "@tanstack/react-router"
 import { describe, expect, test, vi } from "vite-plus/test"
 
-import { render, screen } from "../../../test/test-utils"
+import { renderWithRouter } from "../../../test/helpers/renderWithRouter"
+import { screen, waitFor } from "../../../test/test-utils"
+import { ErrorPage } from "./ErrorPage"
 import * as stories from "./ErrorPage.stories"
 
-const { Default } = composeStories(stories)
+const defaultArgs = stories.Default.args
+
+function renderDefaultStory() {
+  return renderWithRouter(
+    "/",
+    (root) => [
+      createRoute({
+        getParentRoute: () => root,
+        path: "/",
+        component: () => (
+          <ErrorPage
+            error={defaultArgs?.error ?? new Error("Storybook root error")}
+            info={defaultArgs?.info ?? { componentStack: "" }}
+            reset={defaultArgs?.reset ?? vi.fn()}
+          />
+        ),
+      }),
+    ],
+    { withProviders: false },
+  )
+}
 
 describe("ErrorPage", () => {
-  test("汎用エラー表示と復帰導線を表示する", () => {
+  test("汎用エラー表示と復帰導線を表示する", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
 
-    render(<Default />, { withProviders: false })
+    renderDefaultStory()
 
-    expect(screen.getByRole("heading", { name: "Something went wrong" })).toBeInTheDocument()
+    expect(await screen.findByRole("heading", { name: "Something went wrong" })).toBeInTheDocument()
     expect(
       screen.getByText("The page could not be displayed. Try reloading the page, or go back home."),
     ).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Reload page" })).toBeInTheDocument()
     expect(screen.getByRole("link", { name: "Go home" })).toHaveAttribute("href", "/")
     expect(screen.queryByText("Storybook root error")).not.toBeInTheDocument()
-    expect(consoleError).toHaveBeenCalledWith(expect.any(Error))
+    await waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith(expect.any(Error))
+    })
 
     consoleError.mockRestore()
   })

--- a/apps/web/src/app/routes/ErrorPage/ErrorPage.tsx
+++ b/apps/web/src/app/routes/ErrorPage/ErrorPage.tsx
@@ -1,13 +1,16 @@
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons"
 import { Button, Container, Flex, Heading, Text } from "@radix-ui/themes"
 import type { ErrorComponentProps } from "@tanstack/react-router"
-import { useId } from "react"
+import { useEffect, useId } from "react"
 
 import { Paper } from "../../../components/misc/Paper"
 
 export function ErrorPage({ error }: ErrorComponentProps) {
   const id = useId()
-  console.error(error)
+
+  useEffect(() => {
+    console.error(error)
+  }, [error])
 
   return (
     <Container id={`error-page-${id}`} size="2">

--- a/apps/web/src/app/routes/ErrorPage/ErrorPage.tsx
+++ b/apps/web/src/app/routes/ErrorPage/ErrorPage.tsx
@@ -1,19 +1,37 @@
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons"
+import { Button, Container, Flex, Heading, Text } from "@radix-ui/themes"
 import type { ErrorComponentProps } from "@tanstack/react-router"
 import { useId } from "react"
+
+import { Paper } from "../../../components/misc/Paper"
 
 export function ErrorPage({ error }: ErrorComponentProps) {
   const id = useId()
   console.error(error)
 
   return (
-    <div id={`error-page-${id}`}>
-      <h1>Oops!</h1>
-      <p>Sorry, an unexpected error has occurred.</p>
-      {error instanceof Error && (
-        <p>
-          <i>{error.message}</i>
-        </p>
-      )}
-    </div>
+    <Container id={`error-page-${id}`} size="2">
+      <Paper>
+        <Flex align="start" direction="column" gap="4">
+          <Flex align="center" gap="2">
+            <ExclamationTriangleIcon aria-hidden width="22" height="22" />
+            <Heading as="h1" size="5">
+              Something went wrong
+            </Heading>
+          </Flex>
+          <Text as="p" color="gray" size="3">
+            The page could not be displayed. Try reloading the page, or go back home.
+          </Text>
+          <Flex gap="3" wrap="wrap">
+            <Button type="button" onClick={() => window.location.reload()}>
+              Reload page
+            </Button>
+            <Button asChild variant="soft">
+              <a href="/">Go home</a>
+            </Button>
+          </Flex>
+        </Flex>
+      </Paper>
+    </Container>
   )
 }

--- a/apps/web/src/app/routes/ErrorPage/ErrorPage.tsx
+++ b/apps/web/src/app/routes/ErrorPage/ErrorPage.tsx
@@ -1,6 +1,6 @@
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons"
 import { Button, Container, Flex, Heading, Text } from "@radix-ui/themes"
-import type { ErrorComponentProps } from "@tanstack/react-router"
+import { Link, type ErrorComponentProps } from "@tanstack/react-router"
 import { useEffect, useId } from "react"
 
 import { Paper } from "../../../components/misc/Paper"
@@ -30,7 +30,7 @@ export function ErrorPage({ error }: ErrorComponentProps) {
               Reload page
             </Button>
             <Button asChild variant="soft">
-              <a href="/">Go home</a>
+              <Link to="/">Go home</Link>
             </Button>
           </Flex>
         </Flex>

--- a/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.stories.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.stories.tsx
@@ -38,3 +38,16 @@ export const Loading: Story = {
     },
   },
 }
+
+export const FetchError: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...createPaymentHandlers({
+          get: { error: true },
+        }),
+        ...createCategoryHandlers(),
+      ],
+    },
+  },
+}

--- a/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
@@ -150,6 +150,30 @@ describe("PaymentList", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent("Could not load payments.")
   })
 
+  test("取得失敗後に検索条件が変わると一覧表示へ復帰する", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        get: { error: true },
+      }),
+      ...createCategoryHandlers(),
+    )
+    const { router } = renderPaymentList("/payments?year=2025&month=6")
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Could not load payments.")
+
+    server.resetHandlers(...createPaymentHandlers(), ...createCategoryHandlers())
+    await router.navigate({
+      to: "/payments",
+      search: (prev) => ({ ...prev, category: "10" }),
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+    })
+    expect(await screen.findAllByRole("button", { name: /コンビニ/ })).toHaveLength(2)
+  })
+
   test("支払い行を開くと現在の検索条件を維持して詳細URLへ遷移する", async () => {
     server.resetHandlers(...createPaymentHandlers(), ...createCategoryHandlers())
     const { router, user } = renderPaymentList("/payments?year=2025&month=6&category=10")

--- a/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
@@ -12,7 +12,7 @@ import { paymentsSearchSchema } from "../paymentsSearchSchema"
 import { PaymentList } from "./PaymentList"
 import * as stories from "./PaymentList.stories"
 
-const { Default, Loading } = composeStories(stories)
+const { Default, FetchError, Loading } = composeStories(stories)
 
 function renderStory() {
   const queryClient = createTestQueryClient()
@@ -130,6 +130,19 @@ describe("PaymentList", () => {
     render(<Loading />)
 
     expect(await screen.findAllByLabelText("loading-payment-item")).toHaveLength(3)
+  })
+
+  test("取得に失敗した場合はエラー状態を表示する", async () => {
+    server.resetHandlers(
+      ...createPaymentHandlers({
+        get: { error: true },
+      }),
+      ...createCategoryHandlers(),
+    )
+
+    render(<FetchError />)
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Could not load payments.")
   })
 
   test("支払い行を開くと現在の検索条件を維持して詳細URLへ遷移する", async () => {

--- a/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.test.tsx
@@ -1,7 +1,7 @@
 import { composeStories } from "@storybook/react-vite"
 import { createRoute } from "@tanstack/react-router"
 import { HttpResponse, http } from "msw"
-import { describe, expect, test } from "vite-plus/test"
+import { afterEach, describe, expect, test, vi } from "vite-plus/test"
 
 import { renderWithRouter } from "../../../../test/helpers/renderWithRouter"
 import { createCategoryHandlers } from "../../../../test/msw/handlers/categories"
@@ -48,6 +48,10 @@ function renderPaymentList(initialEntry: string) {
 }
 
 describe("PaymentList", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   test("支払い行が button として並び、詳細内に削除導線がある", async () => {
     renderStory()
 
@@ -133,6 +137,7 @@ describe("PaymentList", () => {
   })
 
   test("取得に失敗した場合はエラー状態を表示する", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
     server.resetHandlers(
       ...createPaymentHandlers({
         get: { error: true },

--- a/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.tsx
@@ -1,6 +1,7 @@
 import { Button, Flex, Text } from "@radix-ui/themes"
 import { useNavigate } from "@tanstack/react-router"
 import { memo, Suspense, use, useCallback, useState } from "react"
+import { ErrorBoundary } from "react-error-boundary"
 
 import { PaymentCard } from "../../../../components/payments/PaymentCard/PaymentCard"
 import type { Category } from "../../../../types/category"
@@ -51,15 +52,17 @@ export const PaymentList = memo(function PaymentList() {
   return (
     <>
       <Flex aria-label="payment-list" direction="column" gap="2" tabIndex={-1}>
-        <Suspense fallback={<SkeltonItems />}>
-          <Items
-            promiseCategories={promiseCategories}
-            getPayments={promisePayments}
-            onOpenPayment={openPaymentDetails}
-            filtered={categoryId !== undefined}
-            onClearCategory={handleClearCategory}
-          />
-        </Suspense>
+        <ErrorBoundary fallback={<PaymentListError />}>
+          <Suspense fallback={<SkeltonItems />}>
+            <Items
+              promiseCategories={promiseCategories}
+              getPayments={promisePayments}
+              onOpenPayment={openPaymentDetails}
+              filtered={categoryId !== undefined}
+              onClearCategory={handleClearCategory}
+            />
+          </Suspense>
+        </ErrorBoundary>
       </Flex>
       <PaymentDetailsOverlay
         open={hasPaymentDetailsRoute}
@@ -149,5 +152,13 @@ function SkeltonItems() {
       <PaymentCard loading interactive />
       <PaymentCard loading interactive />
     </>
+  )
+}
+
+function PaymentListError() {
+  return (
+    <Text color="red" role="alert">
+      Could not load payments.
+    </Text>
   )
 }

--- a/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentList/PaymentList.tsx
@@ -52,7 +52,10 @@ export const PaymentList = memo(function PaymentList() {
   return (
     <>
       <Flex aria-label="payment-list" direction="column" gap="2" tabIndex={-1}>
-        <ErrorBoundary fallback={<PaymentListError />}>
+        <ErrorBoundary
+          fallback={<PaymentListError />}
+          resetKeys={[promisePayments, promiseCategories]}
+        >
           <Suspense fallback={<SkeltonItems />}>
             <Items
               promiseCategories={promiseCategories}


### PR DESCRIPTION
## 関連Issue

- #1336

## 変更内容

- ルートエラーページをアプリUIに合わせた汎用エラー画面へ更新
- 支払い一覧の取得失敗を一覧領域内のエラー表示で扱うように変更
- それぞれのStorybookとテストを追加

## 動作確認

- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] pnpm --filter web test:unit
- [x] pnpm --filter web test:integration
- [x] pnpm --filter web test:storybook