### PR TITLE
docs: Web検証コマンドの案内を更新

### DIFF
--- a/.github/instructions/apps-web.instructions.md
+++ b/.github/instructions/apps-web.instructions.md
@@ -6,7 +6,8 @@ applyTo: "apps/web/**"
 
 ## Rules
 
-- Run Web verification from the repository root with `pnpm run web:lint`, `pnpm run web:format-check`, `pnpm run web:typecheck`, and `pnpm run web:test`.
+- Run Web verification from the repository root with `pnpm run web:lint`, `pnpm run web:format-check`, `pnpm run web:typecheck`, and `pnpm --filter web exec vp test run --project unit --project integration --reporter=dot --silent`.
+- Run `pnpm --filter web test:storybook --reporter=dot --silent` only when the change affects `browser-test` tagged stories, `apps/web/.storybook-test/`, or Storybook browser-test configuration.
 - Use `pnpm install` from the repository root for installing/updating dependencies.
 - Add new components manually, following `apps/web/docs/policies/component-structure.md`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,18 +93,19 @@ do not require verification.
 - Define verification as the concrete commands for each app, not a `verify` wrapper task.
 - When application code changes, run the verification commands for the affected app from the repository root.
 - If the current diff is exactly identical to the diff for the most recent run of the same verification commands, you may skip rerunning them.
-- Run independent verification commands in parallel when practical.
+- Run the listed independent verification commands in parallel when practical.
 - Do not start multiple instances of the same verification command at the same time.
 - When running verification commands in parallel, if one command fails before the others finish,
   wait for all already-started verification commands to finish before making fixes or rerunning checks.
 - After fixing a failure, start any required reruns as a new verification batch only after the previous batch has fully completed.
 
 - **Web** (`apps/web/`)
+  Run these commands in the same verification batch:
   `pnpm run web:lint`
   `pnpm run web:format-check`
   `pnpm run web:typecheck`
-  `pnpm --filter web test:unit`
-  `pnpm --filter web test:integration`
-  `pnpm --filter web test:storybook`
+  `pnpm --filter web exec vp test run --project unit --project integration`
+
+  Run `pnpm --filter web test:storybook` only when the change affects `browser-test` tagged stories, `apps/web/.storybook-test/`, or Storybook browser-test configuration.
 - **API** (`apps/api`)
   No dedicated verification commands are currently defined. If verification commands are added later, define the concrete commands here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,8 +104,8 @@ do not require verification.
   `pnpm run web:lint`
   `pnpm run web:format-check`
   `pnpm run web:typecheck`
-  `pnpm --filter web exec vp test run --project unit --project integration`
+  `pnpm --filter web exec vp test run --project unit --project integration --reporter=dot --silent`
 
-  Run `pnpm --filter web test:storybook` only when the change affects `browser-test` tagged stories, `apps/web/.storybook-test/`, or Storybook browser-test configuration.
+  Run `pnpm --filter web test:storybook --reporter=dot --silent` only when the change affects `browser-test` tagged stories, `apps/web/.storybook-test/`, or Storybook browser-test configuration.
 - **API** (`apps/api`)
   No dedicated verification commands are currently defined. If verification commands are added later, define the concrete commands here.

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@
 
 このリポジトリは `pnpm workspace` を使用します。依存関係のインストールは、この README があるリポジトリルートで `pnpm install` を実行します。
 
-各アプリの操作は pnpm workspace scripts から実行します。フロントエンドの検証はリポジトリルートで `pnpm run web:lint`、`pnpm run web:format-check`、`pnpm run web:typecheck`、`pnpm run web:test` を実行します。
+各アプリの操作は pnpm workspace scripts から実行します。変更時の検証ルールは `AGENTS.md` の Verification を参照します。

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -67,18 +67,6 @@ pnpm storybook -- --no-open
 
 ユニット / コンポーネントテストは Vitest で実行します。
 
-```bash
-pnpm test
-```
-
-個別に実行したい場合:
-
-```bash
-pnpm test:unit
-pnpm test:integration
-pnpm test:storybook
-```
-
 E2E テストや Playwright が設定されている場合は、CI 設定や `package.json` のスクリプトを参照してください。
 
 ## Lint / 型チェック
@@ -92,14 +80,7 @@ pnpm format --check
 pnpm typecheck
 ```
 
-リポジトリルートから検証する場合は、次のコマンドを順に実行します。
-
-```bash
-pnpm run web:lint
-pnpm run web:format-check
-pnpm run web:typecheck
-pnpm run web:test
-```
+変更時の検証ルールは、リポジトリルートの `AGENTS.md` にある Verification を参照してください。
 
 型チェックは `pnpm typecheck` で明示的に実行できます。`pnpm build` でも `tsc -b` を通るため、ビルド時にも型チェックされます。
 `pnpm typecheck` を直接実行しても同じチェックが走ります。

--- a/apps/web/docs/policies/storybook-browser-tests.md
+++ b/apps/web/docs/policies/storybook-browser-tests.md
@@ -12,14 +12,16 @@ topics:
 when_to_read:
   - Storybookのブラウザテスト対象を変更するとき
   - Page storyを追加または変更するとき
-  - pnpm run web:testのStorybook対象範囲を確認するとき
+  - pnpm --filter web test:storybookの対象範囲を確認するとき
 ---
 
 # Storybook Browser Tests
 
 Storybook のブラウザテストは opt-in で運用します。
 
-`pnpm run web:test` の Storybook project は `apps/web/.storybook-test/` の Storybook 設定を使い、`apps/web/src/app/routes/**/*.stories.tsx` 配下の Page story だけを読み込みます。その上で、`browser-test` tag が付いた story だけを対象にします。
+`pnpm --filter web test:storybook` の Storybook project は `apps/web/.storybook-test/` の Storybook 設定を使い、`apps/web/src/app/routes/**/*.stories.tsx` 配下の Page story だけを読み込みます。その上で、`browser-test` tag が付いた story だけを対象にします。
+
+Web の通常検証では Storybook browser test を常時実行しません。`browser-test` 対象の story、`apps/web/.storybook-test/`、または Storybook browser-test 設定を変更した場合に実行します。
 
 ブラウザ実行はコストが高いため、Storybook 上の全 story を網羅するのではなく、ページ単位または統合境界をまたぐ story に絞ります。
 

--- a/apps/web/docs/policies/storybook-browser-tests.md
+++ b/apps/web/docs/policies/storybook-browser-tests.md
@@ -12,14 +12,14 @@ topics:
 when_to_read:
   - Storybookのブラウザテスト対象を変更するとき
   - Page storyを追加または変更するとき
-  - pnpm --filter web test:storybookの対象範囲を確認するとき
+  - `pnpm --filter web test:storybook` の対象範囲を確認するとき
 ---
 
 # Storybook Browser Tests
 
 Storybook のブラウザテストは opt-in で運用します。
 
-`pnpm --filter web test:storybook` の Storybook project は `apps/web/.storybook-test/` の Storybook 設定を使い、`apps/web/src/app/routes/**/*.stories.tsx` 配下の Page story だけを読み込みます。その上で、`browser-test` tag が付いた story だけを対象にします。
+`pnpm --filter web test:storybook --reporter=dot --silent` の Storybook project は `apps/web/.storybook-test/` の Storybook 設定を使い、`apps/web/src/app/routes/**/*.stories.tsx` 配下の Page story だけを読み込みます。その上で、`browser-test` tag が付いた story だけを対象にします。
 
 Web の通常検証では Storybook browser test を常時実行しません。`browser-test` 対象の story、`apps/web/.storybook-test/`、または Storybook browser-test 設定を変更した場合に実行します。
 


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- Webの通常検証コマンドを unit / integration 同時実行の案内へ更新
- Storybook検証を browser-test 対象の変更時のみ実行する案内へ更新
- README の検証コマンド列を削除し、AGENTS.md の Verification 参照に集約

## 動作確認

- [x] git diff --check
- [x] ドキュメントのみの変更のためアプリ検証は未実行