### PR TITLE
zizmorでGitHub Actions定義を検査する

### DIFF
--- a/.github/actions/setup-playwright/action.yaml
+++ b/.github/actions/setup-playwright/action.yaml
@@ -9,13 +9,17 @@ runs:
   using: "composite"
   steps:
     - name: Show project-directory
-      run: echo "project-directory=${{ inputs.project-directory }}"
+      env:
+        PROJECT_DIRECTORY: ${{ inputs.project-directory }}
+      run: echo "project-directory=$PROJECT_DIRECTORY"
       shell: bash
 
     - name: Get Playwright version from node_modules
       id: get_version
+      env:
+        PROJECT_DIRECTORY: ${{ inputs.project-directory }}
       run: |
-        cd "${{ inputs.project-directory }}"
+        cd "$PROJECT_DIRECTORY"
         VERSION=$(pnpm exec playwright --version | head -n1 | awk '{print $NF}')
         echo "playwright_version=$VERSION" >> $GITHUB_OUTPUT
       shell: bash
@@ -33,8 +37,10 @@ runs:
 
     - name: Install Playwright
       if: steps.playwright-cache.outputs.cache-hit != 'true'
+      env:
+        PROJECT_DIRECTORY: ${{ inputs.project-directory }}
       run: |
         set -euo pipefail
-        cd "${{ inputs.project-directory }}"
+        cd "$PROJECT_DIRECTORY"
         pnpm exec playwright install --with-deps chromium
       shell: bash

--- a/.github/workflows/cache_main.yaml
+++ b/.github/workflows/cache_main.yaml
@@ -5,12 +5,17 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   warm-pnpm-and-playwright-caches:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -60,6 +60,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "package.json"
+          package-manager-cache: false
 
       - name: Install deps and build
         run: |

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -3,15 +3,15 @@ name: Deploy Production
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
-  deployments: write
+permissions: {}
 
 jobs:
   # --- Backend (Supabase) のデプロイ ---
   deploy-api:
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: read
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       AUTH_SITE_URL: ${{ secrets.AUTH_SITE_URL }}
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@df56b21da46c98abb12a9804e4fb1f657773e333 # v2.0.0
@@ -40,9 +42,14 @@ jobs:
     needs: deploy-api
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      contents: read
+      deployments: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
@@ -53,8 +60,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "package.json"
-          cache: "pnpm"
-          cache-dependency-path: "pnpm-lock.yaml"
 
       - name: Install deps and build
         run: |

--- a/.github/workflows/frontend_ci.yaml
+++ b/.github/workflows/frontend_ci.yaml
@@ -11,11 +11,16 @@ on:
       - "apps/web/**"
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   lint-format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
@@ -42,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
@@ -69,6 +76,8 @@ jobs:
         shard: ["1/2", "2/2"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
@@ -94,6 +103,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6

--- a/.github/workflows/github_actions_security.yaml
+++ b/.github/workflows/github_actions_security.yaml
@@ -1,0 +1,33 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+    types: [opened, synchronize]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b572f7b1a1c2d41efaab43d504f68d215c3cd727 # v0.5.4
+        with:
+          advanced-security: false


### PR DESCRIPTION
## 変更内容

- GitHub Actions / local actions 定義変更時に zizmor を実行する workflow を追加
- `advanced-security: false` で通常の PR check failure として扱う構成にした
- 既存 workflow/action の zizmor findings に対応し、権限・checkout・cache 設定を調整

## 動作確認

- [x] `git diff --check`
- [x] GitHub Actions: `zizmor`
- [x] GitHub Actions: `Frontend CI`