### PR TITLE
test: 支払い詳細storyのカテゴリ検索範囲を絞る

### DIFF
--- a/apps/web/src/app/routes/PaymentsPage/PaymentPage.stories.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentPage.stories.tsx
@@ -60,7 +60,8 @@ export const OpenDetails: Story = {
     const canvas = within(canvasElement)
     const body = within(canvasElement.ownerDocument.body)
     await canvas.findByText("2025/06/03")
-    expect(await canvas.findByText("Daily Necessities")).toBeInTheDocument()
+    const paymentList = await canvas.findByLabelText("payment-list")
+    expect(await within(paymentList).findByText("Daily Necessities")).toBeInTheDocument()
 
     const paymentButtons = await canvas.findAllByRole("button", { name: /コンビニ/ })
     const paymentButton = paymentButtons[0]


### PR DESCRIPTION
## 関連Issue

- 関連PR: #1428

## 変更内容

- PaymentsPage の Storybook interaction test で、カテゴリ名の検索範囲を支払い一覧に限定
- 月次サマリと支払い一覧に同じカテゴリ名がある場合の複数一致を回避

## 動作確認

- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] pnpm --filter web exec vp test run --project unit --project integration --reporter=dot --silent
- [x] pnpm --filter web test:storybook --reporter=dot --silent
