### PR TITLE
カテゴリ作成用のRLSを追加する

### DIFF
--- a/apps/api/supabase/migrations/20260520000000_add_category_insert_policy.sql
+++ b/apps/api/supabase/migrations/20260520000000_add_category_insert_policy.sql
@@ -1,0 +1,11 @@
+create policy "Users can insert member book categories"
+  on categories for insert
+  to authenticated
+  with check (
+    exists (
+      select 1
+      from book_members
+      where book_members.book_id = categories.book_id
+        and book_members.user_id = get_authenticated_user_id()
+    )
+  );


### PR DESCRIPTION
## 関連Issue

- closes #1283

## 変更内容

- `categories` に所属 Book の member だけが insert できる RLS policy を追加
- Book 内カテゴリ名の一意性は既存の `categories_book_name_key` を利用

## 動作確認

- [x] `SUPABASE_GOOGLE_SKIP_NONCE_CHECK=false supabase migration up`
- [x] `SUPABASE_GOOGLE_SKIP_NONCE_CHECK=false supabase gen types typescript --local --schema public`
- [x] 所属 Book への insert 成功と非所属 Book への insert RLS 拒否を psql で確認
- [x] `pnpm run web:typecheck`