### PR TITLE
Book設定でカテゴリ名を編集できるようにする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ web_modules/
 
 # Optional npm cache directory
 .npm
+.pnpm-store/
 
 # Optional eslint cache
 .eslintcache

--- a/apps/web/src/features/categories/categorySchema.test.ts
+++ b/apps/web/src/features/categories/categorySchema.test.ts
@@ -4,6 +4,15 @@ import z from "zod"
 import { CATEGORY_NAME_MAX_LENGTH, categoryNameSchema } from "./categorySchema"
 
 describe("categoryNameSchema", () => {
+  test("空文字のカテゴリ名を拒否する", () => {
+    const result = categoryNameSchema.safeParse("")
+
+    expect(result.success).toBe(false)
+
+    const error = result.error && z.flattenError(result.error).formErrors
+    expect(error).toEqual(["Category name cannot be empty"])
+  })
+
   test("20文字以下のカテゴリ名を許可する", () => {
     const result = categoryNameSchema.safeParse("a".repeat(CATEGORY_NAME_MAX_LENGTH))
 

--- a/apps/web/src/features/categories/categorySchema.test.ts
+++ b/apps/web/src/features/categories/categorySchema.test.ts
@@ -13,6 +13,15 @@ describe("categoryNameSchema", () => {
     expect(error).toEqual(["Category name cannot be empty"])
   })
 
+  test("空白のみのカテゴリ名を拒否する", () => {
+    const result = categoryNameSchema.safeParse("   ")
+
+    expect(result.success).toBe(false)
+
+    const error = result.error && z.flattenError(result.error).formErrors
+    expect(error).toEqual(["Category name cannot be empty"])
+  })
+
   test("20文字以下のカテゴリ名を許可する", () => {
     const result = categoryNameSchema.safeParse("a".repeat(CATEGORY_NAME_MAX_LENGTH))
 

--- a/apps/web/src/features/categories/categorySchema.ts
+++ b/apps/web/src/features/categories/categorySchema.ts
@@ -4,6 +4,7 @@ export const CATEGORY_NAME_MAX_LENGTH = 20
 
 export const categoryNameSchema = z
   .string()
+  .min(1, "Category name cannot be empty")
   .max(
     CATEGORY_NAME_MAX_LENGTH,
     `Category name must be ${CATEGORY_NAME_MAX_LENGTH} characters or less`,

--- a/apps/web/src/features/categories/categorySchema.ts
+++ b/apps/web/src/features/categories/categorySchema.ts
@@ -4,7 +4,7 @@ export const CATEGORY_NAME_MAX_LENGTH = 20
 
 export const categoryNameSchema = z
   .string()
-  .min(1, "Category name cannot be empty")
+  .refine((value) => value.trim().length > 0, "Category name cannot be empty")
   .max(
     CATEGORY_NAME_MAX_LENGTH,
     `Category name must be ${CATEGORY_NAME_MAX_LENGTH} characters or less`,

--- a/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.test.tsx
+++ b/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, test } from "vite-plus/test"
 
 import { createCategorySettingsHandlers } from "../../../../test/msw/handlers/categorySettings"
 import { server } from "../../../../test/msw/server"
-import { act, render, screen, within } from "../../../../test/test-utils"
+import { act, render, screen, waitFor, within } from "../../../../test/test-utils"
 import * as stories from "./CategorySettingsList.stories"
 
 const { Default } = composeStories(stories)
@@ -26,7 +26,9 @@ describe("CategorySettingsList", () => {
     expect(await screen.findByText("Categories")).toBeInTheDocument()
     expect(screen.getByText("Name")).toBeInTheDocument()
     expect(screen.getAllByText("Monthly budget").length).toBeGreaterThan(0)
-    expect(screen.getAllByText("Pin").length).toBeGreaterThan(0)
+    expect(
+      within(screen.getByText("Name").parentElement!).queryByText("Pin"),
+    ).not.toBeInTheDocument()
     expect(await screen.findByText("Food")).toBeInTheDocument()
     expect(screen.getByText("Daily Necessities")).toBeInTheDocument()
     expect(screen.getByText("Entertainment")).toBeInTheDocument()
@@ -43,6 +45,32 @@ describe("CategorySettingsList", () => {
     ).not.toBeInTheDocument()
     expect(screen.queryByText("Pinned")).not.toBeInTheDocument()
     expect(screen.queryByText("Not pinned")).not.toBeInTheDocument()
+    expect(
+      await screen.findAllByRole("button", { name: /edit .* category name/i }),
+    ).not.toHaveLength(0)
+  })
+
+  test("カテゴリ名を更新して一覧に反映する", async () => {
+    const { user } = await renderCategorySettingsList(<Default />)
+
+    await user.click(
+      within(await screen.findByLabelText("Food category settings")).getAllByRole("button", {
+        name: /edit food category name/i,
+      })[0]!,
+    )
+
+    const dialog = await screen.findByRole("dialog", { name: "Edit category" })
+
+    await user.clear(within(dialog).getByRole("textbox", { name: /Name/ }))
+    await user.type(within(dialog).getByRole("textbox", { name: /Name/ }), "Groceries")
+    await user.click(within(dialog).getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Edit category" })).not.toBeInTheDocument()
+    })
+    expect(await screen.findByText("Groceries")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Food category settings")).not.toBeInTheDocument()
+    expect(await screen.findByLabelText("Groceries category settings")).toBeInTheDocument()
   })
 
   test("カテゴリ設定取得中は loading を表示する", async () => {

--- a/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.tsx
+++ b/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.tsx
@@ -5,6 +5,7 @@ import { ErrorBoundary } from "react-error-boundary"
 import { toCurrency } from "../../../../utils/toCurrency"
 import type { CategorySettingsItem } from "../../listCategorySettings/types"
 import { useCategorySettingsItems } from "../../listCategorySettings/useCategorySettingsItems"
+import { UpdateCategoryNameModal } from "../../updateCategoryName/UpdateCategoryNameModal"
 
 export function CategorySettingsList() {
   const { promise } = useCategorySettingsItems()
@@ -56,10 +57,10 @@ function CategorySettingsListContent({ promise }: CategorySettingsListContentPro
 function CategorySettingsHeader() {
   return (
     <Box display={{ initial: "none", sm: "block" }}>
-      <Grid columns="1fr minmax(120px, auto) minmax(56px, auto)" gap="3">
+      <Grid columns="1fr minmax(120px, auto) minmax(64px, auto)" gap="3">
         <Text color="gray">Name</Text>
         <Text color="gray">Monthly budget</Text>
-        <Text color="gray">Pin</Text>
+        <Box aria-hidden />
       </Grid>
     </Box>
   )
@@ -69,7 +70,13 @@ function CategorySettingsLoadingRows() {
   return (
     <Flex aria-label="loading category settings" direction="column" gap="2">
       <CategorySettingsHeader />
-      <Grid columns={{ initial: "1fr", sm: "1fr minmax(120px, auto) minmax(56px, auto)" }} gap="2">
+      <Grid
+        columns={{
+          initial: "1fr",
+          sm: "1fr minmax(120px, auto) minmax(64px, auto)",
+        }}
+        gap="2"
+      >
         <Skeleton loading>
           <Text>Category name</Text>
         </Skeleton>
@@ -77,7 +84,7 @@ function CategorySettingsLoadingRows() {
           <Text>Monthly budget ￥000,000</Text>
         </Skeleton>
         <Skeleton loading>
-          <Text>Pin</Text>
+          <Text>Edit</Text>
         </Skeleton>
       </Grid>
     </Flex>
@@ -93,12 +100,20 @@ function CategorySettingsRow({ item }: { item: CategorySettingsItem }) {
     <Grid
       align="center"
       aria-label={`${item.category.name} category settings`}
-      columns={{ initial: "1fr", sm: "1fr minmax(120px, auto) minmax(56px, auto)" }}
+      columns={{
+        initial: "1fr",
+        sm: "1fr minmax(120px, auto) minmax(64px, auto)",
+      }}
       gap="2"
     >
-      <Flex align="center" gap="2" justify="between">
-        <Text>{item.category.name}</Text>
-        <Box display={{ initial: "block", sm: "none" }}>{item.pinned && <PinBadge />}</Box>
+      <Flex align="center" gap="3" justify="between">
+        <Flex align="center" gap="2" minWidth="0">
+          <Text>{item.category.name}</Text>
+          {item.pinned && <PinBadge />}
+        </Flex>
+        <Box display={{ initial: "block", sm: "none" }} flexShrink="0">
+          <UpdateCategoryNameModal category={item.category} />
+        </Box>
       </Flex>
       <Flex align="center" gap="3" justify={{ initial: "between", sm: "start" }}>
         <Box display={{ initial: "block", sm: "none" }}>
@@ -108,7 +123,9 @@ function CategorySettingsRow({ item }: { item: CategorySettingsItem }) {
         </Box>
         <Text color={item.latestCategoryBudget ? undefined : "gray"}>{budgetText}</Text>
       </Flex>
-      <Box display={{ initial: "none", sm: "block" }}>{item.pinned && <PinBadge />}</Box>
+      <Flex align="center" display={{ initial: "none", sm: "flex" }}>
+        <UpdateCategoryNameModal category={item.category} />
+      </Flex>
     </Grid>
   )
 }

--- a/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.tsx
+++ b/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.tsx
@@ -106,27 +106,66 @@ function CategorySettingsRow({ item }: { item: CategorySettingsItem }) {
       }}
       gap="2"
     >
-      <Flex align="center" gap="3" justify="between">
-        <Flex align="center" gap="2" minWidth="0">
-          <Text>{item.category.name}</Text>
-          {item.pinned && <PinBadge />}
-        </Flex>
-        <Box display={{ initial: "block", sm: "none" }} flexShrink="0">
-          <UpdateCategoryNameModal category={item.category} />
-        </Box>
-      </Flex>
-      <Flex align="center" gap="3" justify={{ initial: "between", sm: "start" }}>
-        <Box display={{ initial: "block", sm: "none" }}>
-          <Text color="gray" size="2">
-            Monthly budget
-          </Text>
-        </Box>
-        <Text color={item.latestCategoryBudget ? undefined : "gray"}>{budgetText}</Text>
-      </Flex>
-      <Flex align="center" display={{ initial: "none", sm: "flex" }}>
-        <UpdateCategoryNameModal category={item.category} />
-      </Flex>
+      <CategoryNameWithMobileActionCell item={item} />
+      <CategoryBudgetCell item={item} budgetText={budgetText} />
+      <CategoryActionsCell category={item.category} placement="desktop" />
     </Grid>
+  )
+}
+
+function CategoryNameWithMobileActionCell({ item }: { item: CategorySettingsItem }) {
+  return (
+    <Flex align="center" gap="3" justify="between">
+      <CategoryNameCell item={item} />
+      <CategoryActionsCell category={item.category} placement="mobile" />
+    </Flex>
+  )
+}
+
+function CategoryNameCell({ item }: { item: CategorySettingsItem }) {
+  return (
+    <Flex align="center" gap="2" minWidth="0">
+      <Text>{item.category.name}</Text>
+      {item.pinned && <PinBadge />}
+    </Flex>
+  )
+}
+
+function CategoryBudgetCell({
+  item,
+  budgetText,
+}: {
+  item: CategorySettingsItem
+  budgetText: string
+}) {
+  return (
+    <Flex align="center" gap="3" justify={{ initial: "between", sm: "start" }}>
+      <Box display={{ initial: "block", sm: "none" }}>
+        <Text color="gray" size="2">
+          Monthly budget
+        </Text>
+      </Box>
+      <Text color={item.latestCategoryBudget ? undefined : "gray"}>{budgetText}</Text>
+    </Flex>
+  )
+}
+
+function CategoryActionsCell({
+  category,
+  placement,
+}: {
+  category: CategorySettingsItem["category"]
+  placement: "mobile" | "desktop"
+}) {
+  const display =
+    placement === "mobile"
+      ? { initial: "flex" as const, sm: "none" as const }
+      : { initial: "none" as const, sm: "flex" as const }
+
+  return (
+    <Flex align="center" display={display} flexShrink="0">
+      <UpdateCategoryNameModal category={category} />
+    </Flex>
   )
 }
 

--- a/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.stories.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { QueryClientProvider } from "@tanstack/react-query"
+import { fn } from "storybook/test"
+
+import { createQueryClient } from "../../../../lib/queryClient"
+import { ThemeProvider } from "../../../../providers/theme/ThemeProvider"
+import { createCategorySettingsHandlers } from "../../../../test/msw/handlers/categorySettings"
+import { UpdateCategoryNameForm } from "./UpdateCategoryNameForm"
+
+const meta = {
+  title: "Features/Categories/UpdateCategoryNameForm",
+  component: UpdateCategoryNameForm,
+  parameters: {
+    layout: "centered",
+    msw: {
+      handlers: createCategorySettingsHandlers(),
+    },
+  },
+  tags: ["autodocs"],
+  args: {
+    category: {
+      id: 10,
+      name: "Food",
+    },
+    onCancel: fn(),
+    onSuccess: fn(),
+  },
+  decorators: (Story) => {
+    const queryClient = createQueryClient()
+
+    return (
+      <ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      </ThemeProvider>
+    )
+  },
+} satisfies Meta<typeof UpdateCategoryNameForm>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.test.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.test.tsx
@@ -68,6 +68,21 @@ describe("UpdateCategoryNameForm", () => {
     expect(onSuccess).not.toHaveBeenCalled()
   })
 
+  test("空白のみのカテゴリ名は保存前にエラーを表示する", async () => {
+    const onSuccess = fn()
+    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
+    const nameInput = screen.getByRole("textbox", { name: /Name/ })
+
+    await user.clear(nameInput)
+    await user.type(nameInput, "   ")
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    expect(await screen.findByText("Category name cannot be empty")).toBeInTheDocument()
+    expect(nameInput).toHaveAttribute("aria-invalid", "true")
+    expect(nameInput).toHaveAccessibleDescription("Category name cannot be empty")
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
   test("有効なカテゴリ名で保存に成功するとonSuccessを呼ぶ", async () => {
     const onSuccess = fn()
     const { user } = await renderStory(<Default onSuccess={onSuccess} />)

--- a/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.test.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.test.tsx
@@ -37,44 +37,12 @@ describe("UpdateCategoryNameForm", () => {
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
 
-  test("20文字を超えるカテゴリ名は保存前にエラーを表示する", async () => {
-    const onSuccess = fn()
-    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
-    const nameInput = screen.getByRole("textbox", { name: /Name/ })
-
-    await user.clear(nameInput)
-    await user.type(nameInput, "a".repeat(21))
-    await user.click(screen.getByRole("button", { name: "Save" }))
-
-    expect(
-      await screen.findByText("Category name must be 20 characters or less"),
-    ).toBeInTheDocument()
-    expect(nameInput).toHaveAttribute("aria-invalid", "true")
-    expect(nameInput).toHaveAccessibleDescription("Category name must be 20 characters or less")
-    expect(onSuccess).not.toHaveBeenCalled()
-  })
-
   test("空文字のカテゴリ名は保存前にエラーを表示する", async () => {
     const onSuccess = fn()
     const { user } = await renderStory(<Default onSuccess={onSuccess} />)
     const nameInput = screen.getByRole("textbox", { name: /Name/ })
 
     await user.clear(nameInput)
-    await user.click(screen.getByRole("button", { name: "Save" }))
-
-    expect(await screen.findByText("Category name cannot be empty")).toBeInTheDocument()
-    expect(nameInput).toHaveAttribute("aria-invalid", "true")
-    expect(nameInput).toHaveAccessibleDescription("Category name cannot be empty")
-    expect(onSuccess).not.toHaveBeenCalled()
-  })
-
-  test("空白のみのカテゴリ名は保存前にエラーを表示する", async () => {
-    const onSuccess = fn()
-    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
-    const nameInput = screen.getByRole("textbox", { name: /Name/ })
-
-    await user.clear(nameInput)
-    await user.type(nameInput, "   ")
     await user.click(screen.getByRole("button", { name: "Save" }))
 
     expect(await screen.findByText("Category name cannot be empty")).toBeInTheDocument()

--- a/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.test.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.test.tsx
@@ -54,6 +54,20 @@ describe("UpdateCategoryNameForm", () => {
     expect(onSuccess).not.toHaveBeenCalled()
   })
 
+  test("空文字のカテゴリ名は保存前にエラーを表示する", async () => {
+    const onSuccess = fn()
+    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
+    const nameInput = screen.getByRole("textbox", { name: /Name/ })
+
+    await user.clear(nameInput)
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    expect(await screen.findByText("Category name cannot be empty")).toBeInTheDocument()
+    expect(nameInput).toHaveAttribute("aria-invalid", "true")
+    expect(nameInput).toHaveAccessibleDescription("Category name cannot be empty")
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
   test("有効なカテゴリ名で保存に成功するとonSuccessを呼ぶ", async () => {
     const onSuccess = fn()
     const { user } = await renderStory(<Default onSuccess={onSuccess} />)

--- a/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.test.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.test.tsx
@@ -1,0 +1,114 @@
+import { composeStories } from "@storybook/react-vite"
+import type { ReactElement } from "react"
+import { fn } from "storybook/test"
+import { beforeEach, describe, expect, test } from "vite-plus/test"
+
+import { createCategorySettingsHandlers } from "../../../../test/msw/handlers/categorySettings"
+import { server } from "../../../../test/msw/server"
+import { act, render, screen, waitFor } from "../../../../test/test-utils"
+import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../../utils/postgresError"
+import * as stories from "./UpdateCategoryNameForm.stories"
+
+const { Default } = composeStories(stories)
+
+async function renderStory(story: ReactElement) {
+  return await act(async () => {
+    return render(story)
+  })
+}
+
+describe("UpdateCategoryNameForm", () => {
+  beforeEach(() => {
+    server.resetHandlers(...createCategorySettingsHandlers())
+  })
+
+  test("カテゴリ名の初期値を表示する", async () => {
+    await renderStory(<Default />)
+
+    expect(screen.getByRole("textbox", { name: /Name/ })).toHaveValue("Food")
+  })
+
+  test("CancelをクリックするとonCancelを呼ぶ", async () => {
+    const onCancel = fn()
+    const { user } = await renderStory(<Default onCancel={onCancel} />)
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  test("20文字を超えるカテゴリ名は保存前にエラーを表示する", async () => {
+    const onSuccess = fn()
+    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
+    const nameInput = screen.getByRole("textbox", { name: /Name/ })
+
+    await user.clear(nameInput)
+    await user.type(nameInput, "a".repeat(21))
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    expect(
+      await screen.findByText("Category name must be 20 characters or less"),
+    ).toBeInTheDocument()
+    expect(nameInput).toHaveAttribute("aria-invalid", "true")
+    expect(nameInput).toHaveAccessibleDescription("Category name must be 20 characters or less")
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  test("有効なカテゴリ名で保存に成功するとonSuccessを呼ぶ", async () => {
+    const onSuccess = fn()
+    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
+    const nameInput = screen.getByRole("textbox", { name: /Name/ })
+
+    await user.clear(nameInput)
+    await user.type(nameInput, "Groceries")
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  test("カテゴリ名重複時は保存エラーを表示してonSuccessを呼ばない", async () => {
+    server.resetHandlers(
+      ...createCategorySettingsHandlers({
+        update: {
+          error: true,
+          errorResponse: {
+            code: POSTGRES_UNIQUE_VIOLATION_CODE,
+            message: "duplicate key value violates unique constraint",
+          },
+        },
+      }),
+    )
+    const onSuccess = fn()
+    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
+    const nameInput = screen.getByRole("textbox", { name: /Name/ })
+
+    await user.clear(nameInput)
+    await user.type(nameInput, "Daily Necessities")
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    expect(await screen.findByText("A category with this name already exists.")).toBeInTheDocument()
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  test("カテゴリ名保存失敗時は汎用エラーを表示してonSuccessを呼ばない", async () => {
+    server.resetHandlers(
+      ...createCategorySettingsHandlers({
+        update: {
+          error: true,
+        },
+      }),
+    )
+    const onSuccess = fn()
+    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
+    const nameInput = screen.getByRole("textbox", { name: /Name/ })
+
+    await user.clear(nameInput)
+    await user.type(nameInput, "Groceries")
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    expect(await screen.findByText("Failed to update category name.")).toBeInTheDocument()
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.tsx
@@ -1,0 +1,134 @@
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons"
+import { Callout, Flex, TextField } from "@radix-ui/themes"
+import { useForm } from "@tanstack/react-form"
+import { useCallback, useId, useState } from "react"
+import * as z from "zod"
+
+import { CancelButton } from "../../../../components/buttons/CancelButton"
+import { SubmitButton } from "../../../../components/buttons/SubmitButton"
+import { BaseField, FieldLabel, FieldMessages } from "../../../../components/inputs/BaseField"
+import { getErrorMessages } from "../../../../utils/getErrorMessages"
+import { categoryNameSchema } from "../../categorySchema"
+import { toCategoryNameUpdateErrorMessage } from "../categoryNameUpdateError"
+import { useUpdateCategoryName } from "../useUpdateCategoryName"
+
+const updateCategoryNameFormSubmitSchema = z.object({
+  name: categoryNameSchema,
+})
+
+interface UpdateCategoryNameFormValues {
+  name: string
+}
+
+interface UpdateCategoryNameFormProps {
+  category: {
+    id: number
+    name: string
+  }
+  onSuccess?: () => void
+  onCancel: () => void
+}
+
+export function UpdateCategoryNameForm({
+  category,
+  onSuccess,
+  onCancel,
+}: UpdateCategoryNameFormProps) {
+  const nameInputId = useId()
+  const nameErrorId = useId()
+  const { updateCategoryName, isPending } = useUpdateCategoryName()
+  const [submitErrorMessage, setSubmitErrorMessage] = useState<string | undefined>()
+  const defaultValues: UpdateCategoryNameFormValues = {
+    name: category.name,
+  }
+
+  const form = useForm({
+    defaultValues,
+    validators: {
+      onSubmit: updateCategoryNameFormSubmitSchema,
+    },
+    onSubmit: async ({ value }) => {
+      if (isPending) return
+
+      const parsedValue = updateCategoryNameFormSubmitSchema.parse(value)
+
+      try {
+        setSubmitErrorMessage(undefined)
+        await updateCategoryName({
+          categoryId: category.id,
+          name: parsedValue.name,
+        })
+        onSuccess?.()
+      } catch (error) {
+        setSubmitErrorMessage(toCategoryNameUpdateErrorMessage(error))
+      }
+    },
+  })
+
+  const handleCancel = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+      if (isPending) return
+
+      onCancel()
+    },
+    [isPending, onCancel],
+  )
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        setSubmitErrorMessage(undefined)
+        void form.handleSubmit()
+      }}
+    >
+      <Flex direction="column" gap="4">
+        {submitErrorMessage ? (
+          <Callout.Root aria-live="polite" role="alert" color="red" variant="surface" size="1">
+            <Callout.Icon>
+              <ExclamationTriangleIcon />
+            </Callout.Icon>
+            <Callout.Text>{submitErrorMessage}</Callout.Text>
+          </Callout.Root>
+        ) : null}
+        <form.Field name="name">
+          {(field) => {
+            const isValid = field.state.meta.isValid
+            const errorMessages = getErrorMessages(field.state.meta.errors) ?? []
+            const hasError = !isValid && errorMessages.length > 0
+
+            return (
+              <BaseField>
+                <FieldLabel htmlFor={nameInputId} required>
+                  Name
+                </FieldLabel>
+                <TextField.Root
+                  autoFocus
+                  disabled={isPending}
+                  id={nameInputId}
+                  name="name"
+                  value={field.state.value}
+                  aria-describedby={hasError ? nameErrorId : undefined}
+                  aria-invalid={hasError}
+                  onChange={(event) => {
+                    field.handleChange(event.target.value)
+                    setSubmitErrorMessage(undefined)
+                  }}
+                />
+                <span id={nameErrorId}>
+                  <FieldMessages error={!isValid} messages={errorMessages} />
+                </span>
+              </BaseField>
+            )
+          }}
+        </form.Field>
+        <Flex gap="3" justify="end">
+          <CancelButton disabled={isPending} onClick={handleCancel} />
+          <SubmitButton loading={isPending}>Save</SubmitButton>
+        </Flex>
+      </Flex>
+    </form>
+  )
+}

--- a/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/index.ts
+++ b/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/index.ts
@@ -1,0 +1,1 @@
+export { UpdateCategoryNameForm } from "./UpdateCategoryNameForm"

--- a/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameModal/UpdateCategoryNameModal.stories.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameModal/UpdateCategoryNameModal.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { QueryClientProvider } from "@tanstack/react-query"
+
+import { createQueryClient } from "../../../../lib/queryClient"
+import { ThemeProvider } from "../../../../providers/theme/ThemeProvider"
+import { createCategorySettingsHandlers } from "../../../../test/msw/handlers/categorySettings"
+import { UpdateCategoryNameModal } from "./UpdateCategoryNameModal"
+
+const meta = {
+  title: "Features/Categories/UpdateCategoryNameModal",
+  component: UpdateCategoryNameModal,
+  parameters: {
+    layout: "centered",
+    msw: {
+      handlers: createCategorySettingsHandlers(),
+    },
+  },
+  tags: ["autodocs"],
+  args: {
+    category: {
+      id: 10,
+      name: "Food",
+    },
+  },
+  decorators: (Story) => {
+    const queryClient = createQueryClient()
+
+    return (
+      <ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      </ThemeProvider>
+    )
+  },
+} satisfies Meta<typeof UpdateCategoryNameModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameModal/UpdateCategoryNameModal.test.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameModal/UpdateCategoryNameModal.test.tsx
@@ -1,0 +1,85 @@
+import { composeStories } from "@storybook/react-vite"
+import type { ReactElement } from "react"
+import { beforeEach, describe, expect, test } from "vite-plus/test"
+
+import { createCategorySettingsHandlers } from "../../../../test/msw/handlers/categorySettings"
+import { server } from "../../../../test/msw/server"
+import { act, fireEvent, render, screen, waitFor, within } from "../../../../test/test-utils"
+import * as stories from "./UpdateCategoryNameModal.stories"
+
+const { Default } = composeStories(stories)
+
+async function renderStory(story: ReactElement) {
+  return await act(async () => {
+    return render(story)
+  })
+}
+
+async function openUpdateCategoryNameModal() {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /edit food category name/i }))
+  })
+
+  return await screen.findByRole("dialog", { name: "Edit category" })
+}
+
+describe("UpdateCategoryNameModal", () => {
+  beforeEach(() => {
+    server.resetHandlers(...createCategorySettingsHandlers())
+  })
+
+  test("トリガー操作でダイアログとフォームを表示する", async () => {
+    await renderStory(<Default />)
+
+    const dialog = await openUpdateCategoryNameModal()
+
+    expect(dialog).toBeInTheDocument()
+    expect(within(dialog).getByText("Update the category name.")).toBeInTheDocument()
+    expect(within(dialog).getByRole("textbox", { name: /Name/ })).toHaveValue("Food")
+  })
+
+  test("Cancelをクリックするとダイアログを閉じる", async () => {
+    const { user } = await renderStory(<Default />)
+
+    await openUpdateCategoryNameModal()
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+
+    expect(screen.queryByRole("dialog", { name: "Edit category" })).not.toBeInTheDocument()
+  })
+
+  test("保存成功後にダイアログを閉じる", async () => {
+    const { user } = await renderStory(<Default />)
+
+    const dialog = await openUpdateCategoryNameModal()
+    const nameInput = within(dialog).getByRole("textbox", { name: /Name/ })
+
+    await user.clear(nameInput)
+    await user.type(nameInput, "Groceries")
+    await user.click(within(dialog).getByRole("button", { name: "Save" }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Edit category" })).not.toBeInTheDocument()
+    })
+  })
+
+  test("保存失敗時はダイアログを閉じない", async () => {
+    server.resetHandlers(
+      ...createCategorySettingsHandlers({
+        update: {
+          error: true,
+        },
+      }),
+    )
+    const { user } = await renderStory(<Default />)
+
+    const dialog = await openUpdateCategoryNameModal()
+    const nameInput = within(dialog).getByRole("textbox", { name: /Name/ })
+
+    await user.clear(nameInput)
+    await user.type(nameInput, "Groceries")
+    await user.click(within(dialog).getByRole("button", { name: "Save" }))
+
+    expect(await within(dialog).findByText("Failed to update category name.")).toBeInTheDocument()
+    expect(screen.getByRole("dialog", { name: "Edit category" })).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameModal/UpdateCategoryNameModal.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameModal/UpdateCategoryNameModal.tsx
@@ -1,0 +1,52 @@
+import { Pencil1Icon } from "@radix-ui/react-icons"
+import { Button } from "@radix-ui/themes"
+import { useCallback, type ReactElement } from "react"
+
+import { ResponsiveOverlay } from "../../../../components/overlay/ResponsiveOverlay"
+import { useDialog } from "../../../../utils/useDialog"
+import { UpdateCategoryNameForm } from "../UpdateCategoryNameForm"
+
+interface UpdateCategoryNameModalProps {
+  category: {
+    id: number
+    name: string
+  }
+  trigger?: ReactElement
+}
+
+export function UpdateCategoryNameModal({
+  category,
+  trigger = (
+    <Button aria-label={`Edit ${category.name} category name`} size="1" variant="ghost">
+      <Pencil1Icon aria-hidden />
+      Edit
+    </Button>
+  ),
+}: UpdateCategoryNameModalProps) {
+  const { open, closeDialog, onOpenChange } = useDialog()
+
+  const handleSuccess = useCallback(() => {
+    closeDialog()
+  }, [closeDialog])
+
+  const handleCancel = useCallback(() => {
+    closeDialog()
+  }, [closeDialog])
+
+  return (
+    <ResponsiveOverlay
+      open={open}
+      onOpenChange={onOpenChange}
+      dismissible={false}
+      trigger={trigger}
+      title="Edit category"
+      description="Update the category name."
+    >
+      <UpdateCategoryNameForm
+        category={category}
+        onSuccess={handleSuccess}
+        onCancel={handleCancel}
+      />
+    </ResponsiveOverlay>
+  )
+}

--- a/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameModal/index.ts
+++ b/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameModal/index.ts
@@ -1,0 +1,1 @@
+export { UpdateCategoryNameModal } from "./UpdateCategoryNameModal"

--- a/apps/web/src/features/categories/updateCategoryName/categoryNameUpdateError.test.ts
+++ b/apps/web/src/features/categories/updateCategoryName/categoryNameUpdateError.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vite-plus/test"
+
+import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../utils/postgresError"
+import { toCategoryNameUpdateErrorMessage } from "./categoryNameUpdateError"
+
+describe("toCategoryNameUpdateErrorMessage", () => {
+  test("PostgreSQL unique_violationは重複カテゴリ名メッセージに変換する", () => {
+    expect(
+      toCategoryNameUpdateErrorMessage({
+        code: POSTGRES_UNIQUE_VIOLATION_CODE,
+        message: "duplicate key value violates unique constraint",
+      }),
+    ).toBe("A category with this name already exists.")
+  })
+
+  test("その他のエラーは汎用メッセージに変換する", () => {
+    expect(toCategoryNameUpdateErrorMessage({ message: "network error" })).toBe(
+      "Failed to update category name.",
+    )
+  })
+})

--- a/apps/web/src/features/categories/updateCategoryName/categoryNameUpdateError.ts
+++ b/apps/web/src/features/categories/updateCategoryName/categoryNameUpdateError.ts
@@ -1,0 +1,12 @@
+import { isPostgresUniqueViolationError } from "../../../utils/postgresError"
+
+const DUPLICATE_CATEGORY_NAME_MESSAGE = "A category with this name already exists."
+const GENERIC_UPDATE_CATEGORY_NAME_MESSAGE = "Failed to update category name."
+
+export function toCategoryNameUpdateErrorMessage(error: unknown): string {
+  if (isPostgresUniqueViolationError(error)) {
+    return DUPLICATE_CATEGORY_NAME_MESSAGE
+  }
+
+  return GENERIC_UPDATE_CATEGORY_NAME_MESSAGE
+}

--- a/apps/web/src/features/categories/updateCategoryName/categoryNameUpdateMappers.test.ts
+++ b/apps/web/src/features/categories/updateCategoryName/categoryNameUpdateMappers.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "vite-plus/test"
+
+import { toCategoryNameUpdate } from "./categoryNameUpdateMappers"
+
+describe("toCategoryNameUpdate", () => {
+  test("カテゴリ名更新payloadに変換する", () => {
+    expect(toCategoryNameUpdate({ categoryId: 10, name: "Groceries" })).toEqual({
+      name: "Groceries",
+    })
+  })
+})

--- a/apps/web/src/features/categories/updateCategoryName/categoryNameUpdateMappers.ts
+++ b/apps/web/src/features/categories/updateCategoryName/categoryNameUpdateMappers.ts
@@ -1,0 +1,14 @@
+import type { TablesUpdate } from "../../../types/database.types"
+
+export interface CategoryNameUpdateInput {
+  categoryId: number
+  name: string
+}
+
+export type CategoryNameUpdate = Pick<TablesUpdate<"categories">, "name">
+
+export function toCategoryNameUpdate(value: CategoryNameUpdateInput): CategoryNameUpdate {
+  return {
+    name: value.name,
+  }
+}

--- a/apps/web/src/features/categories/updateCategoryName/updateCategoryName.test.ts
+++ b/apps/web/src/features/categories/updateCategoryName/updateCategoryName.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { updateCategoryName } from "./updateCategoryName"
+
+const mockSingle = vi.fn()
+const mockSelect = vi.fn(() => ({ single: mockSingle }))
+const mockEq = vi.fn()
+const mockUpdate = vi.fn(() => ({ eq: mockEq }))
+const mockFrom = vi.fn(() => ({ update: mockUpdate }))
+
+vi.mock("../../../lib/supabase", () => ({
+  getSupabaseClient: () => ({ from: mockFrom }),
+}))
+
+describe("updateCategoryName", () => {
+  beforeEach(() => {
+    mockEq.mockReset()
+    mockSelect.mockClear()
+    mockSingle.mockReset()
+    mockFrom.mockClear()
+    mockUpdate.mockClear()
+  })
+
+  it("categoriesテーブルの指定IDレコードのnameを更新する", async () => {
+    mockEq.mockReturnValue({ select: mockSelect })
+    mockSingle.mockResolvedValue({ data: { id: 10 }, error: null })
+
+    await updateCategoryName({
+      categoryId: 10,
+      name: "Groceries",
+    })
+
+    expect(mockFrom).toHaveBeenCalledWith("categories")
+    expect(mockUpdate).toHaveBeenCalledWith({
+      name: "Groceries",
+    })
+    expect(mockEq).toHaveBeenCalledWith("id", 10)
+    expect(mockSelect).toHaveBeenCalledWith("id")
+    expect(mockSingle).toHaveBeenCalledTimes(1)
+  })
+
+  it("Supabaseがエラーを返した場合にthrowする", async () => {
+    const supabaseError = { message: "更新に失敗しました", code: "42501" }
+    mockEq.mockReturnValue({ select: mockSelect })
+    mockSingle.mockResolvedValue({ data: null, error: supabaseError })
+
+    await expect(
+      updateCategoryName({
+        categoryId: 10,
+        name: "Groceries",
+      }),
+    ).rejects.toEqual(supabaseError)
+  })
+
+  it("更新対象が返らない場合にthrowする", async () => {
+    mockEq.mockReturnValue({ select: mockSelect })
+    mockSingle.mockResolvedValue({ data: null, error: null })
+
+    await expect(
+      updateCategoryName({
+        categoryId: 999,
+        name: "Groceries",
+      }),
+    ).rejects.toThrow("Category was not updated.")
+  })
+})

--- a/apps/web/src/features/categories/updateCategoryName/updateCategoryName.ts
+++ b/apps/web/src/features/categories/updateCategoryName/updateCategoryName.ts
@@ -1,0 +1,21 @@
+import { getSupabaseClient } from "../../../lib/supabase"
+import { type CategoryNameUpdateInput, toCategoryNameUpdate } from "./categoryNameUpdateMappers"
+
+export async function updateCategoryName(value: CategoryNameUpdateInput): Promise<void> {
+  const supabase = getSupabaseClient()
+  const payload = toCategoryNameUpdate(value)
+  const { data, error } = await supabase
+    .from("categories")
+    .update(payload)
+    .eq("id", value.categoryId)
+    .select("id")
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  if (!data) {
+    throw new Error("Category was not updated.")
+  }
+}

--- a/apps/web/src/features/categories/updateCategoryName/useUpdateCategoryName.test.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/useUpdateCategoryName.test.tsx
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { act, createTestQueryClient, renderHook } from "../../../test/test-utils"
+import { useUpdateCategoryName } from "./useUpdateCategoryName"
+
+const { mockUpdateCategoryName } = vi.hoisted(() => ({
+  mockUpdateCategoryName: vi.fn(),
+}))
+
+vi.mock("./updateCategoryName", () => ({
+  updateCategoryName: mockUpdateCategoryName,
+}))
+
+describe("useUpdateCategoryName", () => {
+  beforeEach(() => {
+    mockUpdateCategoryName.mockReset()
+  })
+
+  it("成功時にカテゴリ設定一覧queryをinvalidateしてresolveする", async () => {
+    const queryClient = createTestQueryClient()
+    const invalidateQueries = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined)
+    const input = {
+      categoryId: 10,
+      name: "Groceries",
+    }
+    mockUpdateCategoryName.mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useUpdateCategoryName(), {
+      queryClient,
+    })
+
+    await act(async () => {
+      const promise = result.current.updateCategoryName(input)
+
+      expect(promise).toBeInstanceOf(Promise)
+      await promise
+    })
+
+    expect(mockUpdateCategoryName).toHaveBeenCalledTimes(1)
+    expect(mockUpdateCategoryName.mock.calls[0]?.[0]).toBe(input)
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["categorySettingsItems"] })
+    expect(invalidateQueries).toHaveBeenCalledTimes(1)
+  })
+
+  it("失敗時にqueryをinvalidateせずrejectする", async () => {
+    const queryClient = createTestQueryClient()
+    const invalidateQueries = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined)
+    const error = { message: "更新に失敗しました", code: "42501" }
+    mockUpdateCategoryName.mockRejectedValue(error)
+
+    const { result } = renderHook(() => useUpdateCategoryName(), {
+      queryClient,
+    })
+
+    await act(async () => {
+      await expect(
+        result.current.updateCategoryName({
+          categoryId: 10,
+          name: "Groceries",
+        }),
+      ).rejects.toEqual(error)
+    })
+
+    expect(invalidateQueries).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/categories/updateCategoryName/useUpdateCategoryName.ts
+++ b/apps/web/src/features/categories/updateCategoryName/useUpdateCategoryName.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useCallback } from "react"
+
+import type { CategoryNameUpdateInput } from "./categoryNameUpdateMappers"
+import { updateCategoryName as updateCategoryNameRecord } from "./updateCategoryName"
+
+interface UseUpdateCategoryNameReturn {
+  updateCategoryName: (value: CategoryNameUpdateInput) => Promise<void>
+  isPending: boolean
+}
+
+export function useUpdateCategoryName(): UseUpdateCategoryNameReturn {
+  const queryClient = useQueryClient()
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: updateCategoryNameRecord,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["categorySettingsItems"] })
+    },
+  })
+
+  const updateCategoryName = useCallback(
+    async (value: CategoryNameUpdateInput) => {
+      return mutateAsync(value)
+    },
+    [mutateAsync],
+  )
+
+  return { updateCategoryName, isPending }
+}

--- a/apps/web/src/test/msw/handlers/categorySettings.ts
+++ b/apps/web/src/test/msw/handlers/categorySettings.ts
@@ -1,4 +1,5 @@
 import { type DelayMode, HttpResponse, delay, http } from "msw"
+import * as z from "zod"
 
 import { allCategories } from "../../data/categories"
 import { categoryBudgets } from "../../data/categoryBudgets"
@@ -35,13 +36,28 @@ interface GetCategorySettingsOptions {
   durationOrMode?: number | DelayMode | undefined
 }
 
+interface UpdateCategorySettingsOptions {
+  error?: boolean
+  errorResponse?: unknown
+  durationOrMode?: number | DelayMode | undefined
+}
+
+const updateCategoryNameBodySchema = z.object({
+  name: z.string(),
+})
+
+type UpdateCategoryNameBody = z.infer<typeof updateCategoryNameBodySchema>
+
 export function createCategorySettingsHandlers({
   response,
   currentBookId = CURRENT_BOOK_ID,
   pinnedCategoryIds = [10],
   error = false,
   durationOrMode,
-}: GetCategorySettingsOptions = {}) {
+  update = {},
+}: GetCategorySettingsOptions & { update?: UpdateCategorySettingsOptions } = {}) {
+  let rows = response ?? buildCategorySettingsResponse(currentBookId, pinnedCategoryIds)
+
   return [
     http.get(REST_URL, async () => {
       await delay(durationOrMode)
@@ -50,9 +66,28 @@ export function createCategorySettingsHandlers({
         return HttpResponse.json({ message: "Failed to fetch category settings." }, { status: 500 })
       }
 
-      return HttpResponse.json(
-        response ?? buildCategorySettingsResponse(currentBookId, pinnedCategoryIds),
-      )
+      return HttpResponse.json(rows)
+    }),
+    http.patch(REST_URL, async ({ request }) => {
+      await delay(update.durationOrMode)
+
+      if (update.error) {
+        return HttpResponse.json(
+          update.errorResponse ?? { message: "Failed to update category name." },
+          { status: 500 },
+        )
+      }
+
+      const body = await request.json()
+      const parsedBody = updateCategoryNameBodySchema.parse(body)
+      const id = parseUpdateCategoryId(request.url)
+      const updatedRow = buildUpdatedCategorySettingsRow(id, parsedBody, rows)
+
+      if (updatedRow) {
+        rows = rows.map((row) => (row.id === updatedRow.id ? updatedRow : row))
+      }
+
+      return HttpResponse.json(updatedRow ? { id: updatedRow.id } : null)
     }),
   ]
 }
@@ -93,6 +128,35 @@ function buildCategorySettingsResponse(
           ]
         : [],
     }))
+}
+
+function parseUpdateCategoryId(url: string): number | undefined {
+  const idParam = new URL(url).searchParams.get("id")
+
+  if (!idParam?.startsWith("eq.")) {
+    return undefined
+  }
+
+  const id = Number(idParam.slice(3))
+
+  return Number.isInteger(id) ? id : undefined
+}
+
+function buildUpdatedCategorySettingsRow(
+  id: number | undefined,
+  body: UpdateCategoryNameBody,
+  rows: CategorySettingsResponseRow[],
+): CategorySettingsResponseRow | undefined {
+  const row = rows.find((category) => category.id === id)
+
+  if (!row) {
+    return undefined
+  }
+
+  return {
+    ...row,
+    name: body.name,
+  }
 }
 
 export const categorySettingsHandlers = createCategorySettingsHandlers()


### PR DESCRIPTION
## 関連Issue

- close #1287

## 変更内容

- Book設定のカテゴリ一覧からカテゴリ名を編集できるフォーム/モーダルを追加
- 空文字と20文字超過の保存前validation、重複/汎用保存失敗表示、Story経由テストを追加
- 保存成功後はcategorySettingsItemsのみinvalidateし、Settings一覧を再取得
- Codex環境で生成される.pnpm-store/をGit管理外に追加

## 動作確認

- [ ] ローカルでの動作確認
- [x] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

- #1288 のカテゴリ名編集UIの内容は #1287 に統合済みです。
- 今回はSettings画面のカテゴリ名変更に範囲を限定しています。支払い一覧のカテゴリ取得、useCategories、支払い詳細、カテゴリ別予算のcache方針は変更していません。
