### PR TITLE
query key と invalidate をドメイン単位に整理

### DIFF
--- a/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
@@ -8,6 +8,7 @@ import {
   PAYMENT_SEARCH_CATEGORY_NONE_VALUE,
   paymentsSearchSchema,
 } from "../../../features/payments/listPayment/paymentsSearchSchema"
+import { paymentQueryKeys } from "../../../features/payments/queryKeys"
 import { categories, entertainmentCat, foodCat } from "../../../test/data/categories"
 import { monthlyBudgets } from "../../../test/data/monthlyBudgets"
 import { payments } from "../../../test/data/payments"
@@ -50,6 +51,7 @@ const initialCurrentMonthPaymentRows = initialPaymentRows.filter((payment) =>
   payment.date.startsWith("2025-06-"),
 )
 const currentMonthPaymentsQueryDate = new Date(2025, 5, 1).toISOString()
+const paymentsPageCacheScope = "payments-page-test"
 const uncategorizedPayment = mapPaymentToRow({
   ...payments[0],
   id: 1000,
@@ -78,17 +80,21 @@ function renderPaymentsPageRoute(initialEntry: string) {
   const queryClient = createTestQueryClient()
   queryClient.setQueryData(categoryQueryKeys.list, categories)
   queryClient.setQueryData(
-    ["payments", currentMonthPaymentsQueryDate, `category-${foodCat.id}`],
+    paymentQueryKeys.list(paymentsPageCacheScope, currentMonthPaymentsQueryDate, foodCat.id),
     initialCurrentMonthPaymentRows.filter((payment) => payment.category_id === foodCat.id),
     { updatedAt: 0 },
   )
   queryClient.setQueryData(
-    ["payments", currentMonthPaymentsQueryDate, `category-${entertainmentCat.id}`],
+    paymentQueryKeys.list(
+      paymentsPageCacheScope,
+      currentMonthPaymentsQueryDate,
+      entertainmentCat.id,
+    ),
     [],
     { updatedAt: 0 },
   )
   queryClient.setQueryData(
-    ["payments", currentMonthPaymentsQueryDate, "uncategorized"],
+    paymentQueryKeys.list(paymentsPageCacheScope, currentMonthPaymentsQueryDate, null),
     [uncategorizedPayment],
     { updatedAt: 0 },
   )
@@ -141,6 +147,7 @@ function lastRequest(requests: URL[]): URL | undefined {
 
 describe("PaymentsPage", () => {
   beforeEach(() => {
+    vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000000")
     server.resetHandlers(
       ...createPaymentHandlers({
         initialRows: initialPaymentRows,
@@ -157,6 +164,7 @@ describe("PaymentsPage", () => {
 
   afterEach(() => {
     server.resetHandlers()
+    vi.restoreAllMocks()
     vi.useRealTimers()
   })
 
@@ -343,7 +351,7 @@ describe("PaymentsPage", () => {
     })
 
     queryClient.removeQueries({
-      queryKey: ["payments"],
+      queryKey: paymentQueryKeys.all,
       predicate: (query) => query.queryKey[3] === "all-categories",
     })
 

--- a/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
@@ -51,7 +51,8 @@ const initialCurrentMonthPaymentRows = initialPaymentRows.filter((payment) =>
   payment.date.startsWith("2025-06-"),
 )
 const currentMonthPaymentsQueryDate = new Date(2025, 5, 1).toISOString()
-const paymentsPageCacheScope = "payments-page-test"
+const paymentsPageCacheScopeId = "00000000-0000-4000-8000-000000000000"
+const paymentsPageCacheScope = `payments-page-${paymentsPageCacheScopeId}`
 const uncategorizedPayment = mapPaymentToRow({
   ...payments[0],
   id: 1000,
@@ -147,7 +148,7 @@ function lastRequest(requests: URL[]): URL | undefined {
 
 describe("PaymentsPage", () => {
   beforeEach(() => {
-    vi.spyOn(crypto, "randomUUID").mockReturnValue("00000000-0000-4000-8000-000000000000")
+    vi.spyOn(crypto, "randomUUID").mockReturnValue(paymentsPageCacheScopeId)
     server.resetHandlers(
       ...createPaymentHandlers({
         initialRows: initialPaymentRows,

--- a/apps/web/src/features/budgets/createMonthlyBudget/useCreateMonthlyBudget.test.tsx
+++ b/apps/web/src/features/budgets/createMonthlyBudget/useCreateMonthlyBudget.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import { act, createTestQueryClient, renderHook } from "../../../test/test-utils"
+import { monthlyBudgetQueryKeys } from "../queryKeys"
 import type { MonthlyBudgetWriteInput } from "./monthlyBudgetFormMappers"
 import { useCreateMonthlyBudget } from "./useCreateMonthlyBudget"
 
@@ -41,8 +42,11 @@ describe("useCreateMonthlyBudget", () => {
 
     expect(mockCreateMonthlyBudget).toHaveBeenCalledTimes(1)
     expect(mockCreateMonthlyBudget.mock.calls[0]?.[0]).toBe(input)
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["monthlyBudgets"] })
-    expect(invalidateQueries).toHaveBeenCalledTimes(1)
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: monthlyBudgetQueryKeys.listAll })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: monthlyBudgetQueryKeys.effectiveAll,
+    })
+    expect(invalidateQueries).toHaveBeenCalledTimes(2)
   })
 
   it("失敗時に関連queryをinvalidateせずrejectする", async () => {

--- a/apps/web/src/features/budgets/createMonthlyBudget/useCreateMonthlyBudget.ts
+++ b/apps/web/src/features/budgets/createMonthlyBudget/useCreateMonthlyBudget.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
+import { monthlyBudgetQueryKeys } from "../queryKeys"
 import { createMonthlyBudget as createMonthlyBudgetRecord } from "./createMonthlyBudget"
 import type { MonthlyBudgetWriteInput } from "./monthlyBudgetFormMappers"
 
@@ -15,7 +16,10 @@ export function useCreateMonthlyBudget(): UseCreateMonthlyBudgetReturn {
   const { mutateAsync, isPending } = useMutation({
     mutationFn: createMonthlyBudgetRecord,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["monthlyBudgets"] })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: monthlyBudgetQueryKeys.listAll }),
+        queryClient.invalidateQueries({ queryKey: monthlyBudgetQueryKeys.effectiveAll }),
+      ])
     },
   })
 

--- a/apps/web/src/features/budgets/getMonthlyBudget/useEffectiveMonthlyBudget.ts
+++ b/apps/web/src/features/budgets/getMonthlyBudget/useEffectiveMonthlyBudget.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 
+import { monthlyBudgetQueryKeys } from "../queryKeys"
 import type { MonthlyBudget } from "../types"
 import { formatTargetMonthKey, toTargetMonth } from "../utils/month"
 import { fetchEffectiveMonthlyBudget } from "./fetchEffectiveMonthlyBudget"
@@ -16,7 +17,7 @@ export function useEffectiveMonthlyBudget(
 ): UseEffectiveMonthlyBudgetReturn {
   const targetMonth = targetDate ? formatTargetMonthKey(toTargetMonth(targetDate)) : "none"
   const query = useQuery({
-    queryKey: ["effectiveMonthlyBudget", targetMonth],
+    queryKey: monthlyBudgetQueryKeys.effective(targetMonth),
     queryFn: async () => {
       if (!targetDate) {
         return Promise.resolve(null)

--- a/apps/web/src/features/budgets/listMonthlyBudget/useMonthlyBudgets.ts
+++ b/apps/web/src/features/budgets/listMonthlyBudget/useMonthlyBudgets.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query"
 
+import { monthlyBudgetQueryKeys } from "../queryKeys"
 import type { MonthlyBudget } from "../types"
 import { fetchMonthlyBudgets } from "./fetchMonthlyBudgets"
 
@@ -12,7 +13,7 @@ interface UseMonthlyBudgetsReturn {
 
 export function useMonthlyBudgets(limit: number): UseMonthlyBudgetsReturn {
   const query = useQuery({
-    queryKey: ["monthlyBudgets", limit],
+    queryKey: monthlyBudgetQueryKeys.list(limit),
     queryFn: async () => fetchMonthlyBudgets(limit),
     staleTime: 3000, // 3秒
   })

--- a/apps/web/src/features/budgets/queryKeys.ts
+++ b/apps/web/src/features/budgets/queryKeys.ts
@@ -1,0 +1,6 @@
+export const monthlyBudgetQueryKeys = {
+  listAll: ["monthlyBudgets"],
+  list: (limit: number) => ["monthlyBudgets", limit] as const,
+  effectiveAll: ["effectiveMonthlyBudget"],
+  effective: (targetMonth: string) => ["effectiveMonthlyBudget", targetMonth] as const,
+} as const

--- a/apps/web/src/features/budgets/updateMonthlyBudget/useUpdateMonthlyBudget.test.tsx
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/useUpdateMonthlyBudget.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import { act, createTestQueryClient, renderHook } from "../../../test/test-utils"
+import { monthlyBudgetQueryKeys } from "../queryKeys"
 import { useUpdateMonthlyBudget } from "./useUpdateMonthlyBudget"
 
 const { mockUpdateMonthlyBudget } = vi.hoisted(() => ({
@@ -40,8 +41,11 @@ describe("useUpdateMonthlyBudget", () => {
 
     expect(mockUpdateMonthlyBudget).toHaveBeenCalledTimes(1)
     expect(mockUpdateMonthlyBudget.mock.calls[0]?.[0]).toBe(input)
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["monthlyBudgets"] })
-    expect(invalidateQueries).toHaveBeenCalledTimes(1)
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: monthlyBudgetQueryKeys.listAll })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: monthlyBudgetQueryKeys.effectiveAll,
+    })
+    expect(invalidateQueries).toHaveBeenCalledTimes(2)
   })
 
   it("失敗時にmonthlyBudgets queryをinvalidateせずrejectする", async () => {

--- a/apps/web/src/features/budgets/updateMonthlyBudget/useUpdateMonthlyBudget.ts
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/useUpdateMonthlyBudget.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
+import { monthlyBudgetQueryKeys } from "../queryKeys"
 import type { MonthlyBudgetUpdateInput } from "./monthlyBudgetUpdateMappers"
 import { updateMonthlyBudget as updateMonthlyBudgetRecord } from "./updateMonthlyBudget"
 
@@ -15,7 +16,10 @@ export function useUpdateMonthlyBudget(): UseUpdateMonthlyBudgetReturn {
   const { mutateAsync, isPending } = useMutation({
     mutationFn: updateMonthlyBudgetRecord,
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["monthlyBudgets"] })
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: monthlyBudgetQueryKeys.listAll }),
+        queryClient.invalidateQueries({ queryKey: monthlyBudgetQueryKeys.effectiveAll }),
+      ])
     },
   })
 

--- a/apps/web/src/features/categories/createCategory/useCreateCategory.test.tsx
+++ b/apps/web/src/features/categories/createCategory/useCreateCategory.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import { act, createTestQueryClient, renderHook } from "../../../test/test-utils"
+import { summaryQueryKeys } from "../../summaryByMonth/queryKeys"
 import { categoryQueryKeys } from "../queryKeys"
 import type { CategoryCreateValues } from "./categoryCreateSchema"
 import { useCreateCategory } from "./useCreateCategory"
@@ -43,7 +44,8 @@ describe("useCreateCategory", () => {
     expect(mockCreateCategory).toHaveBeenCalledTimes(1)
     expect(mockCreateCategory.mock.calls[0]?.[0]).toBe(input)
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: categoryQueryKeys.all })
-    expect(invalidateQueries).toHaveBeenCalledTimes(1)
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: summaryQueryKeys.categoryTotalsAll })
+    expect(invalidateQueries).toHaveBeenCalledTimes(2)
   })
 
   it("失敗時にqueryをinvalidateせずrejectする", async () => {

--- a/apps/web/src/features/categories/createCategory/useCreateCategory.ts
+++ b/apps/web/src/features/categories/createCategory/useCreateCategory.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
+import { summaryQueryKeys } from "../../summaryByMonth/queryKeys"
 import { invalidateCategoryQueries } from "../queryKeys"
 import type { CategoryCreateValues } from "./categoryCreateSchema"
 import { createCategory as createCategoryRecord } from "./createCategory"
@@ -16,7 +17,10 @@ export function useCreateCategory(): UseCreateCategoryReturn {
   const { mutateAsync, isPending } = useMutation({
     mutationFn: createCategoryRecord,
     onSuccess: async () => {
-      await invalidateCategoryQueries(queryClient)
+      await Promise.all([
+        invalidateCategoryQueries(queryClient),
+        queryClient.invalidateQueries({ queryKey: summaryQueryKeys.categoryTotalsAll }),
+      ])
     },
   })
 

--- a/apps/web/src/features/categories/updateCategoryName/useUpdateCategoryName.test.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/useUpdateCategoryName.test.tsx
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import { act, createTestQueryClient, renderHook } from "../../../test/test-utils"
+import { paymentQueryKeys } from "../../payments/queryKeys"
+import { summaryQueryKeys } from "../../summaryByMonth/queryKeys"
 import { categoryQueryKeys } from "../queryKeys"
 import { useUpdateCategoryName } from "./useUpdateCategoryName"
 
@@ -42,7 +44,10 @@ describe("useUpdateCategoryName", () => {
     expect(mockUpdateCategoryName).toHaveBeenCalledTimes(1)
     expect(mockUpdateCategoryName.mock.calls[0]?.[0]).toBe(input)
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: categoryQueryKeys.all })
-    expect(invalidateQueries).toHaveBeenCalledTimes(1)
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: paymentQueryKeys.all })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: paymentQueryKeys.detailsAll })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: summaryQueryKeys.categoryTotalsAll })
+    expect(invalidateQueries).toHaveBeenCalledTimes(4)
   })
 
   it("失敗時にqueryをinvalidateせずrejectする", async () => {

--- a/apps/web/src/features/categories/updateCategoryName/useUpdateCategoryName.ts
+++ b/apps/web/src/features/categories/updateCategoryName/useUpdateCategoryName.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
+import { paymentQueryKeys } from "../../payments/queryKeys"
+import { summaryQueryKeys } from "../../summaryByMonth/queryKeys"
 import { invalidateCategoryQueries } from "../queryKeys"
 import type { CategoryNameUpdateInput } from "./categoryNameUpdateMappers"
 import { updateCategoryName as updateCategoryNameRecord } from "./updateCategoryName"
@@ -16,7 +18,12 @@ export function useUpdateCategoryName(): UseUpdateCategoryNameReturn {
   const { mutateAsync, isPending } = useMutation({
     mutationFn: updateCategoryNameRecord,
     onSuccess: async () => {
-      await invalidateCategoryQueries(queryClient)
+      await Promise.all([
+        invalidateCategoryQueries(queryClient),
+        queryClient.invalidateQueries({ queryKey: paymentQueryKeys.all }),
+        queryClient.invalidateQueries({ queryKey: paymentQueryKeys.detailsAll }),
+        queryClient.invalidateQueries({ queryKey: summaryQueryKeys.categoryTotalsAll }),
+      ])
     },
   })
 

--- a/apps/web/src/features/payments/createPayment/useCreatePayment.test.tsx
+++ b/apps/web/src/features/payments/createPayment/useCreatePayment.test.tsx
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import { act, createTestQueryClient, renderHook, waitFor } from "../../../test/test-utils"
+import { summaryQueryKeys } from "../../summaryByMonth/queryKeys"
+import { paymentQueryKeys } from "../queryKeys"
 import { useCreatePayment } from "./useCreatePayment"
 
 const { mockFrom, mockInsert } = vi.hoisted(() => ({
@@ -49,9 +51,11 @@ describe("useCreatePayment", () => {
     })
     expect(onError).not.toHaveBeenCalled()
     expect(mockFrom).toHaveBeenCalledWith("payments")
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["payments"] })
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["totalExpenditures"] })
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["categoryTotals"] })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: paymentQueryKeys.all })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: summaryQueryKeys.totalExpendituresAll,
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: summaryQueryKeys.categoryTotalsAll })
   })
 
   it("失敗時にonErrorを呼んでinvalidateしない", async () => {

--- a/apps/web/src/features/payments/createPayment/useCreatePayment.ts
+++ b/apps/web/src/features/payments/createPayment/useCreatePayment.ts
@@ -2,7 +2,9 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
 import { getSupabaseClient } from "../../../lib/supabase"
+import { summaryQueryKeys } from "../../summaryByMonth/queryKeys"
 import { type PaymentWriteInput, toPaymentWriteInsert } from "../paymentFormMappers"
+import { paymentQueryKeys } from "../queryKeys"
 
 async function postPayment(value: PaymentWriteInput): Promise<void> {
   const supabase = getSupabaseClient()
@@ -29,9 +31,9 @@ export function useCreatePayment(
     mutationFn: postPayment,
     onSuccess: async () => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["payments"] }),
-        queryClient.invalidateQueries({ queryKey: ["totalExpenditures"] }),
-        queryClient.invalidateQueries({ queryKey: ["categoryTotals"] }),
+        queryClient.invalidateQueries({ queryKey: paymentQueryKeys.all }),
+        queryClient.invalidateQueries({ queryKey: summaryQueryKeys.totalExpendituresAll }),
+        queryClient.invalidateQueries({ queryKey: summaryQueryKeys.categoryTotalsAll }),
       ])
       onSuccess?.()
     },

--- a/apps/web/src/features/payments/deletePayment/useDeletePayment.test.tsx
+++ b/apps/web/src/features/payments/deletePayment/useDeletePayment.test.tsx
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import { act, createTestQueryClient, renderHook, waitFor } from "../../../test/test-utils"
+import { summaryQueryKeys } from "../../summaryByMonth/queryKeys"
+import { paymentQueryKeys } from "../queryKeys"
 import { useDeletePayment } from "./useDeletePayment"
 
 const { mockRemovePayment } = vi.hoisted(() => ({
@@ -41,10 +43,12 @@ describe("useDeletePayment", () => {
       expect(onSuccess).toHaveBeenCalledTimes(1)
     })
     expect(onError).not.toHaveBeenCalled()
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["payments"] })
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["paymentDetails", 42] })
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["totalExpenditures"] })
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["categoryTotals"] })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: paymentQueryKeys.all })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: paymentQueryKeys.details(42) })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: summaryQueryKeys.totalExpendituresAll,
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: summaryQueryKeys.categoryTotalsAll })
   })
 
   it("失敗時にonErrorを呼んでエラーをrethrowする", async () => {

--- a/apps/web/src/features/payments/deletePayment/useDeletePayment.ts
+++ b/apps/web/src/features/payments/deletePayment/useDeletePayment.ts
@@ -2,6 +2,8 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
 import type { PaymentId } from "../../../types/payment"
+import { summaryQueryKeys } from "../../summaryByMonth/queryKeys"
+import { paymentQueryKeys } from "../queryKeys"
 import { removePayment } from "./removePayment"
 
 interface UseDeletePaymentReturn {
@@ -19,10 +21,10 @@ export function useDeletePayment(
     mutationFn: async (paymentId: PaymentId) => removePayment(paymentId),
     onSuccess: async (__, paymentId) => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["payments"] }),
-        queryClient.invalidateQueries({ queryKey: ["paymentDetails", paymentId] }),
-        queryClient.invalidateQueries({ queryKey: ["totalExpenditures"] }),
-        queryClient.invalidateQueries({ queryKey: ["categoryTotals"] }),
+        queryClient.invalidateQueries({ queryKey: paymentQueryKeys.all }),
+        queryClient.invalidateQueries({ queryKey: paymentQueryKeys.details(paymentId) }),
+        queryClient.invalidateQueries({ queryKey: summaryQueryKeys.totalExpendituresAll }),
+        queryClient.invalidateQueries({ queryKey: summaryQueryKeys.categoryTotalsAll }),
       ])
       onSuccess?.()
     },

--- a/apps/web/src/features/payments/listPayment/usePayments.ts
+++ b/apps/web/src/features/payments/listPayment/usePayments.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query"
 
 import type { Payment } from "../../../types/payment"
 import { useDateRange } from "../../../utils/useDateRange"
+import { paymentQueryKeys } from "../queryKeys"
 import { fetchPayments } from "./fetchPayments"
 
 interface UseGetPaymentsReturn {
@@ -22,12 +23,7 @@ export function usePayments({
 }: UsePaymentsOptions = {}): UseGetPaymentsReturn {
   const { date, dateRange } = useDateRange()
   const query = useQuery({
-    queryKey: [
-      "payments",
-      cacheScope,
-      date?.toISOString() ?? "all",
-      getCategoryQueryKey(categoryId),
-    ],
+    queryKey: paymentQueryKeys.list(cacheScope, date?.toISOString() ?? "all", categoryId),
     queryFn: async () => fetchPayments(dateRange, { categoryId }),
     enabled: date !== null,
     staleTime: 3000, // 3秒
@@ -39,10 +35,4 @@ export function usePayments({
     promise: query.promise,
     error: query.error,
   }
-}
-
-function getCategoryQueryKey(categoryId: number | null | undefined): string {
-  if (categoryId === undefined) return "all-categories"
-  if (categoryId === null) return "uncategorized"
-  return `category-${categoryId}`
 }

--- a/apps/web/src/features/payments/paymentDetails/usePaymentDetails.ts
+++ b/apps/web/src/features/payments/paymentDetails/usePaymentDetails.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 
 import type { PaymentDetails, PaymentId } from "../../../types/payment"
+import { paymentQueryKeys } from "../queryKeys"
 import { fetchPaymentDetails } from "./fetchPaymentDetails"
 
 interface UsePaymentDetailsReturn {
@@ -11,7 +12,7 @@ interface UsePaymentDetailsReturn {
 
 export function usePaymentDetails(paymentId: PaymentId | null): UsePaymentDetailsReturn {
   const query = useQuery({
-    queryKey: ["paymentDetails", paymentId],
+    queryKey: paymentQueryKeys.details(paymentId),
     queryFn: async () => {
       if (paymentId === null) {
         return Promise.resolve(null)

--- a/apps/web/src/features/payments/queryKeys.ts
+++ b/apps/web/src/features/payments/queryKeys.ts
@@ -1,0 +1,15 @@
+import type { PaymentId } from "../../types/payment"
+
+export const paymentQueryKeys = {
+  all: ["payments"],
+  list: (cacheScope: string, dateKey: string, categoryId: number | null | undefined) =>
+    ["payments", cacheScope, dateKey, getCategoryQueryKey(categoryId)] as const,
+  detailsAll: ["paymentDetails"],
+  details: (paymentId: PaymentId | null) => ["paymentDetails", paymentId] as const,
+} as const
+
+function getCategoryQueryKey(categoryId: number | null | undefined): string {
+  if (categoryId === undefined) return "all-categories"
+  if (categoryId === null) return "uncategorized"
+  return `category-${categoryId}`
+}

--- a/apps/web/src/features/payments/updatePayment/useUpdatePayment.test.tsx
+++ b/apps/web/src/features/payments/updatePayment/useUpdatePayment.test.tsx
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
 
 import { act, createTestQueryClient, renderHook, waitFor } from "../../../test/test-utils"
+import { summaryQueryKeys } from "../../summaryByMonth/queryKeys"
+import { paymentQueryKeys } from "../queryKeys"
 import { useUpdatePayment } from "./useUpdatePayment"
 
 const { mockUpdatePayment } = vi.hoisted(() => ({
@@ -44,10 +46,12 @@ describe("useUpdatePayment", () => {
       expect(onSuccess).toHaveBeenCalledTimes(1)
     })
     expect(onError).not.toHaveBeenCalled()
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["payments"] })
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["paymentDetails", 42] })
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["totalExpenditures"] })
-    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["categoryTotals"] })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: paymentQueryKeys.all })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: paymentQueryKeys.details(42) })
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: summaryQueryKeys.totalExpendituresAll,
+    })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: summaryQueryKeys.categoryTotalsAll })
   })
 
   it("失敗時にonErrorを呼んでエラーをrethrowする", async () => {

--- a/apps/web/src/features/payments/updatePayment/useUpdatePayment.ts
+++ b/apps/web/src/features/payments/updatePayment/useUpdatePayment.ts
@@ -2,7 +2,9 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
 import type { PaymentId } from "../../../types/payment"
+import { summaryQueryKeys } from "../../summaryByMonth/queryKeys"
 import type { PaymentUpdatePatch } from "../paymentFormMappers"
+import { paymentQueryKeys } from "../queryKeys"
 import { updatePayment as updatePaymentRecord } from "./updatePayment"
 
 interface UpdatePaymentInput {
@@ -26,10 +28,10 @@ export function useUpdatePayment(
       updatePaymentRecord(paymentId, patch),
     onSuccess: async (_, { paymentId }) => {
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ["payments"] }),
-        queryClient.invalidateQueries({ queryKey: ["paymentDetails", paymentId] }),
-        queryClient.invalidateQueries({ queryKey: ["totalExpenditures"] }),
-        queryClient.invalidateQueries({ queryKey: ["categoryTotals"] }),
+        queryClient.invalidateQueries({ queryKey: paymentQueryKeys.all }),
+        queryClient.invalidateQueries({ queryKey: paymentQueryKeys.details(paymentId) }),
+        queryClient.invalidateQueries({ queryKey: summaryQueryKeys.totalExpendituresAll }),
+        queryClient.invalidateQueries({ queryKey: summaryQueryKeys.categoryTotalsAll }),
       ])
       onSuccess?.()
     },

--- a/apps/web/src/features/summaryByMonth/CategoryTotals/useCategoryTotals.ts
+++ b/apps/web/src/features/summaryByMonth/CategoryTotals/useCategoryTotals.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query"
 import { format } from "date-fns"
 
 import { useDateRange } from "../../../utils/useDateRange"
+import { summaryQueryKeys } from "../queryKeys"
 import { type CategoryTotals, fetchCategoryTotals } from "./fetchCategoryTotals"
 
 interface UseCategoryTotalsReturn {
@@ -18,7 +19,7 @@ function useCategoryTotals({
   const { date, dateRange } = useDateRange()
   const month = date ? format(date, "yyyy-MM") : ""
   const query = useQuery({
-    queryKey: ["categoryTotals", cacheScope, month],
+    queryKey: summaryQueryKeys.categoryTotals(cacheScope, month),
     queryFn: async () => fetchCategoryTotals(dateRange),
     enabled: !!month,
     staleTime: 3000,

--- a/apps/web/src/features/summaryByMonth/queryKeys.ts
+++ b/apps/web/src/features/summaryByMonth/queryKeys.ts
@@ -1,0 +1,7 @@
+export const summaryQueryKeys = {
+  totalExpendituresAll: ["totalExpenditures"],
+  totalExpenditures: (month: string) => ["totalExpenditures", month] as const,
+  categoryTotalsAll: ["categoryTotals"],
+  categoryTotals: (cacheScope: string, month: string) =>
+    ["categoryTotals", cacheScope, month] as const,
+} as const

--- a/apps/web/src/features/summaryByMonth/useTotalExpenditures.ts
+++ b/apps/web/src/features/summaryByMonth/useTotalExpenditures.ts
@@ -3,6 +3,7 @@ import { format } from "date-fns"
 
 import { useDateRange } from "../../utils/useDateRange"
 import { fetchTotalExpenditures } from "./fetchTotalExpenditures"
+import { summaryQueryKeys } from "./queryKeys"
 
 interface UseTotalExpendituresReturn {
   data: number | null
@@ -16,7 +17,7 @@ export function useTotalExpenditures(): UseTotalExpendituresReturn {
   const month = date ? format(date, "yyyy-MM") : ""
 
   const query = useQuery({
-    queryKey: ["totalExpenditures", month],
+    queryKey: summaryQueryKeys.totalExpenditures(month),
     queryFn: async () => fetchTotalExpenditures(month),
     enabled: !!month,
     staleTime: 3000, // 3秒


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- カテゴリ・支払い・月予算・集計の query key を各ドメインの helper に集約
- カテゴリ名変更や月予算更新などの mutation 成功時に、表示鮮度に必要な query を invalidate
- PaymentsPage のテスト seed が実際の cacheScope と一致するように調整

## 動作確認

- [x] `pnpm run web:lint`
- [x] `pnpm run web:format-check`
- [x] `pnpm run web:typecheck`
- [x] `pnpm --filter web exec vp test run --project unit --project integration --reporter=dot --silent`