### PR TITLE
フォーム送信ボタンの状態管理を統一

### DIFF
--- a/apps/web/src/features/budgets/createMonthlyBudget/CreateMonthlyBudgetForm/CreateMonthlyBudgetForm.test.tsx
+++ b/apps/web/src/features/budgets/createMonthlyBudget/CreateMonthlyBudgetForm/CreateMonthlyBudgetForm.test.tsx
@@ -3,7 +3,8 @@ import { HttpResponse, http } from "msw"
 import { describe, expect, test, vi } from "vite-plus/test"
 
 import { server } from "../../../../test/msw/server"
-import { act, render, screen, waitFor } from "../../../../test/test-utils"
+import { act, render, screen, waitFor, within } from "../../../../test/test-utils"
+import { createDeferred } from "../../../../test/utils/createDeferred"
 import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../../utils/postgresError"
 import { fillCreateMonthlyBudgetForm, selectBudgetMonth } from "../../test/utils/budgetCreationForm"
 import * as stories from "./CreateMonthlyBudgetForm.stories"
@@ -62,6 +63,37 @@ describe("CreateMonthlyBudgetForm", () => {
       effective_from: "2026-03-01",
     })
     expect(onError).not.toHaveBeenCalled()
+  })
+
+  test("月予算作成中は作成ボタンをローディング表示し操作ボタンを無効化する", async () => {
+    const monthlyBudgetCreated = createDeferred()
+
+    server.resetHandlers(
+      http.post(MONTHLY_BUDGETS_REST_URL, async () => {
+        await monthlyBudgetCreated.promise
+        return HttpResponse.json([{ id: 999 }], { status: 201 })
+      }),
+    )
+
+    const { user } = await renderStory(<Default />)
+
+    await fillCreateMonthlyBudgetForm({ user, year: "2026", month: "3", amount: "300000" })
+    await user.click(screen.getByRole("button", { name: "Create" }))
+
+    const createButton = await screen.findByRole("button", { name: /create/i })
+    expect(await within(createButton).findByLabelText("loading-spinner")).toBeInTheDocument()
+    expect(createButton).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled()
+
+    await act(async () => {
+      monthlyBudgetCreated.resolve()
+    })
+
+    await waitFor(() => {
+      expect(within(createButton).queryByLabelText("loading-spinner")).not.toBeInTheDocument()
+    })
+    expect(createButton).toBeEnabled()
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled()
   })
 
   test("重複年月エラー時は重複メッセージを表示する", async () => {

--- a/apps/web/src/features/budgets/createMonthlyBudget/CreateMonthlyBudgetForm/CreateMonthlyBudgetForm.tsx
+++ b/apps/web/src/features/budgets/createMonthlyBudget/CreateMonthlyBudgetForm/CreateMonthlyBudgetForm.tsx
@@ -104,10 +104,14 @@ export function CreateMonthlyBudgetForm({
             }}
           </form.Field>
         </Flex>
-        <Flex gap="3" justify="end">
-          <CancelButton onClick={handleCancel} />
-          <SubmitButton>Create</SubmitButton>
-        </Flex>
+        <form.Subscribe selector={(state) => state.isSubmitting}>
+          {(isSubmitting) => (
+            <Flex gap="3" justify="end">
+              <CancelButton disabled={isSubmitting} onClick={handleCancel} />
+              <SubmitButton loading={isSubmitting}>Create</SubmitButton>
+            </Flex>
+          )}
+        </form.Subscribe>
       </Flex>
     </form>
   )

--- a/apps/web/src/features/budgets/updateMonthlyBudget/UpdateMonthlyBudgetForm/UpdateMonthlyBudgetForm.test.tsx
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/UpdateMonthlyBudgetForm/UpdateMonthlyBudgetForm.test.tsx
@@ -1,0 +1,49 @@
+import { HttpResponse, http } from "msw"
+import { describe, expect, test } from "vite-plus/test"
+
+import { monthlyBudgets } from "../../../../test/data/monthlyBudgets"
+import { server } from "../../../../test/msw/server"
+import { act, render, screen, waitFor, within } from "../../../../test/test-utils"
+import { createDeferred } from "../../../../test/utils/createDeferred"
+import { toMonthlyBudget } from "../../monthlyBudgetMappers"
+import { UpdateMonthlyBudgetForm } from "./UpdateMonthlyBudgetForm"
+
+const MONTHLY_BUDGETS_REST_URL = "*/rest/v1/monthly_budgets*"
+
+describe("UpdateMonthlyBudgetForm", () => {
+  test("月予算更新中は保存ボタンをローディング表示し操作ボタンを無効化する", async () => {
+    const monthlyBudgetUpdated = createDeferred()
+    const monthlyBudget = toMonthlyBudget(monthlyBudgets[2])
+
+    server.resetHandlers(
+      http.patch(MONTHLY_BUDGETS_REST_URL, async () => {
+        await monthlyBudgetUpdated.promise
+        return HttpResponse.json({ id: monthlyBudget.id })
+      }),
+    )
+
+    const { user } = render(
+      <UpdateMonthlyBudgetForm monthlyBudget={monthlyBudget} onCancel={() => {}} />,
+    )
+    const amountInput = screen.getByRole("textbox", { name: /amount/i })
+
+    await user.clear(amountInput)
+    await user.type(amountInput, "70000")
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    const saveButton = await screen.findByRole("button", { name: /save/i })
+    expect(await within(saveButton).findByLabelText("loading-spinner")).toBeInTheDocument()
+    expect(saveButton).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled()
+
+    await act(async () => {
+      monthlyBudgetUpdated.resolve()
+    })
+
+    await waitFor(() => {
+      expect(within(saveButton).queryByLabelText("loading-spinner")).not.toBeInTheDocument()
+    })
+    expect(saveButton).toBeEnabled()
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled()
+  })
+})

--- a/apps/web/src/features/budgets/updateMonthlyBudget/UpdateMonthlyBudgetForm/UpdateMonthlyBudgetForm.tsx
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/UpdateMonthlyBudgetForm/UpdateMonthlyBudgetForm.tsx
@@ -123,10 +123,14 @@ export function UpdateMonthlyBudgetForm({
             }}
           </form.Field>
         </Flex>
-        <Flex gap="3" justify="end">
-          <CancelButton disabled={isPending} onClick={handleCancel} />
-          <SubmitButton loading={isPending}>Save</SubmitButton>
-        </Flex>
+        <form.Subscribe selector={(state) => state.isSubmitting}>
+          {(isSubmitting) => (
+            <Flex gap="3" justify="end">
+              <CancelButton disabled={isSubmitting} onClick={handleCancel} />
+              <SubmitButton loading={isSubmitting}>Save</SubmitButton>
+            </Flex>
+          )}
+        </form.Subscribe>
       </Flex>
     </form>
   )

--- a/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.test.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.test.tsx
@@ -1,15 +1,18 @@
 import { composeStories } from "@storybook/react-vite"
+import { HttpResponse, http } from "msw"
 import type { ReactElement } from "react"
 import { fn } from "storybook/test"
 import { beforeEach, describe, expect, test } from "vite-plus/test"
 
 import { createCategorySettingsHandlers } from "../../../../test/msw/handlers/categorySettings"
 import { server } from "../../../../test/msw/server"
-import { act, render, screen, waitFor } from "../../../../test/test-utils"
+import { act, render, screen, waitFor, within } from "../../../../test/test-utils"
+import { createDeferred } from "../../../../test/utils/createDeferred"
 import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../../utils/postgresError"
 import * as stories from "./UpdateCategoryNameForm.stories"
 
 const { Default } = composeStories(stories)
+const CATEGORIES_REST_URL = "*/rest/v1/categories*"
 
 async function renderStory(story: ReactElement) {
   return await act(async () => {
@@ -63,6 +66,39 @@ describe("UpdateCategoryNameForm", () => {
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledTimes(1)
     })
+  })
+
+  test("カテゴリ名保存中は保存ボタンをローディング表示し操作ボタンを無効化する", async () => {
+    const categoryUpdated = createDeferred()
+
+    server.resetHandlers(
+      http.patch(CATEGORIES_REST_URL, async () => {
+        await categoryUpdated.promise
+        return HttpResponse.json({ id: 10 })
+      }),
+    )
+
+    const { user } = await renderStory(<Default />)
+    const nameInput = screen.getByRole("textbox", { name: /Name/ })
+
+    await user.clear(nameInput)
+    await user.type(nameInput, "Groceries")
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    const saveButton = await screen.findByRole("button", { name: /save/i })
+    expect(await within(saveButton).findByLabelText("loading-spinner")).toBeInTheDocument()
+    expect(saveButton).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled()
+
+    await act(async () => {
+      categoryUpdated.resolve()
+    })
+
+    await waitFor(() => {
+      expect(within(saveButton).queryByLabelText("loading-spinner")).not.toBeInTheDocument()
+    })
+    expect(saveButton).toBeEnabled()
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled()
   })
 
   test("カテゴリ名重複時は保存エラーを表示してonSuccessを呼ばない", async () => {

--- a/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.tsx
@@ -124,10 +124,14 @@ export function UpdateCategoryNameForm({
             )
           }}
         </form.Field>
-        <Flex gap="3" justify="end">
-          <CancelButton disabled={isPending} onClick={handleCancel} />
-          <SubmitButton loading={isPending}>Save</SubmitButton>
-        </Flex>
+        <form.Subscribe selector={(state) => state.isSubmitting}>
+          {(isSubmitting) => (
+            <Flex gap="3" justify="end">
+              <CancelButton disabled={isSubmitting} onClick={handleCancel} />
+              <SubmitButton loading={isSubmitting}>Save</SubmitButton>
+            </Flex>
+          )}
+        </form.Subscribe>
       </Flex>
     </form>
   )


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- SubmitButton を使うフォームの送信中表示を form.Subscribe の isSubmitting に統一
- 月予算作成・月予算更新・カテゴリ名更新フォームの Cancel / Submit ボタン状態を支払い作成フォーム方式に合わせた
- 対象フォームの送信中ローディングとボタン無効化をテストで追加確認

## 動作確認

- [x] テストの実行
  - pnpm run web:lint
  - pnpm run web:format-check
  - pnpm run web:typecheck
  - pnpm --filter web exec vp test run --project unit --project integration --reporter=dot --silent

## 補足

- Storybook browser-test 対象の変更はないため、storybook テストは未実行です