### PR TITLE
設定画面でカテゴリ作成と月予算登録をできるようにする

### DIFF
--- a/apps/web/src/components/inputs/AmountInput/AmountInput.test.tsx
+++ b/apps/web/src/components/inputs/AmountInput/AmountInput.test.tsx
@@ -21,4 +21,12 @@ describe("AmountInput", () => {
 
     expect(screen.getByRole("textbox")).toHaveValue("1200")
   })
+
+  test("aria属性をinputへ渡す", () => {
+    render(<Default aria-describedby="amount-error" aria-invalid />)
+
+    const input = screen.getByRole("textbox")
+    expect(input).toHaveAttribute("aria-describedby", "amount-error")
+    expect(input).toHaveAttribute("aria-invalid", "true")
+  })
 })

--- a/apps/web/src/components/inputs/AmountInput/AmountInput.tsx
+++ b/apps/web/src/components/inputs/AmountInput/AmountInput.tsx
@@ -6,10 +6,20 @@ interface AmountInputProps {
   value?: number
   autoFocus?: boolean
   disabled?: boolean
+  "aria-describedby"?: string
+  "aria-invalid"?: boolean
   onChange?: (amount: number | undefined) => void
 }
 
-export function AmountInput({ id, value, autoFocus, disabled, onChange }: AmountInputProps) {
+export function AmountInput({
+  id,
+  value,
+  autoFocus,
+  disabled,
+  "aria-describedby": ariaDescribedBy,
+  "aria-invalid": ariaInvalid,
+  onChange,
+}: AmountInputProps) {
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     const value = event.target.value
     if (value === "") {
@@ -35,6 +45,8 @@ export function AmountInput({ id, value, autoFocus, disabled, onChange }: Amount
       value={value?.toString() ?? ""}
       autoFocus={autoFocus}
       disabled={disabled}
+      aria-describedby={ariaDescribedBy}
+      aria-invalid={ariaInvalid}
       onChange={handleChange}
     />
   )

--- a/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.test.tsx
+++ b/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.test.tsx
@@ -73,6 +73,43 @@ describe("CategorySettingsList", () => {
     expect(await screen.findByLabelText("Groceries category settings")).toBeInTheDocument()
   })
 
+  test("月予算なしでカテゴリを作成して一覧に反映する", async () => {
+    const { user } = await renderCategorySettingsList(<Default />)
+
+    await user.click(await screen.findByRole("button", { name: "Create category" }))
+    const dialog = await screen.findByRole("dialog", { name: "Create category" })
+
+    await user.type(within(dialog).getByRole("textbox", { name: /Name/ }), "Groceries")
+    await user.click(within(dialog).getByRole("button", { name: "Create" }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Create category" })).not.toBeInTheDocument()
+    })
+    expect(await screen.findByLabelText("Groceries category settings")).toBeInTheDocument()
+    expect(
+      within(screen.getByLabelText("Groceries category settings")).getByText("Not set"),
+    ).toBeInTheDocument()
+  })
+
+  test("月予算金額つきでカテゴリを作成して一覧に反映する", async () => {
+    const { user } = await renderCategorySettingsList(<Default />)
+
+    await user.click(await screen.findByRole("button", { name: "Create category" }))
+    const dialog = await screen.findByRole("dialog", { name: "Create category" })
+
+    await user.type(within(dialog).getByRole("textbox", { name: /Name/ }), "Groceries")
+    await user.type(within(dialog).getByRole("textbox", { name: /Monthly budget/ }), "50000")
+    await user.click(within(dialog).getByRole("button", { name: "Create" }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Create category" })).not.toBeInTheDocument()
+    })
+    expect(await screen.findByLabelText("Groceries category settings")).toBeInTheDocument()
+    expect(
+      within(screen.getByLabelText("Groceries category settings")).getByText("￥50,000"),
+    ).toBeInTheDocument()
+  })
+
   test("カテゴリ設定取得中は loading を表示する", async () => {
     server.resetHandlers(...createCategorySettingsHandlers({ durationOrMode: "infinite" }))
 

--- a/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.tsx
+++ b/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.tsx
@@ -3,6 +3,7 @@ import { Fragment, Suspense, use } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 
 import { toCurrency } from "../../../../utils/toCurrency"
+import { CreateCategoryModal } from "../../createCategory/CreateCategoryModal"
 import type { CategorySettingsItem } from "../../listCategorySettings/types"
 import { useCategorySettingsItems } from "../../listCategorySettings/useCategorySettingsItems"
 import { UpdateCategoryNameModal } from "../../updateCategoryName/UpdateCategoryNameModal"
@@ -12,9 +13,12 @@ export function CategorySettingsList() {
 
   return (
     <Flex direction="column" gap="3">
-      <Text as="p" size="4" weight="medium">
-        Categories
-      </Text>
+      <Flex align="center" gap="3" justify="between">
+        <Text as="p" size="4" weight="medium">
+          Categories
+        </Text>
+        <CreateCategoryModal />
+      </Flex>
       <ErrorBoundary
         fallback={
           <Text color="red" role="alert">

--- a/apps/web/src/features/categories/createCategory/CreateCategoryForm/CreateCategoryForm.stories.tsx
+++ b/apps/web/src/features/categories/createCategory/CreateCategoryForm/CreateCategoryForm.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { QueryClientProvider } from "@tanstack/react-query"
+import { fn } from "storybook/test"
+
+import { createQueryClient } from "../../../../lib/queryClient"
+import { ThemeProvider } from "../../../../providers/theme/ThemeProvider"
+import { createCategorySettingsHandlers } from "../../../../test/msw/handlers/categorySettings"
+import { CreateCategoryForm } from "./CreateCategoryForm"
+
+const meta = {
+  title: "Features/Categories/CreateCategoryForm",
+  component: CreateCategoryForm,
+  parameters: {
+    layout: "centered",
+    msw: {
+      handlers: createCategorySettingsHandlers(),
+    },
+  },
+  tags: ["autodocs"],
+  args: {
+    onCancel: fn(),
+    onSuccess: fn(),
+  },
+  decorators: (Story) => {
+    const queryClient = createQueryClient()
+
+    return (
+      <ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      </ThemeProvider>
+    )
+  },
+} satisfies Meta<typeof CreateCategoryForm>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/apps/web/src/features/categories/createCategory/CreateCategoryForm/CreateCategoryForm.test.tsx
+++ b/apps/web/src/features/categories/createCategory/CreateCategoryForm/CreateCategoryForm.test.tsx
@@ -1,0 +1,168 @@
+import { composeStories } from "@storybook/react-vite"
+import { HttpResponse, http } from "msw"
+import type { ReactElement } from "react"
+import { fn } from "storybook/test"
+import { beforeEach, describe, expect, test } from "vite-plus/test"
+
+import { createCategorySettingsHandlers } from "../../../../test/msw/handlers/categorySettings"
+import { server } from "../../../../test/msw/server"
+import { act, render, screen, waitFor, within } from "../../../../test/test-utils"
+import { createDeferred } from "../../../../test/utils/createDeferred"
+import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../../utils/postgresError"
+import * as stories from "./CreateCategoryForm.stories"
+
+const { Default } = composeStories(stories)
+const CREATE_CATEGORY_RPC_URL = "*/rest/v1/rpc/create_category_with_budget"
+
+async function renderStory(story: ReactElement) {
+  return await act(async () => {
+    return render(story)
+  })
+}
+
+describe("CreateCategoryForm", () => {
+  beforeEach(() => {
+    server.resetHandlers(...createCategorySettingsHandlers())
+  })
+
+  test("カテゴリ名と任意の月予算金額入力欄を表示する", async () => {
+    await renderStory(<Default />)
+
+    expect(screen.getByRole("textbox", { name: /Name/ })).toBeInTheDocument()
+    expect(screen.getByRole("textbox", { name: /Monthly budget/ })).toBeInTheDocument()
+  })
+
+  test("未入力で送信するとカテゴリ名のvalidation errorを表示する", async () => {
+    const { user } = await renderStory(<Default />)
+
+    await user.click(screen.getByRole("button", { name: "Create" }))
+
+    expect(await screen.findByText("Category name cannot be empty")).toBeInTheDocument()
+    expect(screen.getByRole("textbox", { name: /Name/ })).toHaveAttribute("aria-invalid", "true")
+  })
+
+  test("20文字超過のカテゴリ名は保存前にvalidation errorを表示する", async () => {
+    const { user } = await renderStory(<Default />)
+
+    await user.type(screen.getByRole("textbox", { name: /Name/ }), "a".repeat(21))
+    await user.click(screen.getByRole("button", { name: "Create" }))
+
+    expect(
+      await screen.findByText("Category name must be 20 characters or less"),
+    ).toBeInTheDocument()
+  })
+
+  test("有効なカテゴリ名で作成に成功するとonSuccessを呼ぶ", async () => {
+    const onSuccess = fn()
+    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
+
+    await user.type(screen.getByRole("textbox", { name: /Name/ }), "Groceries")
+    await user.click(screen.getByRole("button", { name: "Create" }))
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  test("月予算金額つきで作成RPCを呼ぶ", async () => {
+    const onSuccess = fn()
+    let requestBody: Record<string, unknown> | undefined
+
+    server.resetHandlers(
+      http.post(CREATE_CATEGORY_RPC_URL, async ({ request }) => {
+        requestBody = (await request.json()) as Record<string, unknown>
+        return HttpResponse.json(999)
+      }),
+    )
+
+    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
+
+    await user.type(screen.getByRole("textbox", { name: /Name/ }), "Groceries")
+    await user.type(screen.getByRole("textbox", { name: /Monthly budget/ }), "50000")
+    await user.click(screen.getByRole("button", { name: "Create" }))
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledTimes(1)
+    })
+    expect(requestBody).toMatchObject({
+      p_category_name: "Groceries",
+      p_budget_amount: 50000,
+    })
+    expect(requestBody?.p_budget_effective_from).toMatch(/^\d{4}-\d{2}-01$/)
+  })
+
+  test("作成中は作成ボタンをローディング表示し操作ボタンを無効化する", async () => {
+    const categoryCreated = createDeferred()
+
+    server.resetHandlers(
+      http.post(CREATE_CATEGORY_RPC_URL, async () => {
+        await categoryCreated.promise
+        return HttpResponse.json(999)
+      }),
+    )
+
+    const { user } = await renderStory(<Default />)
+
+    await user.type(screen.getByRole("textbox", { name: /Name/ }), "Groceries")
+    await user.click(screen.getByRole("button", { name: "Create" }))
+
+    const createButton = await screen.findByRole("button", { name: /create/i })
+    expect(await within(createButton).findByLabelText("loading-spinner")).toBeInTheDocument()
+    expect(createButton).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled()
+    expect(screen.getByRole("textbox", { name: /Name/ })).toBeDisabled()
+    expect(screen.getByRole("textbox", { name: /Monthly budget/ })).toBeDisabled()
+
+    await act(async () => {
+      categoryCreated.resolve()
+    })
+
+    await waitFor(() => {
+      expect(within(createButton).queryByLabelText("loading-spinner")).not.toBeInTheDocument()
+    })
+  })
+
+  test("カテゴリ名重複時は保存エラーを表示してonSuccessを呼ばない", async () => {
+    const onSuccess = fn()
+
+    server.resetHandlers(
+      ...createCategorySettingsHandlers({
+        create: {
+          error: true,
+          errorResponse: {
+            code: POSTGRES_UNIQUE_VIOLATION_CODE,
+            message: "duplicate key value violates unique constraint",
+          },
+        },
+      }),
+    )
+
+    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
+
+    await user.type(screen.getByRole("textbox", { name: /Name/ }), "Food")
+    await user.click(screen.getByRole("button", { name: "Create" }))
+
+    expect(await screen.findByText("A category with this name already exists.")).toBeInTheDocument()
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  test("作成失敗時は汎用エラーを表示してonSuccessを呼ばない", async () => {
+    const onSuccess = fn()
+
+    server.resetHandlers(
+      ...createCategorySettingsHandlers({
+        create: {
+          error: true,
+        },
+      }),
+    )
+
+    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
+
+    await user.type(screen.getByRole("textbox", { name: /Name/ }), "Groceries")
+    await user.click(screen.getByRole("button", { name: "Create" }))
+
+    expect(await screen.findByText("Failed to create category.")).toBeInTheDocument()
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/categories/createCategory/CreateCategoryForm/CreateCategoryForm.tsx
+++ b/apps/web/src/features/categories/createCategory/CreateCategoryForm/CreateCategoryForm.tsx
@@ -1,0 +1,155 @@
+import { ExclamationTriangleIcon } from "@radix-ui/react-icons"
+import { Callout, Flex, TextField } from "@radix-ui/themes"
+import { useForm } from "@tanstack/react-form"
+import { useCallback, useId, useState } from "react"
+
+import { CancelButton } from "../../../../components/buttons/CancelButton"
+import { SubmitButton } from "../../../../components/buttons/SubmitButton"
+import { AmountInput } from "../../../../components/inputs/AmountInput"
+import { BaseField, FieldLabel, FieldMessages } from "../../../../components/inputs/BaseField"
+import { getErrorMessages } from "../../../../utils/getErrorMessages"
+import { toCategoryCreateErrorMessage } from "../categoryCreateError"
+import { categoryCreateSchema, type CategoryCreateValues } from "../categoryCreateSchema"
+import { useCreateCategory } from "../useCreateCategory"
+
+const defaultValues: CategoryCreateValues = {
+  name: "",
+  budgetAmount: undefined,
+}
+
+interface CreateCategoryFormProps {
+  onSuccess?: () => void
+  onCancel: () => void
+}
+
+export function CreateCategoryForm({ onSuccess, onCancel }: CreateCategoryFormProps) {
+  const nameInputId = useId()
+  const nameErrorId = useId()
+  const budgetAmountInputId = useId()
+  const budgetAmountErrorId = useId()
+  const { createCategory, isPending } = useCreateCategory()
+  const [submitErrorMessage, setSubmitErrorMessage] = useState<string | undefined>()
+
+  const form = useForm({
+    defaultValues,
+    validators: {
+      onSubmit: categoryCreateSchema,
+    },
+    onSubmit: async ({ value }) => {
+      if (isPending) return
+
+      const parsedValue = categoryCreateSchema.parse(value)
+
+      try {
+        setSubmitErrorMessage(undefined)
+        await createCategory(parsedValue)
+        form.reset()
+        onSuccess?.()
+      } catch (error) {
+        setSubmitErrorMessage(toCategoryCreateErrorMessage(error))
+      }
+    },
+  })
+
+  const handleCancel = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+      if (isPending) return
+
+      onCancel()
+    },
+    [isPending, onCancel],
+  )
+
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        setSubmitErrorMessage(undefined)
+        void form.handleSubmit()
+      }}
+    >
+      <Flex direction="column" gap="4">
+        {submitErrorMessage ? (
+          <Callout.Root aria-live="polite" role="alert" color="red" variant="surface" size="1">
+            <Callout.Icon>
+              <ExclamationTriangleIcon />
+            </Callout.Icon>
+            <Callout.Text>{submitErrorMessage}</Callout.Text>
+          </Callout.Root>
+        ) : null}
+        <form.Subscribe selector={(state) => state.isSubmitting}>
+          {(isSubmitting) => (
+            <Flex direction="column" gap="3">
+              <form.Field name="name">
+                {(field) => {
+                  const errorMessages = getErrorMessages(field.state.meta.errors) ?? []
+                  const hasError = !field.state.meta.isValid && errorMessages.length > 0
+
+                  return (
+                    <BaseField>
+                      <FieldLabel htmlFor={nameInputId} required>
+                        Name
+                      </FieldLabel>
+                      <TextField.Root
+                        autoFocus
+                        disabled={isSubmitting || isPending}
+                        id={nameInputId}
+                        name="name"
+                        value={field.state.value}
+                        aria-describedby={hasError ? nameErrorId : undefined}
+                        aria-invalid={hasError}
+                        onChange={(event) => {
+                          field.handleChange(event.target.value)
+                          setSubmitErrorMessage(undefined)
+                        }}
+                      />
+                      <span id={nameErrorId}>
+                        <FieldMessages error={hasError} messages={errorMessages} />
+                      </span>
+                    </BaseField>
+                  )
+                }}
+              </form.Field>
+              <form.Field name="budgetAmount">
+                {(field) => {
+                  const errorMessages = getErrorMessages(field.state.meta.errors) ?? []
+                  const hasError = !field.state.meta.isValid && errorMessages.length > 0
+
+                  return (
+                    <BaseField>
+                      <FieldLabel htmlFor={budgetAmountInputId}>Monthly budget</FieldLabel>
+                      <AmountInput
+                        disabled={isSubmitting || isPending}
+                        id={budgetAmountInputId}
+                        value={field.state.value}
+                        aria-describedby={hasError ? budgetAmountErrorId : undefined}
+                        aria-invalid={hasError}
+                        onChange={(amount) => {
+                          field.handleChange(amount)
+                          setSubmitErrorMessage(undefined)
+                        }}
+                      />
+                      <span id={budgetAmountErrorId}>
+                        <FieldMessages error={hasError} messages={errorMessages} />
+                      </span>
+                    </BaseField>
+                  )
+                }}
+              </form.Field>
+            </Flex>
+          )}
+        </form.Subscribe>
+        <form.Subscribe selector={(state) => state.isSubmitting}>
+          {(isSubmitting) => (
+            <Flex gap="3" justify="end">
+              <CancelButton disabled={isSubmitting || isPending} onClick={handleCancel} />
+              <SubmitButton loading={isSubmitting || isPending}>Create</SubmitButton>
+            </Flex>
+          )}
+        </form.Subscribe>
+      </Flex>
+    </form>
+  )
+}

--- a/apps/web/src/features/categories/createCategory/CreateCategoryForm/index.ts
+++ b/apps/web/src/features/categories/createCategory/CreateCategoryForm/index.ts
@@ -1,0 +1,1 @@
+export { CreateCategoryForm } from "./CreateCategoryForm"

--- a/apps/web/src/features/categories/createCategory/CreateCategoryModal/CreateCategoryModal.stories.tsx
+++ b/apps/web/src/features/categories/createCategory/CreateCategoryModal/CreateCategoryModal.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { QueryClientProvider } from "@tanstack/react-query"
+
+import { createQueryClient } from "../../../../lib/queryClient"
+import { ThemeProvider } from "../../../../providers/theme/ThemeProvider"
+import { createCategorySettingsHandlers } from "../../../../test/msw/handlers/categorySettings"
+import { CreateCategoryModal } from "./CreateCategoryModal"
+
+const meta = {
+  title: "Features/Categories/CreateCategoryModal",
+  component: CreateCategoryModal,
+  parameters: {
+    msw: {
+      handlers: createCategorySettingsHandlers(),
+    },
+  },
+  tags: ["autodocs"],
+  decorators: (Story) => {
+    const queryClient = createQueryClient()
+
+    return (
+      <ThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      </ThemeProvider>
+    )
+  },
+} satisfies Meta<typeof CreateCategoryModal>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/apps/web/src/features/categories/createCategory/CreateCategoryModal/CreateCategoryModal.test.tsx
+++ b/apps/web/src/features/categories/createCategory/CreateCategoryModal/CreateCategoryModal.test.tsx
@@ -1,0 +1,82 @@
+import { composeStories } from "@storybook/react-vite"
+import type { ReactElement } from "react"
+import { beforeEach, describe, expect, test } from "vite-plus/test"
+
+import { createCategorySettingsHandlers } from "../../../../test/msw/handlers/categorySettings"
+import { server } from "../../../../test/msw/server"
+import { act, fireEvent, render, screen, waitFor, within } from "../../../../test/test-utils"
+import * as stories from "./CreateCategoryModal.stories"
+
+const { Default } = composeStories(stories)
+
+async function renderStory(story: ReactElement) {
+  return await act(async () => {
+    return render(story)
+  })
+}
+
+async function openCreateCategoryModal() {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: "Create category" }))
+  })
+
+  return await screen.findByRole("dialog", { name: "Create category" })
+}
+
+describe("CreateCategoryModal", () => {
+  beforeEach(() => {
+    server.resetHandlers(...createCategorySettingsHandlers())
+  })
+
+  test("トリガー操作でダイアログとフォームを表示する", async () => {
+    await renderStory(<Default />)
+
+    const dialog = await openCreateCategoryModal()
+
+    expect(dialog).toBeInTheDocument()
+    expect(
+      within(dialog).getByText("Create a category with an optional monthly budget amount."),
+    ).toBeInTheDocument()
+    expect(within(dialog).getByRole("textbox", { name: /Name/ })).toBeInTheDocument()
+    expect(within(dialog).getByRole("textbox", { name: /Monthly budget/ })).toBeInTheDocument()
+  })
+
+  test("Cancelをクリックするとダイアログを閉じる", async () => {
+    const { user } = await renderStory(<Default />)
+
+    await openCreateCategoryModal()
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+
+    expect(screen.queryByRole("dialog", { name: "Create category" })).not.toBeInTheDocument()
+  })
+
+  test("作成成功後にダイアログを閉じる", async () => {
+    const { user } = await renderStory(<Default />)
+    const dialog = await openCreateCategoryModal()
+
+    await user.type(within(dialog).getByRole("textbox", { name: /Name/ }), "Groceries")
+    await user.click(within(dialog).getByRole("button", { name: "Create" }))
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Create category" })).not.toBeInTheDocument()
+    })
+  })
+
+  test("作成失敗時はダイアログを閉じない", async () => {
+    server.resetHandlers(
+      ...createCategorySettingsHandlers({
+        create: {
+          error: true,
+        },
+      }),
+    )
+    const { user } = await renderStory(<Default />)
+    const dialog = await openCreateCategoryModal()
+
+    await user.type(within(dialog).getByRole("textbox", { name: /Name/ }), "Groceries")
+    await user.click(within(dialog).getByRole("button", { name: "Create" }))
+
+    expect(await within(dialog).findByText("Failed to create category.")).toBeInTheDocument()
+    expect(screen.getByRole("dialog", { name: "Create category" })).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/categories/createCategory/CreateCategoryModal/CreateCategoryModal.tsx
+++ b/apps/web/src/features/categories/createCategory/CreateCategoryModal/CreateCategoryModal.tsx
@@ -1,0 +1,43 @@
+import { PlusIcon } from "@radix-ui/react-icons"
+import { Button } from "@radix-ui/themes"
+import { useCallback, type ReactElement } from "react"
+
+import { ResponsiveOverlay } from "../../../../components/overlay/ResponsiveOverlay"
+import { useDialog } from "../../../../utils/useDialog"
+import { CreateCategoryForm } from "../CreateCategoryForm"
+
+interface CreateCategoryModalProps {
+  trigger?: ReactElement
+}
+
+export function CreateCategoryModal({
+  trigger = (
+    <Button size="2" variant="soft">
+      <PlusIcon aria-hidden />
+      Create category
+    </Button>
+  ),
+}: CreateCategoryModalProps) {
+  const { open, closeDialog, onOpenChange } = useDialog()
+
+  const handleSuccess = useCallback(() => {
+    closeDialog()
+  }, [closeDialog])
+
+  const handleCancel = useCallback(() => {
+    closeDialog()
+  }, [closeDialog])
+
+  return (
+    <ResponsiveOverlay
+      open={open}
+      onOpenChange={onOpenChange}
+      dismissible={false}
+      trigger={trigger}
+      title="Create category"
+      description="Create a category with an optional monthly budget amount."
+    >
+      <CreateCategoryForm onSuccess={handleSuccess} onCancel={handleCancel} />
+    </ResponsiveOverlay>
+  )
+}

--- a/apps/web/src/features/categories/createCategory/CreateCategoryModal/index.ts
+++ b/apps/web/src/features/categories/createCategory/CreateCategoryModal/index.ts
@@ -1,0 +1,1 @@
+export { CreateCategoryModal } from "./CreateCategoryModal"

--- a/apps/web/src/features/categories/createCategory/categoryCreateError.test.ts
+++ b/apps/web/src/features/categories/createCategory/categoryCreateError.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vite-plus/test"
+
+import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../utils/postgresError"
+import { toCategoryCreateErrorMessage } from "./categoryCreateError"
+
+describe("toCategoryCreateErrorMessage", () => {
+  test("カテゴリ名重複エラーを表示用メッセージに変換する", () => {
+    expect(
+      toCategoryCreateErrorMessage({
+        code: POSTGRES_UNIQUE_VIOLATION_CODE,
+        message: "duplicate key value violates unique constraint",
+      }),
+    ).toBe("A category with this name already exists.")
+  })
+
+  test("その他のエラーを汎用メッセージに変換する", () => {
+    expect(toCategoryCreateErrorMessage({ message: "network error" })).toBe(
+      "Failed to create category.",
+    )
+  })
+})

--- a/apps/web/src/features/categories/createCategory/categoryCreateError.ts
+++ b/apps/web/src/features/categories/createCategory/categoryCreateError.ts
@@ -1,0 +1,12 @@
+import { isPostgresUniqueViolationError } from "../../../utils/postgresError"
+
+const DUPLICATE_CATEGORY_NAME_MESSAGE = "A category with this name already exists."
+const GENERIC_CREATE_CATEGORY_MESSAGE = "Failed to create category."
+
+export function toCategoryCreateErrorMessage(error: unknown): string {
+  if (isPostgresUniqueViolationError(error)) {
+    return DUPLICATE_CATEGORY_NAME_MESSAGE
+  }
+
+  return GENERIC_CREATE_CATEGORY_MESSAGE
+}

--- a/apps/web/src/test/msw/handlers/categorySettings.ts
+++ b/apps/web/src/test/msw/handlers/categorySettings.ts
@@ -42,11 +42,24 @@ interface UpdateCategorySettingsOptions {
   durationOrMode?: number | DelayMode | undefined
 }
 
+interface CreateCategorySettingsOptions {
+  error?: boolean
+  errorResponse?: unknown
+  durationOrMode?: number | DelayMode | undefined
+}
+
 const updateCategoryNameBodySchema = z.object({
   name: z.string(),
 })
 
+const createCategoryWithBudgetBodySchema = z.object({
+  p_category_name: z.string(),
+  p_budget_effective_from: z.string().optional(),
+  p_budget_amount: z.number().optional(),
+})
+
 type UpdateCategoryNameBody = z.infer<typeof updateCategoryNameBodySchema>
+type CreateCategoryWithBudgetBody = z.infer<typeof createCategoryWithBudgetBodySchema>
 
 export function createCategorySettingsHandlers({
   response,
@@ -54,8 +67,12 @@ export function createCategorySettingsHandlers({
   pinnedCategoryIds = [10],
   error = false,
   durationOrMode,
+  create = {},
   update = {},
-}: GetCategorySettingsOptions & { update?: UpdateCategorySettingsOptions } = {}) {
+}: GetCategorySettingsOptions & {
+  create?: CreateCategorySettingsOptions
+  update?: UpdateCategorySettingsOptions
+} = {}) {
   let rows = response ?? buildCategorySettingsResponse(currentBookId, pinnedCategoryIds)
 
   return [
@@ -67,6 +84,24 @@ export function createCategorySettingsHandlers({
       }
 
       return HttpResponse.json(rows)
+    }),
+    http.post("*/rest/v1/rpc/create_category_with_budget", async ({ request }) => {
+      await delay(create.durationOrMode)
+
+      if (create.error) {
+        return HttpResponse.json(
+          create.errorResponse ?? { message: "Failed to create category." },
+          { status: 500 },
+        )
+      }
+
+      const body = await request.json()
+      const parsedBody = createCategoryWithBudgetBodySchema.parse(body)
+      const createdRow = buildCreatedCategorySettingsRow(parsedBody, rows, currentBookId)
+
+      rows = [...rows, createdRow]
+
+      return HttpResponse.json(createdRow.id)
     }),
     http.patch(REST_URL, async ({ request }) => {
       await delay(update.durationOrMode)
@@ -128,6 +163,35 @@ function buildCategorySettingsResponse(
           ]
         : [],
     }))
+}
+
+function buildCreatedCategorySettingsRow(
+  body: CreateCategoryWithBudgetBody,
+  rows: CategorySettingsResponseRow[],
+  currentBookId: number,
+): CategorySettingsResponseRow {
+  const id = Math.max(0, ...rows.map((row) => row.id)) + 1
+  const amount = body.p_budget_amount
+  const effectiveFrom = body.p_budget_effective_from
+
+  return {
+    id,
+    book_id: currentBookId,
+    name: body.p_category_name,
+    category_budgets:
+      amount !== undefined && effectiveFrom
+        ? [
+            {
+              id: Math.max(0, ...rows.flatMap((row) => row.category_budgets.map((b) => b.id))) + 1,
+              amount,
+              effective_from: effectiveFrom,
+              effective_year: Number.parseInt(effectiveFrom.slice(0, 4), 10),
+              effective_month: Number.parseInt(effectiveFrom.slice(5, 7), 10),
+            },
+          ]
+        : [],
+    category_pins: [],
+  }
 }
 
 function parseUpdateCategoryId(url: string): number | undefined {


### PR DESCRIPTION
## 関連Issue

- closes #1285

## 変更内容

- 設定画面の Categories にカテゴリ作成 modal / form を追加
- カテゴリ名のみ、または任意の月予算金額つきで作成できる導線を追加
- 作成後の一覧更新を確認できる MSW handler と component test を追加
- 月予算 field のエラー表示を入力欄へ関連付けられるよう `AmountInput` の aria 属性透過を追加

## 動作確認

- [x] `pnpm run web:lint`
- [x] `pnpm run web:format-check`
- [x] `pnpm run web:typecheck`
- [x] `pnpm --filter web exec vp test run --project unit --project integration --reporter=dot --silent`

## 補足

- Storybook browser test は `browser-test` 対象の変更ではないため未実行
- `AmountInput` の入力仕様を緩くする対応は #1376 に分離