### PR TITLE
MSW handler の rows 管理を削除

### DIFF
--- a/apps/web/src/features/budgets/latestMonthlyBudget/LatestMonthlyBudget/LatestMonthlyBudget.test.tsx
+++ b/apps/web/src/features/budgets/latestMonthlyBudget/LatestMonthlyBudget/LatestMonthlyBudget.test.tsx
@@ -153,6 +153,11 @@ describe("LatestMonthlyBudget", () => {
 
     await user.clear(amountInput)
     await user.type(amountInput, "82000")
+    server.resetHandlers(
+      ...createMonthlyBudgetHandlers({
+        list: { response: [{ ...monthlyBudgets[3], amount: 82000 }, monthlyBudgets[2]] },
+      }),
+    )
     await user.click(within(dialog).getByRole("button", { name: "Save" }))
 
     await waitFor(() => {

--- a/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.test.tsx
+++ b/apps/web/src/features/categories/components/CategorySettingsList/CategorySettingsList.test.tsx
@@ -2,12 +2,50 @@ import { composeStories } from "@storybook/react-vite"
 import type { ReactElement } from "react"
 import { beforeEach, describe, expect, test } from "vite-plus/test"
 
-import { createCategorySettingsHandlers } from "../../../../test/msw/handlers/categorySettings"
+import {
+  type CategorySettingsResponseRow,
+  createCategorySettingsHandlers,
+} from "../../../../test/msw/handlers/categorySettings"
 import { server } from "../../../../test/msw/server"
 import { act, render, screen, waitFor, within } from "../../../../test/test-utils"
 import * as stories from "./CategorySettingsList.stories"
 
 const { Default } = composeStories(stories)
+
+const defaultCategorySettingsResponse: CategorySettingsResponseRow[] = [
+  {
+    id: 10,
+    book_id: 1,
+    name: "Food",
+    category_pins: [{ id: 10, category_id: 10 }],
+  },
+  {
+    id: 20,
+    book_id: 1,
+    name: "Daily Necessities",
+    category_pins: [],
+  },
+  {
+    id: 30,
+    book_id: 1,
+    name: "Entertainment",
+    category_pins: [],
+  },
+]
+
+const renamedCategorySettingsResponse = defaultCategorySettingsResponse.map((row) =>
+  row.id === 10 ? { ...row, name: "Groceries" } : row,
+)
+
+const createdCategoryResponse: CategorySettingsResponseRow[] = [
+  ...defaultCategorySettingsResponse,
+  {
+    id: 999,
+    book_id: 1,
+    name: "Groceries",
+    category_pins: [],
+  },
+]
 
 async function renderCategorySettingsList(story: ReactElement) {
   return await act(async () => {
@@ -50,6 +88,9 @@ describe("CategorySettingsList", () => {
   })
 
   test("カテゴリ名を更新して一覧に反映する", async () => {
+    server.resetHandlers(
+      ...createCategorySettingsHandlers({ response: defaultCategorySettingsResponse }),
+    )
     const { user } = await renderCategorySettingsList(<Default />)
 
     await user.click(
@@ -62,6 +103,9 @@ describe("CategorySettingsList", () => {
 
     await user.clear(within(dialog).getByRole("textbox", { name: /Name/ }))
     await user.type(within(dialog).getByRole("textbox", { name: /Name/ }), "Groceries")
+    server.resetHandlers(
+      ...createCategorySettingsHandlers({ response: renamedCategorySettingsResponse }),
+    )
     await user.click(within(dialog).getByRole("button", { name: "Save" }))
 
     await waitFor(() => {
@@ -73,12 +117,16 @@ describe("CategorySettingsList", () => {
   })
 
   test("カテゴリを作成して一覧に反映する", async () => {
+    server.resetHandlers(
+      ...createCategorySettingsHandlers({ response: defaultCategorySettingsResponse }),
+    )
     const { user } = await renderCategorySettingsList(<Default />)
 
     await user.click(await screen.findByRole("button", { name: "Create category" }))
     const dialog = await screen.findByRole("dialog", { name: "Create category" })
 
     await user.type(within(dialog).getByRole("textbox", { name: /Name/ }), "Groceries")
+    server.resetHandlers(...createCategorySettingsHandlers({ response: createdCategoryResponse }))
     await user.click(within(dialog).getByRole("button", { name: "Create" }))
 
     await waitFor(() => {

--- a/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.test.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.test.tsx
@@ -144,4 +144,24 @@ describe("UpdateCategoryNameForm", () => {
     expect(await screen.findByText("Failed to update category name.")).toBeInTheDocument()
     expect(onSuccess).not.toHaveBeenCalled()
   })
+
+  test("更新対象が返らない場合は保存エラーを表示してonSuccessを呼ばない", async () => {
+    server.resetHandlers(
+      ...createCategorySettingsHandlers({
+        update: {
+          response: null,
+        },
+      }),
+    )
+    const onSuccess = fn()
+    const { user } = await renderStory(<Default onSuccess={onSuccess} />)
+    const nameInput = screen.getByRole("textbox", { name: /Name/ })
+
+    await user.clear(nameInput)
+    await user.type(nameInput, "Groceries")
+    await user.click(screen.getByRole("button", { name: "Save" }))
+
+    expect(await screen.findByText("Failed to update category name.")).toBeInTheDocument()
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
 })

--- a/apps/web/src/test/msw/handlers/categorySettings.ts
+++ b/apps/web/src/test/msw/handlers/categorySettings.ts
@@ -27,12 +27,14 @@ interface GetCategorySettingsOptions {
 }
 
 interface UpdateCategorySettingsOptions {
+  response?: { id: number } | null
   error?: boolean
   errorResponse?: unknown
   durationOrMode?: number | DelayMode | undefined
 }
 
 interface CreateCategorySettingsOptions {
+  responseId?: number
   error?: boolean
   errorResponse?: unknown
   durationOrMode?: number | DelayMode | undefined
@@ -46,9 +48,6 @@ const createCategoryBodySchema = z.object({
   name: z.string(),
 })
 
-type UpdateCategoryNameBody = z.infer<typeof updateCategoryNameBodySchema>
-type CreateCategoryBody = z.infer<typeof createCategoryBodySchema>
-
 export function createCategorySettingsHandlers({
   response,
   currentBookId = CURRENT_BOOK_ID,
@@ -61,7 +60,7 @@ export function createCategorySettingsHandlers({
   create?: CreateCategorySettingsOptions
   update?: UpdateCategorySettingsOptions
 } = {}) {
-  let rows = response ?? buildCategorySettingsResponse(currentBookId, pinnedCategoryIds)
+  const rows = response ?? buildCategorySettingsResponse(currentBookId, pinnedCategoryIds)
 
   return [
     http.get(REST_URL, async () => {
@@ -84,12 +83,9 @@ export function createCategorySettingsHandlers({
       }
 
       const body = await request.json()
-      const parsedBody = createCategoryBodySchema.parse(body)
-      const createdRow = buildCreatedCategorySettingsRow(parsedBody, rows, currentBookId)
+      createCategoryBodySchema.parse(body)
 
-      rows = [...rows, createdRow]
-
-      return HttpResponse.json({ id: createdRow.id })
+      return HttpResponse.json({ id: create.responseId ?? 999 })
     }),
     http.patch(REST_URL, async ({ request }) => {
       await delay(update.durationOrMode)
@@ -102,15 +98,11 @@ export function createCategorySettingsHandlers({
       }
 
       const body = await request.json()
-      const parsedBody = updateCategoryNameBodySchema.parse(body)
+      updateCategoryNameBodySchema.parse(body)
       const id = parseUpdateCategoryId(request.url)
-      const updatedRow = buildUpdatedCategorySettingsRow(id, parsedBody, rows)
+      const updatedRow = buildUpdatedCategorySettingsRow(id)
 
-      if (updatedRow) {
-        rows = rows.map((row) => (row.id === updatedRow.id ? updatedRow : row))
-      }
-
-      return HttpResponse.json(updatedRow ? { id: updatedRow.id } : null)
+      return HttpResponse.json(update.response ?? updatedRow)
     }),
   ]
 }
@@ -136,21 +128,6 @@ function buildCategorySettingsResponse(
     }))
 }
 
-function buildCreatedCategorySettingsRow(
-  body: CreateCategoryBody,
-  rows: CategorySettingsResponseRow[],
-  currentBookId: number,
-): CategorySettingsResponseRow {
-  const id = Math.max(0, ...rows.map((row) => row.id)) + 1
-
-  return {
-    id,
-    book_id: currentBookId,
-    name: body.name,
-    category_pins: [],
-  }
-}
-
 function parseUpdateCategoryId(url: string): number | undefined {
   const idParam = new URL(url).searchParams.get("id")
 
@@ -163,21 +140,12 @@ function parseUpdateCategoryId(url: string): number | undefined {
   return Number.isInteger(id) ? id : undefined
 }
 
-function buildUpdatedCategorySettingsRow(
-  id: number | undefined,
-  body: UpdateCategoryNameBody,
-  rows: CategorySettingsResponseRow[],
-): CategorySettingsResponseRow | undefined {
-  const row = rows.find((category) => category.id === id)
-
-  if (!row) {
-    return undefined
+function buildUpdatedCategorySettingsRow(id: number | undefined): { id: number } | null {
+  if (id === undefined) {
+    return null
   }
 
-  return {
-    ...row,
-    name: body.name,
-  }
+  return { id }
 }
 
 export const categorySettingsHandlers = createCategorySettingsHandlers()

--- a/apps/web/src/test/msw/handlers/categorySettings.ts
+++ b/apps/web/src/test/msw/handlers/categorySettings.ts
@@ -102,7 +102,7 @@ export function createCategorySettingsHandlers({
       const id = parseUpdateCategoryId(request.url)
       const updatedRow = buildUpdatedCategorySettingsRow(id)
 
-      return HttpResponse.json(update.response ?? updatedRow)
+      return HttpResponse.json("response" in update ? update.response : updatedRow)
     }),
   ]
 }

--- a/apps/web/src/test/msw/handlers/monthlyBudgets.ts
+++ b/apps/web/src/test/msw/handlers/monthlyBudgets.ts
@@ -53,7 +53,7 @@ export function createMonthlyBudgetHandlers(options: CreateMonthlyBudgetHandlers
   const list = options.list ?? {}
   const create = options.create ?? {}
   const update = options.update ?? {}
-  let listRows = list.response ? [...list.response] : [...monthlyBudgets]
+  const listRows = list.response ?? monthlyBudgets
 
   const monthlyBudgetsHandler = http.get(REST_URL, async ({ request }) => {
     const shouldReturnSingle = shouldReturnSingleObject(request)
@@ -109,10 +109,6 @@ export function createMonthlyBudgetHandlers(options: CreateMonthlyBudgetHandlers
     const parsedBody = updateMonthlyBudgetBodySchema.parse(body)
     const id = parseUpdateMonthlyBudgetId(request.url)
     const updatedRow = update.response ?? buildUpdatedMonthlyBudgetRow(id, parsedBody, listRows)
-
-    if (updatedRow) {
-      listRows = listRows.map((row) => (row.id === updatedRow.id ? updatedRow : row))
-    }
 
     return HttpResponse.json(updatedRow ? { id: updatedRow.id } : null)
   })


### PR DESCRIPTION
## 関連Issue

- closes #1374

## 変更内容

- MSW handler 内で mutation 後に rows / listRows を更新する処理を削除
- 作成・更新後の UI 更新テストを、handler 状態ではなくテスト側の固定 response で確認する形へ変更

## 動作確認

- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] CI=true pnpm --filter web exec vp test run --project unit --project integration --reporter=dot --silent