### PR TITLE
カテゴリquery keyを整理する

### DIFF
--- a/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
@@ -3,6 +3,7 @@ import { createRoute } from "@tanstack/react-router"
 import { HttpResponse, http } from "msw"
 import { afterEach, beforeEach, describe, expect, test, vi } from "vite-plus/test"
 
+import { categoryQueryKeys } from "../../../features/categories/queryKeys"
 import {
   PAYMENT_SEARCH_CATEGORY_NONE_VALUE,
   paymentsSearchSchema,
@@ -75,7 +76,7 @@ function renderStory() {
 
 function renderPaymentsPageRoute(initialEntry: string) {
   const queryClient = createTestQueryClient()
-  queryClient.setQueryData(["categories"], categories)
+  queryClient.setQueryData(categoryQueryKeys.list, categories)
   queryClient.setQueryData(
     ["payments", currentMonthPaymentsQueryDate, `category-${foodCat.id}`],
     initialCurrentMonthPaymentRows.filter((payment) => payment.category_id === foodCat.id),

--- a/apps/web/src/features/categories/listCategory/useCategories.ts
+++ b/apps/web/src/features/categories/listCategory/useCategories.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 
 import type { Category } from "../../../types/category"
+import { categoryQueryKeys } from "../queryKeys"
 import { fetchCategories } from "./fetchCategories"
 
 interface UseCategoriesReturn {
@@ -12,7 +13,7 @@ interface UseCategoriesReturn {
 
 export function useCategories(): UseCategoriesReturn {
   const query = useQuery({
-    queryKey: ["categories"],
+    queryKey: categoryQueryKeys.list,
     queryFn: async () => fetchCategories(),
     // データを無期限に新鮮（fresh）扱いにすることで、同じ queryKey で
     // コンポーネントがマウントしても React Query が自動で再フェッチしません。

--- a/apps/web/src/features/categories/listCategorySettings/useCategorySettingsItems.ts
+++ b/apps/web/src/features/categories/listCategorySettings/useCategorySettingsItems.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 
+import { categoryQueryKeys } from "../queryKeys"
 import { fetchCategorySettingsItems } from "./fetchCategorySettingsItems"
 import type { CategorySettingsItem } from "./types"
 
@@ -9,7 +10,7 @@ interface UseCategorySettingsItemsReturn {
 
 export function useCategorySettingsItems(): UseCategorySettingsItemsReturn {
   const query = useQuery({
-    queryKey: ["categorySettingsItems"],
+    queryKey: categoryQueryKeys.settingsItems,
     queryFn: async () => fetchCategorySettingsItems(),
     staleTime: 3000,
   })

--- a/apps/web/src/features/categories/queryKeys.ts
+++ b/apps/web/src/features/categories/queryKeys.ts
@@ -1,0 +1,11 @@
+import type { QueryClient } from "@tanstack/react-query"
+
+export const categoryQueryKeys = {
+  all: ["categories"],
+  list: ["categories", "list"],
+  settingsItems: ["categories", "settingsItems"],
+} as const
+
+export async function invalidateCategoryQueries(queryClient: QueryClient): Promise<void> {
+  await queryClient.invalidateQueries({ queryKey: categoryQueryKeys.all })
+}

--- a/apps/web/src/features/categories/updateCategoryName/useUpdateCategoryName.test.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/useUpdateCategoryName.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import { act, createTestQueryClient, renderHook } from "../../../test/test-utils"
+import { categoryQueryKeys } from "../queryKeys"
 import { useUpdateCategoryName } from "./useUpdateCategoryName"
 
 const { mockUpdateCategoryName } = vi.hoisted(() => ({
@@ -16,7 +17,7 @@ describe("useUpdateCategoryName", () => {
     mockUpdateCategoryName.mockReset()
   })
 
-  it("成功時にカテゴリ設定一覧queryをinvalidateしてresolveする", async () => {
+  it("成功時にカテゴリqueryをinvalidateしてresolveする", async () => {
     const queryClient = createTestQueryClient()
     const invalidateQueries = vi
       .spyOn(queryClient, "invalidateQueries")
@@ -40,7 +41,7 @@ describe("useUpdateCategoryName", () => {
 
     expect(mockUpdateCategoryName).toHaveBeenCalledTimes(1)
     expect(mockUpdateCategoryName.mock.calls[0]?.[0]).toBe(input)
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["categorySettingsItems"] })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: categoryQueryKeys.all })
     expect(invalidateQueries).toHaveBeenCalledTimes(1)
   })
 

--- a/apps/web/src/features/categories/updateCategoryName/useUpdateCategoryName.ts
+++ b/apps/web/src/features/categories/updateCategoryName/useUpdateCategoryName.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
+import { invalidateCategoryQueries } from "../queryKeys"
 import type { CategoryNameUpdateInput } from "./categoryNameUpdateMappers"
 import { updateCategoryName as updateCategoryNameRecord } from "./updateCategoryName"
 
@@ -15,7 +16,7 @@ export function useUpdateCategoryName(): UseUpdateCategoryNameReturn {
   const { mutateAsync, isPending } = useMutation({
     mutationFn: updateCategoryNameRecord,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["categorySettingsItems"] })
+      await invalidateCategoryQueries(queryClient)
     },
   })
 

--- a/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/PaymentCategoryFilter.test.tsx
+++ b/apps/web/src/features/payments/listPayment/PaymentCategoryFilter/PaymentCategoryFilter.test.tsx
@@ -13,6 +13,7 @@ import {
   waitFor,
   within,
 } from "../../../../test/test-utils"
+import { categoryQueryKeys } from "../../../categories/queryKeys"
 import { PAYMENT_SEARCH_CATEGORY_NONE_VALUE, paymentsSearchSchema } from "../paymentsSearchSchema"
 import { PaymentCategoryFilter } from "./PaymentCategoryFilter"
 
@@ -22,7 +23,7 @@ function renderPaymentCategoryFilter(
 ) {
   const queryClient = createTestQueryClient()
   if (cacheCategories) {
-    queryClient.setQueryData(["categories"], categories)
+    queryClient.setQueryData(categoryQueryKeys.list, categories)
   }
 
   return renderWithRouter(


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- カテゴリ関連の query key を `categories` namespace に整理
- カテゴリ名更新時の invalidate をカテゴリドメインの helper 経由に統一
- 新しいカテゴリ一覧 key に合わせて関連テストの seed を更新

## 動作確認

- [ ] ローカルでの動作確認
- [x] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

- UI 表示や API/DB の変更はありません
- 検証: `pnpm run web:lint`, `pnpm run web:format-check`, `pnpm run web:typecheck`, `pnpm --filter web test:unit`, `pnpm --filter web test:integration`, `pnpm --filter web test:storybook`