### PR TITLE
カテゴリ更新用RPCを追加する

### DIFF
--- a/apps/api/supabase/migrations/20260526000000_update_category_with_budget_function.sql
+++ b/apps/api/supabase/migrations/20260526000000_update_category_with_budget_function.sql
@@ -1,0 +1,61 @@
+create or replace function update_category_budget_updated_at()
+returns trigger as $$
+begin
+  new.updated_at := current_timestamp;
+  return new;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+drop trigger if exists trg_update_category_budget_updated_at on category_budgets;
+
+create trigger trg_update_category_budget_updated_at
+  before update on category_budgets
+  for each row
+  execute function update_category_budget_updated_at();
+
+create or replace function update_category_with_budget(
+  p_category_id bigint,
+  p_category_name text,
+  p_category_budget_id bigint,
+  p_budget_amount integer
+)
+returns void as $$
+declare
+  updated_category_count integer;
+  updated_category_budget_count integer;
+begin
+  update categories
+  set name = p_category_name
+  where categories.id = p_category_id;
+
+  get diagnostics updated_category_count = row_count;
+
+  if updated_category_count <> 1 then
+    raise exception 'Category was not updated.'
+      using errcode = 'P0002';
+  end if;
+
+  update category_budgets
+  set amount = p_budget_amount
+  where category_budgets.id = p_category_budget_id
+    and category_budgets.category_id = p_category_id
+    and exists (
+      select 1
+      from categories
+      where categories.id = p_category_id
+        and categories.book_id = category_budgets.book_id
+    );
+
+  get diagnostics updated_category_budget_count = row_count;
+
+  if updated_category_budget_count <> 1 then
+    raise exception 'Category budget was not updated.'
+      using errcode = 'P0002';
+  end if;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+revoke all on function public.update_category_with_budget(bigint, text, bigint, integer) from public;
+revoke all on function public.update_category_with_budget(bigint, text, bigint, integer) from anon;
+grant execute on function public.update_category_with_budget(bigint, text, bigint, integer) to authenticated;
+grant execute on function public.update_category_with_budget(bigint, text, bigint, integer) to service_role;

--- a/apps/web/src/types/database.types.ts
+++ b/apps/web/src/types/database.types.ts
@@ -346,6 +346,15 @@ export type Database = {
       get_authenticated_default_book_id: { Args: never; Returns: number }
       get_authenticated_user_id: { Args: never; Returns: number }
       get_monthly_total_amount: { Args: { p_month: string }; Returns: number }
+      update_category_with_budget: {
+        Args: {
+          p_budget_amount: number
+          p_category_budget_id: number
+          p_category_id: number
+          p_category_name: string
+        }
+        Returns: undefined
+      }
     }
     Enums: {
       [_ in never]: never


### PR DESCRIPTION
## 関連Issue

- closes #1267

## 変更内容

- カテゴリ名とカテゴリ別月予算額を同一トランザクションで更新するRPCを追加
- `category_budgets.updated_at` 更新triggerを追加
- `database.types.ts` にRPC型を同期

## 動作確認

- [x] ローカルDBにmigrationをpsqlで適用し、RPCの正常更新・updated_at更新・不一致時rollback・非member更新拒否を確認
- [x] `pnpm run web:typecheck`
- [x] `pnpm run web:lint`
- [x] `pnpm run web:format-check`
- [x] `pnpm --filter web exec vp test run --project unit --project integration --reporter=dot --silent`

## 補足

- `pnpm --filter api migrations:up` は既存のSupabase config parse問題で失敗したため、migration SQL自体はpsqlで検証しています
- UI変更はありません