### PR TITLE
カテゴリ更新用のDB/RLSと型を追加

### DIFF
--- a/apps/api/supabase/migrations/20260513000000_add_category_update_policy.sql
+++ b/apps/api/supabase/migrations/20260513000000_add_category_update_policy.sql
@@ -1,0 +1,45 @@
+create or replace function keep_category_book_id()
+returns trigger as $$
+begin
+  new.book_id := old.book_id;
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_keep_category_book_id
+  before update on categories
+  for each row
+  execute function keep_category_book_id();
+
+create or replace function update_category_updated_at()
+returns trigger as $$
+begin
+  new.updated_at := current_timestamp;
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+create trigger trg_update_category_updated_at
+  before update on categories
+  for each row
+  execute function update_category_updated_at();
+
+create policy "Users can update member book categories"
+  on categories for update
+  to authenticated
+  using (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = categories.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  )
+  with check (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = categories.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );

--- a/apps/web/src/types/database.types.ts
+++ b/apps/web/src/types/database.types.ts
@@ -334,10 +334,7 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      ensure_authenticated_user: {
-        Args: never
-        Returns: undefined
-      }
+      ensure_authenticated_user: { Args: never; Returns: undefined }
       get_authenticated_default_book_id: { Args: never; Returns: number }
       get_authenticated_user_id: { Args: never; Returns: number }
       get_monthly_total_amount: { Args: { p_month: string }; Returns: number }


### PR DESCRIPTION
## 関連Issue

- #1286

## 変更内容

- categories に所属 Book member だけが更新できる RLS を追加
- categories の book_id 不変と updated_at 更新を DB trigger で保証
- Supabase 生成型を同期

## 動作確認

- [x] pnpm run api:migrations:up
- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] pnpm --filter web test:unit
- [x] pnpm --filter web test:integration
- [x] pnpm --filter web test:storybook

## 補足

- member / non-member の実行時 RLS 挙動はレビュー時に重点確認してください。
