### PR TITLE
fix: カテゴリ作成時のbook_id defaultを復元

### DIFF
--- a/apps/api/supabase/migrations/20260530010000_restore_category_book_id_default.sql
+++ b/apps/api/supabase/migrations/20260530010000_restore_category_book_id_default.sql
@@ -1,0 +1,2 @@
+alter table categories
+  alter column book_id set default get_authenticated_default_book_id();


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- `categories.book_id` に `get_authenticated_default_book_id()` の default を再設定する migration を追加
- カテゴリ名だけで作成する既存の Web 実装が RLS を通過できるように修正

## 動作確認

- [x] `pnpm run api:migrations:up`
- [x] authenticated role で `insert into public.categories (name) ...` が成功することを確認

## 補足

- API 側には専用の自動検証コマンド定義がないため、migration 適用と SQL で確認しています