### PR TITLE
カテゴリ更新RPCを呼ぶWeb更新処理を追加

### DIFF
--- a/apps/web/src/features/categories/updateCategory/categoryUpdateError.test.ts
+++ b/apps/web/src/features/categories/updateCategory/categoryUpdateError.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "vite-plus/test"
+
+import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../utils/postgresError"
+import { toCategoryUpdateErrorMessage } from "./categoryUpdateError"
+
+describe("toCategoryUpdateErrorMessage", () => {
+  test("PostgreSQL unique_violationは重複カテゴリ名メッセージに変換する", () => {
+    expect(
+      toCategoryUpdateErrorMessage({
+        code: POSTGRES_UNIQUE_VIOLATION_CODE,
+        message: "duplicate key value violates unique constraint",
+      }),
+    ).toBe("A category with this name already exists.")
+  })
+
+  test("その他のエラーは汎用メッセージに変換する", () => {
+    expect(toCategoryUpdateErrorMessage({ message: "network error" })).toBe(
+      "Failed to update category.",
+    )
+  })
+})

--- a/apps/web/src/features/categories/updateCategory/categoryUpdateError.ts
+++ b/apps/web/src/features/categories/updateCategory/categoryUpdateError.ts
@@ -1,0 +1,12 @@
+import { isPostgresUniqueViolationError } from "../../../utils/postgresError"
+
+const DUPLICATE_CATEGORY_NAME_MESSAGE = "A category with this name already exists."
+const GENERIC_UPDATE_CATEGORY_MESSAGE = "Failed to update category."
+
+export function toCategoryUpdateErrorMessage(error: unknown): string {
+  if (isPostgresUniqueViolationError(error)) {
+    return DUPLICATE_CATEGORY_NAME_MESSAGE
+  }
+
+  return GENERIC_UPDATE_CATEGORY_MESSAGE
+}

--- a/apps/web/src/features/categories/updateCategory/categoryUpdateMappers.test.ts
+++ b/apps/web/src/features/categories/updateCategory/categoryUpdateMappers.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vite-plus/test"
+
+import { toCategoryUpdateRpcArgs } from "./categoryUpdateMappers"
+
+describe("toCategoryUpdateRpcArgs", () => {
+  test("カテゴリ更新RPCの引数に変換する", () => {
+    const args = toCategoryUpdateRpcArgs({
+      categoryId: 10,
+      name: "Groceries",
+      categoryBudgetId: 30,
+      budgetAmount: 50000,
+    })
+
+    expect(args).toEqual({
+      p_category_id: 10,
+      p_category_name: "Groceries",
+      p_category_budget_id: 30,
+      p_budget_amount: 50000,
+    })
+    expect(args).not.toHaveProperty("effective_from")
+    expect(args).not.toHaveProperty("category_id")
+  })
+})

--- a/apps/web/src/features/categories/updateCategory/categoryUpdateMappers.ts
+++ b/apps/web/src/features/categories/updateCategory/categoryUpdateMappers.ts
@@ -1,0 +1,19 @@
+import type { Database } from "../../../types/database.types"
+
+type CategoryUpdateRpcArgs = Database["public"]["Functions"]["update_category_with_budget"]["Args"]
+
+export interface CategoryUpdateInput {
+  categoryId: number
+  name: string
+  categoryBudgetId: number
+  budgetAmount: number
+}
+
+export function toCategoryUpdateRpcArgs(value: CategoryUpdateInput): CategoryUpdateRpcArgs {
+  return {
+    p_category_id: value.categoryId,
+    p_category_name: value.name,
+    p_category_budget_id: value.categoryBudgetId,
+    p_budget_amount: value.budgetAmount,
+  }
+}

--- a/apps/web/src/features/categories/updateCategory/updateCategory.integration.test.ts
+++ b/apps/web/src/features/categories/updateCategory/updateCategory.integration.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { createCategorySettingsHandlers } from "../../../test/msw/handlers/categorySettings"
+import { server } from "../../../test/msw/server"
+import { supabaseTestClient } from "../../../test/utils/createSupabaseTestClient"
+import { fetchCategorySettingsItems } from "../listCategorySettings/fetchCategorySettingsItems"
+import { updateCategory } from "./updateCategory"
+
+vi.mock("../../../lib/supabase", () => ({
+  getSupabaseClient: () => supabaseTestClient,
+}))
+
+const foodCategory = {
+  id: 10,
+  book_id: 1,
+  name: "Food",
+  category_budgets: [
+    {
+      id: 30,
+      amount: 50000,
+      effective_from: "2026-05-01",
+      effective_year: 2026,
+      effective_month: 5,
+    },
+  ],
+  category_pins: [],
+}
+
+const dailyNecessitiesCategory = {
+  id: 20,
+  book_id: 1,
+  name: "Daily Necessities",
+  category_budgets: [
+    {
+      id: 40,
+      amount: 30000,
+      effective_from: "2026-05-01",
+      effective_year: 2026,
+      effective_month: 5,
+    },
+  ],
+  category_pins: [],
+}
+
+describe("updateCategory", () => {
+  beforeEach(() => {
+    server.resetHandlers(
+      ...createCategorySettingsHandlers({
+        response: [foodCategory, dailyNecessitiesCategory],
+      }),
+    )
+  })
+
+  it("RPCでカテゴリ名とカテゴリ別予算額を更新し、カテゴリ設定一覧に反映する", async () => {
+    await updateCategory({
+      categoryId: 10,
+      name: "Groceries",
+      categoryBudgetId: 30,
+      budgetAmount: 55000,
+    })
+
+    const items = await fetchCategorySettingsItems()
+
+    expect(items[0]).toMatchObject({
+      category: {
+        id: 10,
+        name: "Groceries",
+      },
+      latestCategoryBudget: {
+        id: 30,
+        amount: 55000,
+        effectiveYear: 2026,
+        effectiveMonth: 5,
+      },
+    })
+    expect(items[0]?.latestCategoryBudget?.effectiveFrom).toEqual(new Date(2026, 4, 1))
+    expect(items[1]).toMatchObject({
+      category: {
+        id: 20,
+        name: "Daily Necessities",
+      },
+      latestCategoryBudget: {
+        id: 40,
+        amount: 30000,
+      },
+    })
+  })
+
+  it("カテゴリとカテゴリ別予算が一致しない場合は状態を変えずにrejectする", async () => {
+    await expect(
+      updateCategory({
+        categoryId: 10,
+        name: "Groceries",
+        categoryBudgetId: 40,
+        budgetAmount: 55000,
+      }),
+    ).rejects.toMatchObject({
+      message: "Category budget was not updated.",
+    })
+
+    const items = await fetchCategorySettingsItems()
+
+    expect(items[0]).toMatchObject({
+      category: {
+        id: 10,
+        name: "Food",
+      },
+      latestCategoryBudget: {
+        id: 30,
+        amount: 50000,
+      },
+    })
+    expect(items[1]).toMatchObject({
+      category: {
+        id: 20,
+        name: "Daily Necessities",
+      },
+      latestCategoryBudget: {
+        id: 40,
+        amount: 30000,
+      },
+    })
+  })
+})

--- a/apps/web/src/features/categories/updateCategory/updateCategory.test.ts
+++ b/apps/web/src/features/categories/updateCategory/updateCategory.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { updateCategory } from "./updateCategory"
+
+const mockRpc = vi.fn()
+const mockFrom = vi.fn(() => {
+  throw new Error("Direct table update must not be used.")
+})
+
+vi.mock("../../../lib/supabase", () => ({
+  getSupabaseClient: () => ({ rpc: mockRpc, from: mockFrom }),
+}))
+
+describe("updateCategory", () => {
+  beforeEach(() => {
+    mockRpc.mockReset()
+    mockFrom.mockClear()
+  })
+
+  it("カテゴリ更新RPCを呼ぶ", async () => {
+    mockRpc.mockResolvedValue({ data: undefined, error: null })
+
+    await expect(
+      updateCategory({
+        categoryId: 10,
+        name: "Groceries",
+        categoryBudgetId: 30,
+        budgetAmount: 50000,
+      }),
+    ).resolves.toBeUndefined()
+
+    expect(mockRpc).toHaveBeenCalledWith("update_category_with_budget", {
+      p_category_id: 10,
+      p_category_name: "Groceries",
+      p_category_budget_id: 30,
+      p_budget_amount: 50000,
+    })
+    expect(mockFrom).not.toHaveBeenCalled()
+  })
+
+  it("RPCの戻り値dataに依存せず成功扱いにする", async () => {
+    mockRpc.mockResolvedValue({ data: null, error: null })
+
+    await expect(
+      updateCategory({
+        categoryId: 10,
+        name: "Groceries",
+        categoryBudgetId: 30,
+        budgetAmount: 50000,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it("Supabaseがエラーを返した場合にthrowする", async () => {
+    const supabaseError = { message: "更新に失敗しました", code: "42501" }
+    mockRpc.mockResolvedValue({ data: null, error: supabaseError })
+
+    await expect(
+      updateCategory({
+        categoryId: 10,
+        name: "Groceries",
+        categoryBudgetId: 30,
+        budgetAmount: 50000,
+      }),
+    ).rejects.toEqual(supabaseError)
+  })
+})

--- a/apps/web/src/features/categories/updateCategory/updateCategory.ts
+++ b/apps/web/src/features/categories/updateCategory/updateCategory.ts
@@ -1,0 +1,14 @@
+import { getSupabaseClient } from "../../../lib/supabase"
+import { type CategoryUpdateInput, toCategoryUpdateRpcArgs } from "./categoryUpdateMappers"
+
+export async function updateCategory(value: CategoryUpdateInput): Promise<void> {
+  const supabase = getSupabaseClient()
+  const { error } = await supabase.rpc(
+    "update_category_with_budget",
+    toCategoryUpdateRpcArgs(value),
+  )
+
+  if (error) {
+    throw error
+  }
+}

--- a/apps/web/src/features/categories/updateCategory/useUpdateCategory.test.tsx
+++ b/apps/web/src/features/categories/updateCategory/useUpdateCategory.test.tsx
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { act, createTestQueryClient, renderHook } from "../../../test/test-utils"
+import { summaryQueryKeys } from "../../summaryByMonth/queryKeys"
+import { categoryQueryKeys } from "../queryKeys"
+import { useUpdateCategory } from "./useUpdateCategory"
+
+const { mockUpdateCategory } = vi.hoisted(() => ({
+  mockUpdateCategory: vi.fn(),
+}))
+
+vi.mock("./updateCategory", () => ({
+  updateCategory: mockUpdateCategory,
+}))
+
+describe("useUpdateCategory", () => {
+  beforeEach(() => {
+    mockUpdateCategory.mockReset()
+  })
+
+  it("成功時にカテゴリ作成と同じqueryをinvalidateしてresolveする", async () => {
+    const queryClient = createTestQueryClient()
+    const invalidateQueries = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined)
+    const input = {
+      categoryId: 10,
+      name: "Groceries",
+      categoryBudgetId: 30,
+      budgetAmount: 50000,
+    }
+    mockUpdateCategory.mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useUpdateCategory(), {
+      queryClient,
+    })
+
+    await act(async () => {
+      const promise = result.current.updateCategory(input)
+
+      expect(promise).toBeInstanceOf(Promise)
+      await promise
+    })
+
+    expect(mockUpdateCategory).toHaveBeenCalledTimes(1)
+    expect(mockUpdateCategory.mock.calls[0]?.[0]).toBe(input)
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: categoryQueryKeys.all })
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: summaryQueryKeys.categoryTotalsAll })
+    expect(invalidateQueries).toHaveBeenCalledTimes(2)
+  })
+
+  it("失敗時にqueryをinvalidateせずrejectする", async () => {
+    const queryClient = createTestQueryClient()
+    const invalidateQueries = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined)
+    const error = { message: "更新に失敗しました", code: "42501" }
+    mockUpdateCategory.mockRejectedValue(error)
+
+    const { result } = renderHook(() => useUpdateCategory(), {
+      queryClient,
+    })
+
+    await act(async () => {
+      await expect(
+        result.current.updateCategory({
+          categoryId: 10,
+          name: "Groceries",
+          categoryBudgetId: 30,
+          budgetAmount: 50000,
+        }),
+      ).rejects.toEqual(error)
+    })
+
+    expect(invalidateQueries).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/features/categories/updateCategory/useUpdateCategory.ts
+++ b/apps/web/src/features/categories/updateCategory/useUpdateCategory.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useCallback } from "react"
+
+import { summaryQueryKeys } from "../../summaryByMonth/queryKeys"
+import { invalidateCategoryQueries } from "../queryKeys"
+import type { CategoryUpdateInput } from "./categoryUpdateMappers"
+import { updateCategory as updateCategoryRecord } from "./updateCategory"
+
+interface UseUpdateCategoryReturn {
+  updateCategory: (value: CategoryUpdateInput) => Promise<void>
+  isPending: boolean
+}
+
+export function useUpdateCategory(): UseUpdateCategoryReturn {
+  const queryClient = useQueryClient()
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: updateCategoryRecord,
+    onSuccess: async () => {
+      await Promise.all([
+        invalidateCategoryQueries(queryClient),
+        queryClient.invalidateQueries({ queryKey: summaryQueryKeys.categoryTotalsAll }),
+      ])
+    },
+  })
+
+  const updateCategory = useCallback(
+    async (value: CategoryUpdateInput) => {
+      return mutateAsync(value)
+    },
+    [mutateAsync],
+  )
+
+  return { updateCategory, isPending }
+}

--- a/apps/web/src/test/msw/handlers/categorySettings.ts
+++ b/apps/web/src/test/msw/handlers/categorySettings.ts
@@ -42,6 +42,12 @@ interface UpdateCategorySettingsOptions {
   durationOrMode?: number | DelayMode | undefined
 }
 
+interface UpdateCategoryWithBudgetOptions {
+  error?: boolean
+  errorResponse?: unknown
+  durationOrMode?: number | DelayMode | undefined
+}
+
 interface CreateCategorySettingsOptions {
   error?: boolean
   errorResponse?: unknown
@@ -58,8 +64,16 @@ const createCategoryWithBudgetBodySchema = z.object({
   p_budget_amount: z.number().optional(),
 })
 
+const updateCategoryWithBudgetBodySchema = z.object({
+  p_category_id: z.number(),
+  p_category_name: z.string(),
+  p_category_budget_id: z.number(),
+  p_budget_amount: z.number(),
+})
+
 type UpdateCategoryNameBody = z.infer<typeof updateCategoryNameBodySchema>
 type CreateCategoryWithBudgetBody = z.infer<typeof createCategoryWithBudgetBodySchema>
+type UpdateCategoryWithBudgetBody = z.infer<typeof updateCategoryWithBudgetBodySchema>
 
 export function createCategorySettingsHandlers({
   response,
@@ -69,9 +83,11 @@ export function createCategorySettingsHandlers({
   durationOrMode,
   create = {},
   update = {},
+  updateCategory = {},
 }: GetCategorySettingsOptions & {
   create?: CreateCategorySettingsOptions
   update?: UpdateCategorySettingsOptions
+  updateCategory?: UpdateCategoryWithBudgetOptions
 } = {}) {
   let rows = response ?? buildCategorySettingsResponse(currentBookId, pinnedCategoryIds)
 
@@ -102,6 +118,28 @@ export function createCategorySettingsHandlers({
       rows = [...rows, createdRow]
 
       return HttpResponse.json(createdRow.id)
+    }),
+    http.post("*/rest/v1/rpc/update_category_with_budget", async ({ request }) => {
+      await delay(updateCategory.durationOrMode)
+
+      if (updateCategory.error) {
+        return HttpResponse.json(
+          updateCategory.errorResponse ?? { message: "Failed to update category." },
+          { status: 500 },
+        )
+      }
+
+      const body = await request.json()
+      const parsedBody = updateCategoryWithBudgetBodySchema.parse(body)
+      const updatedRows = buildUpdatedCategorySettingsRowsWithBudget(parsedBody, rows)
+
+      if (!updatedRows) {
+        return HttpResponse.json({ message: "Category budget was not updated." }, { status: 400 })
+      }
+
+      rows = updatedRows
+
+      return HttpResponse.json(null)
     }),
     http.patch(REST_URL, async ({ request }) => {
       await delay(update.durationOrMode)
@@ -221,6 +259,39 @@ function buildUpdatedCategorySettingsRow(
     ...row,
     name: body.name,
   }
+}
+
+function buildUpdatedCategorySettingsRowsWithBudget(
+  body: UpdateCategoryWithBudgetBody,
+  rows: CategorySettingsResponseRow[],
+): CategorySettingsResponseRow[] | undefined {
+  const targetRow = rows.find((category) => category.id === body.p_category_id)
+  const targetBudget = targetRow?.category_budgets.find(
+    (budget) => budget.id === body.p_category_budget_id,
+  )
+
+  if (!targetRow || !targetBudget) {
+    return undefined
+  }
+
+  return rows.map((row) => {
+    if (row.id !== body.p_category_id) {
+      return row
+    }
+
+    return {
+      ...row,
+      name: body.p_category_name,
+      category_budgets: row.category_budgets.map((budget) =>
+        budget.id === body.p_category_budget_id
+          ? {
+              ...budget,
+              amount: body.p_budget_amount,
+            }
+          : budget,
+      ),
+    }
+  })
 }
 
 export const categorySettingsHandlers = createCategorySettingsHandlers()


### PR DESCRIPTION
## 関連Issue

- closes #1268

## 変更内容

- update_category_with_budget RPC を呼ぶ updateCategory API、mapper、mutation hook、エラー変換を追加
- categorySettings MSW handler に RPC 更新 mock を追加し、カテゴリ名と対象予算額だけを更新
- mapper / API / hook / error helper / MSW integration のテストを追加

## 動作確認

- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] pnpm --filter web exec vp test run --project unit --project integration --reporter=dot --silent
- [ ] UIの確認（UI変更なし）