### PR TITLE
Supabase local の不要サービスを無効化する

### DIFF
--- a/apps/api/supabase/config.toml
+++ b/apps/api/supabase/config.toml
@@ -9,3 +9,18 @@ client_id = "env(SUPABASE_GOOGLE_CLIENT_ID)"
 secret = "env(SUPABASE_GOOGLE_CLIENT_SECRET)"
 redirect_uri = "env(SUPABASE_GOOGLE_REDIRECT_URL)"
 skip_nonce_check = "env(SUPABASE_GOOGLE_SKIP_NONCE_CHECK)"
+
+[analytics]
+enabled = false
+
+[storage]
+enabled = false
+
+[edge_runtime]
+enabled = false
+
+[inbucket]
+enabled = false
+
+[realtime]
+enabled = false


### PR DESCRIPTION
## 関連Issue

- #1468

## 変更内容

- Supabase local の未使用候補サービスを config.toml で無効化
- analytics / storage / edge_runtime / inbucket / realtime を対象に設定

## 動作確認

- [ ] ローカルでの動作確認
- [x] TOML 構文確認: python3 -c "import tomllib; tomllib.load(open('apps/api/supabase/config.toml','rb')); print('ok')"
- [ ] UIの確認（スクリーンショット等）

## 補足

- API には専用 verification command が定義されていないため、アプリ検証コマンドは未実行
- pnpm exec supabase --version / start --help は応答が返らなかったため中断
- Supabase local の実起動確認は未実施のため、この PR では closes ではなく関連 Issue として紐づけ