### PR TITLE
test: PaymentsPage storybook testを安定化

### DIFF
--- a/apps/web/src/app/routes/PaymentsPage/PaymentPage.stories.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentPage.stories.tsx
@@ -28,7 +28,6 @@ const meta = {
     },
   },
   tags: ["autodocs", "browser-test"],
-  decorators: [createStoryRouter("/payments?year=2025&month=6", paymentsRouteBuilder)],
   argTypes: {},
   args: {},
 } satisfies Meta<typeof PaymentsPage>
@@ -38,6 +37,7 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {},
+  decorators: [createStoryRouter("/payments?year=2025&month=6", paymentsRouteBuilder)],
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
@@ -46,26 +46,24 @@ export const Default: Story = {
     expect(await canvas.findAllByText("コンビニ")).toHaveLength(2)
     expect(await canvas.findAllByRole("button", { name: /コンビニ/ })).toHaveLength(2)
     expect(canvas.queryByText("スーパー")).not.toBeInTheDocument()
-    expect(await canvas.findByText("2025/06/02")).toBeInTheDocument()
-    expect(await canvas.findByText("2025/06/03")).toBeInTheDocument()
-    expect(await canvas.findByText("￥1,000")).toBeInTheDocument()
-    expect(await canvas.findByText("￥4,000")).toBeInTheDocument()
+    const paymentList = await canvas.findByLabelText("payment-list")
+    expect(await within(paymentList).findByText("2025/06/02")).toBeInTheDocument()
+    expect(await within(paymentList).findByText("2025/06/03")).toBeInTheDocument()
+    expect(await within(paymentList).findByText("￥1,000")).toBeInTheDocument()
+    expect(await within(paymentList).findByText("￥4,000")).toBeInTheDocument()
     expect(await canvas.findByText("￥20,000 left")).toBeInTheDocument()
   },
 }
 
 export const OpenDetails: Story = {
   args: {},
-  play: async ({ canvasElement, userEvent }) => {
+  decorators: [createStoryRouter("/payments/details/2?year=2025&month=6", paymentsRouteBuilder)],
+  play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const body = within(canvasElement.ownerDocument.body)
     await canvas.findByText("2025/06/03")
     const paymentList = await canvas.findByLabelText("payment-list")
     expect(await within(paymentList).findByText("Daily Necessities")).toBeInTheDocument()
-
-    const paymentButtons = await canvas.findAllByRole("button", { name: /コンビニ/ })
-    const paymentButton = paymentButtons[0]
-    await userEvent.click(paymentButton)
 
     const detailDialog = await body.findByRole("dialog", {
       name: /payment details/i,

--- a/apps/web/src/features/payments/paymentDetails/CategoryField/CategoryField.test.tsx
+++ b/apps/web/src/features/payments/paymentDetails/CategoryField/CategoryField.test.tsx
@@ -5,10 +5,18 @@ import { beforeEach, describe, expect, test, vi } from "vite-plus/test"
 import { categoryHandlers } from "../../../../test/msw/handlers/categories"
 import { createPaymentHandlers } from "../../../../test/msw/handlers/payments"
 import { server } from "../../../../test/msw/server"
-import { render, screen, waitFor } from "../../../../test/test-utils"
+import { act, fireEvent, render, screen, waitFor } from "../../../../test/test-utils"
 import * as stories from "./CategoryField.stories"
 
 const { Default, Unknown } = composeStories(stories)
+
+async function openCategoryEditor() {
+  await act(async () => {
+    fireEvent.click(screen.getByRole("button", { name: /edit category/i }))
+  })
+
+  return await screen.findByRole("combobox", { name: /category/i })
+}
 
 describe("PaymentDetails CategoryField", () => {
   beforeEach(() => {
@@ -24,17 +32,18 @@ describe("PaymentDetails CategoryField", () => {
   })
 
   test("編集ボタンを押すと現在カテゴリを選択した combobox を表示する", async () => {
-    const { user } = render(<Default />)
+    render(<Default />)
 
-    await user.click(screen.getByRole("button", { name: /edit category/i }))
-
-    expect(await screen.findByRole("combobox", { name: /category/i })).toHaveTextContent("Food")
+    const combobox = await openCategoryEditor()
+    await waitFor(() => {
+      expect(combobox).toHaveTextContent("Food")
+    })
   })
 
   test("カテゴリを選ぶと保存して editor を閉じる", async () => {
     const { user } = render(<Default />)
 
-    await user.click(screen.getByRole("button", { name: /edit category/i }))
+    await openCategoryEditor()
     await user.click(await screen.findByRole("combobox", { name: /category/i }))
     await user.click(await screen.findByRole("option", { name: /daily necessities/i }))
 
@@ -55,7 +64,7 @@ describe("PaymentDetails CategoryField", () => {
 
     const { user } = render(<Default />)
 
-    await user.click(screen.getByRole("button", { name: /edit category/i }))
+    await openCategoryEditor()
     await user.click(await screen.findByRole("combobox", { name: /category/i }))
     await user.click(await screen.findByRole("option", { name: /^none$/i }))
 
@@ -67,13 +76,14 @@ describe("PaymentDetails CategoryField", () => {
   })
 
   test("未設定カテゴリの編集開始時は None を選択状態にする", async () => {
-    const { user } = render(<Unknown />)
+    render(<Unknown />)
 
     expect(screen.getByText("Unknown")).toBeInTheDocument()
 
-    await user.click(screen.getByRole("button", { name: /edit category/i }))
-
-    expect(await screen.findByRole("combobox", { name: /category/i })).toHaveTextContent("None")
+    const combobox = await openCategoryEditor()
+    await waitFor(() => {
+      expect(combobox).toHaveTextContent("None")
+    })
   })
 
   test("同じカテゴリを再選択すると API は呼ばずに editor を閉じる", async () => {
@@ -88,7 +98,7 @@ describe("PaymentDetails CategoryField", () => {
 
     const { user } = render(<Default />)
 
-    await user.click(screen.getByRole("button", { name: /edit category/i }))
+    await openCategoryEditor()
     await user.click(await screen.findByRole("combobox", { name: /category/i }))
     await user.click(await screen.findByRole("option", { name: /^food$/i }))
 
@@ -110,7 +120,7 @@ describe("PaymentDetails CategoryField", () => {
 
     const { user } = render(<Default />)
 
-    await user.click(screen.getByRole("button", { name: /edit category/i }))
+    await openCategoryEditor()
     await user.click(await screen.findByRole("combobox", { name: /category/i }))
     await user.keyboard("{Escape}")
 
@@ -130,7 +140,7 @@ describe("PaymentDetails CategoryField", () => {
 
     const { user } = render(<Default />)
 
-    await user.click(screen.getByRole("button", { name: /edit category/i }))
+    await openCategoryEditor()
     await user.click(await screen.findByRole("combobox", { name: /category/i }))
     await user.click(await screen.findByRole("option", { name: /daily necessities/i }))
 
@@ -153,7 +163,7 @@ describe("PaymentDetails CategoryField", () => {
 
     const { user } = render(<Default />)
 
-    await user.click(screen.getByRole("button", { name: /edit category/i }))
+    await openCategoryEditor()
     await user.click(await screen.findByRole("combobox", { name: /category/i }))
     await user.click(await screen.findByRole("option", { name: /daily necessities/i }))
 
@@ -165,7 +175,7 @@ describe("PaymentDetails CategoryField", () => {
     const onEditEnd = vi.fn()
     const { user } = render(<Default onEditStart={onEditStart} onEditEnd={onEditEnd} />)
 
-    await user.click(screen.getByRole("button", { name: /edit category/i }))
+    await openCategoryEditor()
     await user.keyboard("{Escape}")
 
     expect(screen.queryByRole("combobox", { name: /category/i })).not.toBeInTheDocument()


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- PaymentsPage の Storybook browser test で詳細表示を初期 URL から検証するように変更
- 支払い一覧の金額検証を `payment-list` 内に限定し、サマリとの重複一致を回避
- CategoryField テストの編集開始操作を `act` で待ち、Suspense による警告を解消

## 動作確認

- [x] `pnpm run web:lint`
- [x] `pnpm run web:format-check`
- [x] `pnpm run web:typecheck`
- [x] `pnpm --filter web exec vp test run --project unit --project integration --reporter=dot`
- [x] `pnpm --filter web test:storybook --reporter=dot`

## 補足

- `--silent` なしの unit/integration と Storybook browser test で `act` 警告が出ないことを確認済み
