### PR TITLE
支払い作成中のボタン状態を制御

### DIFF
--- a/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.test.tsx
+++ b/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.test.tsx
@@ -6,6 +6,7 @@ import { createCategoryHandlers } from "../../../../test/msw/handlers/categories
 import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
 import { server } from "../../../../test/msw/server"
 import { act, render, screen, type TestUser, waitFor, within } from "../../../../test/test-utils"
+import { createDeferred } from "../../../../test/utils/createDeferred"
 import { PAYMENT_NOTE_MAX_LENGTH } from "../../paymentFormSchema"
 import * as stories from "./CreatePaymentForm.stories"
 
@@ -149,5 +150,51 @@ describe("CreatePaymentForm", () => {
     expect(requestBody).not.toHaveProperty("user_id")
     expect(requestBody).not.toHaveProperty("book_id")
     expect(requestBody?.date).toEqual(expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/))
+  })
+
+  test("支払い作成中は作成ボタンをローディング表示し操作ボタンを無効化する", async () => {
+    const paymentCreated = createDeferred()
+
+    server.resetHandlers(
+      ...createCategoryHandlers(),
+      http.post(PAYMENTS_REST_URL, async () => {
+        await paymentCreated.promise
+        return HttpResponse.json([{ id: 1001 }], { status: 201 })
+      }),
+    )
+
+    const { user } = await renderStory(<Default />)
+
+    await user.type(screen.getByRole("textbox", { name: /amount/i }), "1080")
+    await user.click(screen.getByRole("button", { name: /create/i }))
+
+    const createButton = await screen.findByRole("button", { name: /create/i })
+    expect(await within(createButton).findByLabelText("loading-spinner")).toBeInTheDocument()
+    expect(createButton).toBeDisabled()
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeDisabled()
+
+    await act(async () => {
+      paymentCreated.resolve()
+    })
+  })
+
+  test("支払い作成に失敗するとonErrorを呼んで操作ボタンを再度有効化する", async () => {
+    const onError = vi.fn()
+
+    server.resetHandlers(
+      ...createCategoryHandlers(),
+      ...createPaymentHandlers({ create: { error: true } }),
+    )
+
+    const { user } = await renderStory(<Default onError={onError} />)
+
+    await user.type(screen.getByRole("textbox", { name: /amount/i }), "1080")
+    await user.click(screen.getByRole("button", { name: /create/i }))
+
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledTimes(1)
+    })
+    expect(screen.getByRole("button", { name: /create/i })).toBeEnabled()
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled()
   })
 })

--- a/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.test.tsx
+++ b/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.test.tsx
@@ -176,6 +176,12 @@ describe("CreatePaymentForm", () => {
     await act(async () => {
       paymentCreated.resolve()
     })
+
+    await waitFor(() => {
+      expect(within(createButton).queryByLabelText("loading-spinner")).not.toBeInTheDocument()
+    })
+    expect(createButton).toBeEnabled()
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled()
   })
 
   test("支払い作成に失敗するとonErrorを呼んで操作ボタンを再度有効化する", async () => {

--- a/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.tsx
+++ b/apps/web/src/features/payments/createPayment/CreatePaymentForm/CreatePaymentForm.tsx
@@ -42,9 +42,13 @@ export function CreatePaymentForm({
     validators: {
       onSubmit: paymentFormSubmitSchema,
     },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
       const parsedValue = paymentFormSubmitSchema.parse(value)
-      createPayment(mapSubmitFormValuesToPaymentWriteInput(parsedValue))
+      try {
+        await createPayment(mapSubmitFormValuesToPaymentWriteInput(parsedValue))
+      } catch {
+        // 作成失敗時の通知は useCreatePayment の onError に委ねる。
+      }
     },
   })
 
@@ -138,10 +142,14 @@ export function CreatePaymentForm({
             onCheckedChange={onContinuousModeChange}
           />
         ) : null}
-        <Flex gap="3">
-          <CancelButton onClick={handleCancel} />
-          <SubmitButton>Create</SubmitButton>
-        </Flex>
+        <form.Subscribe selector={(state) => state.isSubmitting}>
+          {(isSubmitting) => (
+            <Flex gap="3">
+              <CancelButton disabled={isSubmitting} onClick={handleCancel} />
+              <SubmitButton loading={isSubmitting}>Create</SubmitButton>
+            </Flex>
+          )}
+        </form.Subscribe>
       </Flex>
     </form>
   )

--- a/apps/web/src/features/payments/createPayment/useCreatePayment.test.tsx
+++ b/apps/web/src/features/payments/createPayment/useCreatePayment.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
-import { createTestQueryClient, renderHook } from "../../../test/test-utils"
+import { act, createTestQueryClient, renderHook, waitFor } from "../../../test/test-utils"
 import { useCreatePayment } from "./useCreatePayment"
 
 const { mockFrom, mockInsert } = vi.hoisted(() => ({
@@ -32,14 +32,21 @@ describe("useCreatePayment", () => {
       queryClient,
     })
 
-    await result.current.createPayment({
-      date: new Date(2025, 5, 1),
-      categoryId: "10",
-      note: "lunch",
-      amount: 1000,
+    await act(async () => {
+      const promise = result.current.createPayment({
+        date: new Date(2025, 5, 1),
+        categoryId: "10",
+        note: "lunch",
+        amount: 1000,
+      })
+
+      expect(promise).toBeInstanceOf(Promise)
+      await promise
     })
 
-    expect(onSuccess).toHaveBeenCalledTimes(1)
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
     expect(onError).not.toHaveBeenCalled()
     expect(mockFrom).toHaveBeenCalledWith("payments")
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["payments"] })
@@ -61,16 +68,20 @@ describe("useCreatePayment", () => {
       queryClient,
     })
 
-    await expect(
-      result.current.createPayment({
-        date: new Date(2025, 5, 1),
-        categoryId: "10",
-        note: "lunch",
-        amount: 1000,
-      }),
-    ).rejects.toThrow(error)
+    await act(async () => {
+      await expect(
+        result.current.createPayment({
+          date: new Date(2025, 5, 1),
+          categoryId: "10",
+          note: "lunch",
+          amount: 1000,
+        }),
+      ).rejects.toThrow(error)
+    })
 
-    expect(onError).toHaveBeenCalledWith(error)
+    await waitFor(() => {
+      expect(onError).toHaveBeenCalledWith(error)
+    })
     expect(onSuccess).not.toHaveBeenCalled()
     expect(invalidateQueries).not.toHaveBeenCalled()
   })

--- a/apps/web/src/features/payments/createPayment/useCreatePayment.test.tsx
+++ b/apps/web/src/features/payments/createPayment/useCreatePayment.test.tsx
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
-import { createTestQueryClient, renderHook, waitFor } from "../../../test/test-utils"
+import { createTestQueryClient, renderHook } from "../../../test/test-utils"
 import { useCreatePayment } from "./useCreatePayment"
 
 const { mockFrom, mockInsert } = vi.hoisted(() => ({
@@ -32,16 +32,14 @@ describe("useCreatePayment", () => {
       queryClient,
     })
 
-    result.current.createPayment({
+    await result.current.createPayment({
       date: new Date(2025, 5, 1),
       categoryId: "10",
       note: "lunch",
       amount: 1000,
     })
 
-    await waitFor(() => {
-      expect(onSuccess).toHaveBeenCalledTimes(1)
-    })
+    expect(onSuccess).toHaveBeenCalledTimes(1)
     expect(onError).not.toHaveBeenCalled()
     expect(mockFrom).toHaveBeenCalledWith("payments")
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["payments"] })
@@ -63,16 +61,16 @@ describe("useCreatePayment", () => {
       queryClient,
     })
 
-    result.current.createPayment({
-      date: new Date(2025, 5, 1),
-      categoryId: "10",
-      note: "lunch",
-      amount: 1000,
-    })
+    await expect(
+      result.current.createPayment({
+        date: new Date(2025, 5, 1),
+        categoryId: "10",
+        note: "lunch",
+        amount: 1000,
+      }),
+    ).rejects.toThrow(error)
 
-    await waitFor(() => {
-      expect(onError).toHaveBeenCalledWith(error)
-    })
+    expect(onError).toHaveBeenCalledWith(error)
     expect(onSuccess).not.toHaveBeenCalled()
     expect(invalidateQueries).not.toHaveBeenCalled()
   })

--- a/apps/web/src/features/payments/createPayment/useCreatePayment.ts
+++ b/apps/web/src/features/payments/createPayment/useCreatePayment.ts
@@ -15,7 +15,7 @@ async function postPayment(value: PaymentWriteInput): Promise<void> {
 }
 
 interface UseCreatePaymentReturn {
-  createPayment: (value: PaymentWriteInput) => void
+  createPayment: (value: PaymentWriteInput) => Promise<void>
   isPending: boolean
 }
 
@@ -25,7 +25,7 @@ export function useCreatePayment(
 ): UseCreatePaymentReturn {
   const queryClient = useQueryClient()
 
-  const { mutate, isPending } = useMutation({
+  const { mutateAsync, isPending } = useMutation({
     mutationFn: postPayment,
     onSuccess: async () => {
       await Promise.all([
@@ -41,10 +41,10 @@ export function useCreatePayment(
   })
 
   const createPayment = useCallback(
-    (value: PaymentWriteInput) => {
-      mutate(value)
+    async (value: PaymentWriteInput) => {
+      await mutateAsync(value)
     },
-    [mutate],
+    [mutateAsync],
   )
 
   return { createPayment, isPending }

--- a/apps/web/src/providers/supabase/SupabaseSessionProvider.test.tsx
+++ b/apps/web/src/providers/supabase/SupabaseSessionProvider.test.tsx
@@ -4,6 +4,7 @@ import type { PropsWithChildren } from "react"
 import { beforeEach, describe, expect, test, vi } from "vite-plus/test"
 
 import { act, waitFor } from "../../test/test-utils"
+import { createDeferred } from "../../test/utils/createDeferred"
 import {
   type AuthStatus,
   SupabaseSessionProvider,
@@ -52,17 +53,6 @@ function createSession(userId = "user-id", accessToken = `token-${userId}`): Ses
       created_at: "2024-01-01T00:00:00.000Z",
     },
   }
-}
-
-function createDeferred<T>() {
-  let resolve!: (value: T | PromiseLike<T>) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((promiseResolve, promiseReject) => {
-    resolve = promiseResolve
-    reject = promiseReject
-  })
-
-  return { promise, resolve, reject }
 }
 
 function renderSessionHook() {

--- a/apps/web/src/test/utils/createDeferred.ts
+++ b/apps/web/src/test/utils/createDeferred.ts
@@ -1,0 +1,10 @@
+export function createDeferred<T = void>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+
+  return { promise, resolve, reject }
+}


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- 支払い作成処理を await し、作成中は Create / Cancel ボタンを無効化
- 作成失敗時はフォーム送信へ例外を伝播させず、既存の onError 委譲を維持
- Promise 制御用の test utility を追加し、作成中・失敗後のボタン状態をテスト

## 動作確認

- [x] ローカルでの動作確認
- [x] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

- Storybook テスト中に既存の ErrorPage story 由来の console.error が出ますが、テストは成功しています