### PR TITLE
カテゴリ作成RPCとmutationを追加する

### DIFF
--- a/apps/api/supabase/migrations/20260523000000_create_category_with_budget_function.sql
+++ b/apps/api/supabase/migrations/20260523000000_create_category_with_budget_function.sql
@@ -1,0 +1,44 @@
+create or replace function create_category_with_budget(
+  p_category_name text,
+  p_budget_effective_from date default null,
+  p_budget_amount integer default null
+)
+returns bigint as $$
+declare
+  authenticated_default_book_id bigint;
+  created_category_id bigint;
+begin
+  if (p_budget_effective_from is null) <> (p_budget_amount is null) then
+    raise exception 'Category budget requires both month and amount.'
+      using errcode = '22023';
+  end if;
+
+  authenticated_default_book_id := get_authenticated_default_book_id();
+
+  insert into categories (book_id, name)
+  values (authenticated_default_book_id, p_category_name)
+  returning id into created_category_id;
+
+  if p_budget_effective_from is not null then
+    insert into category_budgets (
+      book_id,
+      category_id,
+      effective_from,
+      amount
+    )
+    values (
+      authenticated_default_book_id,
+      created_category_id,
+      p_budget_effective_from,
+      p_budget_amount
+    );
+  end if;
+
+  return created_category_id;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+revoke all on function public.create_category_with_budget(text, date, integer) from public;
+revoke all on function public.create_category_with_budget(text, date, integer) from anon;
+grant execute on function public.create_category_with_budget(text, date, integer) to authenticated;
+grant execute on function public.create_category_with_budget(text, date, integer) to service_role;

--- a/apps/web/src/features/categories/createCategory/categoryCreateMappers.test.ts
+++ b/apps/web/src/features/categories/createCategory/categoryCreateMappers.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test, vi } from "vite-plus/test"
+
+import {
+  mapCategoryCreateValuesToCategoryCreateInput,
+  toCategoryCreateRpcArgs,
+} from "./categoryCreateMappers"
+
+describe("mapCategoryCreateValuesToCategoryCreateInput", () => {
+  test("カテゴリ名だけの作成入力に変換する", () => {
+    expect(
+      mapCategoryCreateValuesToCategoryCreateInput({
+        name: "Groceries",
+        budgetAmount: undefined,
+      }),
+    ).toEqual({
+      name: "Groceries",
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test("月予算金額つきの場合は今月月初を補完する", () => {
+    const march20 = new Date(2026, 2, 20, 12, 34, 56)
+    const march1 = new Date(2026, 2, 1)
+
+    vi.useFakeTimers()
+    vi.setSystemTime(march20)
+
+    expect(
+      mapCategoryCreateValuesToCategoryCreateInput({
+        name: "Groceries",
+        budgetAmount: 50000,
+      }),
+    ).toEqual({
+      name: "Groceries",
+      budget: {
+        targetMonth: march1,
+        amount: 50000,
+      },
+    })
+  })
+})
+
+describe("toCategoryCreateRpcArgs", () => {
+  test("月予算なしの場合は予算引数を省略する", () => {
+    expect(toCategoryCreateRpcArgs({ name: "Groceries" })).toEqual({
+      p_category_name: "Groceries",
+    })
+  })
+
+  test("月予算ありの場合は月初日のRPC引数に変換する", () => {
+    const march20 = new Date(2026, 2, 20)
+
+    expect(
+      toCategoryCreateRpcArgs({
+        name: "Groceries",
+        budget: {
+          targetMonth: march20,
+          amount: 50000,
+        },
+      }),
+    ).toEqual({
+      p_category_name: "Groceries",
+      p_budget_effective_from: "2026-03-01",
+      p_budget_amount: 50000,
+    })
+  })
+})

--- a/apps/web/src/features/categories/createCategory/categoryCreateMappers.ts
+++ b/apps/web/src/features/categories/createCategory/categoryCreateMappers.ts
@@ -1,0 +1,52 @@
+import { format } from "date-fns"
+
+import type { CategoryCreateValues } from "./categoryCreateSchema"
+
+export interface CategoryCreateInput {
+  name: string
+  budget?: {
+    targetMonth: Date
+    amount: number
+  }
+}
+
+export interface CategoryCreateRpcArgs {
+  p_category_name: string
+  p_budget_effective_from?: string
+  p_budget_amount?: number
+}
+
+function toMonthStartDate(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), 1)
+}
+
+export function mapCategoryCreateValuesToCategoryCreateInput(
+  value: CategoryCreateValues,
+): CategoryCreateInput {
+  if (value.budgetAmount !== undefined) {
+    return {
+      name: value.name,
+      budget: {
+        targetMonth: toMonthStartDate(new Date()),
+        amount: value.budgetAmount,
+      },
+    }
+  }
+
+  return {
+    name: value.name,
+  }
+}
+
+export function toCategoryCreateRpcArgs(value: CategoryCreateInput): CategoryCreateRpcArgs {
+  const args: CategoryCreateRpcArgs = {
+    p_category_name: value.name,
+  }
+
+  if (value.budget) {
+    args.p_budget_effective_from = format(toMonthStartDate(value.budget.targetMonth), "yyyy-MM-dd")
+    args.p_budget_amount = value.budget.amount
+  }
+
+  return args
+}

--- a/apps/web/src/features/categories/createCategory/categoryCreateSchema.test.ts
+++ b/apps/web/src/features/categories/createCategory/categoryCreateSchema.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vite-plus/test"
+import z from "zod"
+
+import { CATEGORY_NAME_MAX_LENGTH } from "../categorySchema"
+import { categoryCreateSchema } from "./categoryCreateSchema"
+
+describe("categoryCreateSchema", () => {
+  test("カテゴリ名だけで作成できる", () => {
+    const result = categoryCreateSchema.safeParse({
+      name: "Groceries",
+      budgetAmount: undefined,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  test("カテゴリ名と月予算金額で作成できる", () => {
+    const result = categoryCreateSchema.safeParse({
+      name: "Groceries",
+      budgetAmount: 50000,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  test("カテゴリ名は20文字以下に制限する", () => {
+    const result = categoryCreateSchema.safeParse({
+      name: "a".repeat(CATEGORY_NAME_MAX_LENGTH + 1),
+      budgetAmount: undefined,
+    })
+
+    expect(result.success).toBe(false)
+    const error = result.error && z.flattenError(result.error).fieldErrors.name
+    expect(error).toEqual([`Category name must be ${CATEGORY_NAME_MAX_LENGTH} characters or less`])
+  })
+
+  test("月予算金額が負数の場合は拒否する", () => {
+    const result = categoryCreateSchema.safeParse({
+      name: "Groceries",
+      budgetAmount: -1,
+    })
+
+    expect(result.success).toBe(false)
+    const error = result.error && z.flattenError(result.error).fieldErrors.budgetAmount
+    expect(error).toEqual(["Amount must be a non-negative integer"])
+  })
+})

--- a/apps/web/src/features/categories/createCategory/categoryCreateSchema.ts
+++ b/apps/web/src/features/categories/createCategory/categoryCreateSchema.ts
@@ -1,0 +1,29 @@
+import * as z from "zod"
+
+import { categoryNameSchema } from "../categorySchema"
+
+const budgetAmountSchema = z
+  .number({
+    error: (iss) => {
+      if (iss.input === undefined || iss.input === null || iss.input === "") {
+        return "Amount cannot be empty"
+      }
+      if (typeof iss.input !== "number" || Number.isNaN(iss.input)) {
+        return "Amount must be a number"
+      }
+      return "Amount is invalid"
+    },
+  })
+  .int("Amount must be an integer")
+  .nonnegative("Amount must be a non-negative integer")
+
+const baseSchema = z.object({
+  name: categoryNameSchema,
+  budgetAmount: budgetAmountSchema.optional(),
+})
+
+export const categoryCreateSchema = baseSchema.required({
+  name: true,
+})
+
+export type CategoryCreateValues = z.infer<typeof categoryCreateSchema>

--- a/apps/web/src/features/categories/createCategory/createCategory.test.ts
+++ b/apps/web/src/features/categories/createCategory/createCategory.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { createCategory } from "./createCategory"
+
+const mockRpc = vi.fn()
+
+vi.mock("../../../lib/supabase", () => ({
+  getSupabaseClient: () => ({ rpc: mockRpc }),
+}))
+
+describe("createCategory", () => {
+  beforeEach(() => {
+    mockRpc.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("カテゴリ名だけでRPCを呼び、作成したカテゴリIDを返す", async () => {
+    mockRpc.mockResolvedValue({ data: 40, error: null })
+
+    await expect(createCategory({ name: "Groceries" })).resolves.toBe(40)
+
+    expect(mockRpc).toHaveBeenCalledWith("create_category_with_budget", {
+      p_category_name: "Groceries",
+    })
+  })
+
+  it("月予算つきでRPCを呼ぶ", async () => {
+    const march20 = new Date(2026, 2, 20, 12, 34, 56)
+
+    mockRpc.mockResolvedValue({ data: 40, error: null })
+    vi.useFakeTimers()
+    vi.setSystemTime(march20)
+
+    await createCategory({
+      name: "Groceries",
+      budgetAmount: 50000,
+    })
+
+    expect(mockRpc).toHaveBeenCalledWith("create_category_with_budget", {
+      p_category_name: "Groceries",
+      p_budget_effective_from: "2026-03-01",
+      p_budget_amount: 50000,
+    })
+  })
+
+  it("Supabaseがエラーを返した場合にthrowする", async () => {
+    const supabaseError = { message: "重複しています", code: "23505" }
+    mockRpc.mockResolvedValue({ data: null, error: supabaseError })
+
+    await expect(createCategory({ name: "Groceries" })).rejects.toEqual(supabaseError)
+  })
+
+  it("カテゴリ名が20文字を超える場合はRPCを呼ばずにrejectする", async () => {
+    await expect(createCategory({ name: "a".repeat(21) })).rejects.toThrow(
+      "Category name must be 20 characters or less",
+    )
+
+    expect(mockRpc).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/categories/createCategory/createCategory.ts
+++ b/apps/web/src/features/categories/createCategory/createCategory.ts
@@ -1,0 +1,26 @@
+import { getSupabaseClient } from "../../../lib/supabase"
+import {
+  mapCategoryCreateValuesToCategoryCreateInput,
+  toCategoryCreateRpcArgs,
+} from "./categoryCreateMappers"
+import { categoryCreateSchema, type CategoryCreateValues } from "./categoryCreateSchema"
+
+export async function createCategory(value: CategoryCreateValues): Promise<number> {
+  const supabase = getSupabaseClient()
+  const parsedValue = categoryCreateSchema.parse(value)
+  const input = mapCategoryCreateValuesToCategoryCreateInput(parsedValue)
+  const { data, error } = await supabase.rpc(
+    "create_category_with_budget",
+    toCategoryCreateRpcArgs(input),
+  )
+
+  if (error) {
+    throw error
+  }
+
+  if (data === null) {
+    throw new Error("Category was not created.")
+  }
+
+  return data
+}

--- a/apps/web/src/features/categories/createCategory/useCreateCategory.test.tsx
+++ b/apps/web/src/features/categories/createCategory/useCreateCategory.test.tsx
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { act, createTestQueryClient, renderHook } from "../../../test/test-utils"
+import type { CategoryCreateValues } from "./categoryCreateSchema"
+import { useCreateCategory } from "./useCreateCategory"
+
+const { mockCreateCategory } = vi.hoisted(() => ({
+  mockCreateCategory: vi.fn(),
+}))
+
+vi.mock("./createCategory", () => ({
+  createCategory: mockCreateCategory,
+}))
+
+describe("useCreateCategory", () => {
+  beforeEach(() => {
+    mockCreateCategory.mockReset()
+  })
+
+  it("成功時にカテゴリ設定一覧queryだけをinvalidateしてresolveする", async () => {
+    const queryClient = createTestQueryClient()
+    const invalidateQueries = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined)
+    const input: CategoryCreateValues = {
+      name: "Groceries",
+      budgetAmount: 50000,
+    }
+    mockCreateCategory.mockResolvedValue(40)
+
+    const { result } = renderHook(() => useCreateCategory(), {
+      queryClient,
+    })
+
+    await act(async () => {
+      const promise = result.current.createCategory(input)
+
+      expect(promise).toBeInstanceOf(Promise)
+      await expect(promise).resolves.toBe(40)
+    })
+
+    expect(mockCreateCategory).toHaveBeenCalledTimes(1)
+    expect(mockCreateCategory.mock.calls[0]?.[0]).toBe(input)
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["categorySettingsItems"] })
+    expect(invalidateQueries).toHaveBeenCalledTimes(1)
+  })
+
+  it("失敗時にqueryをinvalidateせずrejectする", async () => {
+    const queryClient = createTestQueryClient()
+    const invalidateQueries = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined)
+    const error = { message: "作成に失敗しました" }
+    mockCreateCategory.mockRejectedValue(error)
+
+    const { result } = renderHook(() => useCreateCategory(), {
+      queryClient,
+    })
+
+    await act(async () => {
+      await expect(result.current.createCategory({ name: "Groceries" })).rejects.toEqual(error)
+    })
+
+    expect(invalidateQueries).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/categories/createCategory/useCreateCategory.test.tsx
+++ b/apps/web/src/features/categories/createCategory/useCreateCategory.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import { act, createTestQueryClient, renderHook } from "../../../test/test-utils"
+import { categoryQueryKeys } from "../queryKeys"
 import type { CategoryCreateValues } from "./categoryCreateSchema"
 import { useCreateCategory } from "./useCreateCategory"
 
@@ -17,7 +18,7 @@ describe("useCreateCategory", () => {
     mockCreateCategory.mockReset()
   })
 
-  it("成功時にカテゴリ設定一覧queryだけをinvalidateしてresolveする", async () => {
+  it("成功時にカテゴリqueryをinvalidateしてresolveする", async () => {
     const queryClient = createTestQueryClient()
     const invalidateQueries = vi
       .spyOn(queryClient, "invalidateQueries")
@@ -41,7 +42,7 @@ describe("useCreateCategory", () => {
 
     expect(mockCreateCategory).toHaveBeenCalledTimes(1)
     expect(mockCreateCategory.mock.calls[0]?.[0]).toBe(input)
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["categorySettingsItems"] })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: categoryQueryKeys.all })
     expect(invalidateQueries).toHaveBeenCalledTimes(1)
   })
 

--- a/apps/web/src/features/categories/createCategory/useCreateCategory.ts
+++ b/apps/web/src/features/categories/createCategory/useCreateCategory.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
+import { invalidateCategoryQueries } from "../queryKeys"
 import type { CategoryCreateValues } from "./categoryCreateSchema"
 import { createCategory as createCategoryRecord } from "./createCategory"
 
@@ -15,7 +16,7 @@ export function useCreateCategory(): UseCreateCategoryReturn {
   const { mutateAsync, isPending } = useMutation({
     mutationFn: createCategoryRecord,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["categorySettingsItems"] })
+      await invalidateCategoryQueries(queryClient)
     },
   })
 

--- a/apps/web/src/features/categories/createCategory/useCreateCategory.ts
+++ b/apps/web/src/features/categories/createCategory/useCreateCategory.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useCallback } from "react"
+
+import type { CategoryCreateValues } from "./categoryCreateSchema"
+import { createCategory as createCategoryRecord } from "./createCategory"
+
+interface UseCreateCategoryReturn {
+  createCategory: (value: CategoryCreateValues) => Promise<number>
+  isPending: boolean
+}
+
+export function useCreateCategory(): UseCreateCategoryReturn {
+  const queryClient = useQueryClient()
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: createCategoryRecord,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["categorySettingsItems"] })
+    },
+  })
+
+  const createCategory = useCallback(
+    async (value: CategoryCreateValues) => {
+      return mutateAsync(value)
+    },
+    [mutateAsync],
+  )
+
+  return { createCategory, isPending }
+}

--- a/apps/web/src/types/database.types.ts
+++ b/apps/web/src/types/database.types.ts
@@ -334,6 +334,14 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      create_category_with_budget: {
+        Args: {
+          p_category_name: string
+          p_budget_amount?: number
+          p_budget_effective_from?: string
+        }
+        Returns: number
+      }
       ensure_authenticated_user: { Args: never; Returns: undefined }
       get_authenticated_default_book_id: { Args: never; Returns: number }
       get_authenticated_user_id: { Args: never; Returns: number }


### PR DESCRIPTION
## 関連Issue

- close #1284

## 変更内容

- カテゴリ作成と任意の月予算登録を同一RPCで扱うPostgres functionを追加
- Webのカテゴリ作成mutation、schema、RPC mapper、hookを追加
- 作成成功後のinvalidateをカテゴリ共通query方針に揃えた

## 動作確認

- [ ] ローカルでの動作確認
- [x] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

- UI追加は含めていません
- test:storybook は実行していません
