### PR TITLE
docs: Context PacketとScout agentを追加

### DIFF
--- a/.agents/skills/context-scout/SKILL.md
+++ b/.agents/skills/context-scout/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: context-scout
+description: Low-cost repository context scout for bounded discovery, document selection, pattern summaries, and verification-failure summaries before a main Goal executor makes decisions.
+argument-hint: "[scope or question]"
+---
+
+# Context Scout
+
+## Purpose
+
+Find and summarize the smallest useful repository context for a main executor.
+
+Use this skill with the project-scoped custom agent `.codex/agents/context-scout.toml` when a Goal needs bounded read-heavy work before scope, design, edit, or verification decisions. That agent pins a lower-cost model and read-only sandbox for repository discovery.
+
+Do not make product decisions, final design decisions, file edits, GitHub writes, git writes, or Stop-condition judgments.
+
+## Inputs
+
+The caller should provide:
+
+- The target Goal phase or task.
+- Known issue, PR, branch, or artifact paths.
+- The suspected app or docs area.
+- The exact question to answer.
+
+If the input is too broad, return the missing boundary instead of widening the search.
+
+## Allowed Work
+
+- Select candidate docs from `docs/harness/rule-map.json`.
+- Scan Markdown front matter for `area`, `applies_to`, `topics`, `when_to_read`, and `status`.
+- Find related files with targeted `rg` queries.
+- Summarize existing implementation or documentation patterns.
+- Identify likely affected files.
+- Summarize verification failures from provided logs.
+
+## Output Contract
+
+Return only concise findings. Do not paste raw logs, full source, or full document bodies.
+
+Use this shape:
+
+```md
+## Findings
+- <finding> - <file path or command evidence>
+
+## Selected refs
+- <id or path>: <short reason>
+
+## Risks / gaps
+- <risk or missing input>
+
+## Suggested packet items
+- Scope: <short scope material>
+- Constraints: <short constraint material>
+- Stop checks: <short stop material>
+- Verification expectations: <short verification material>
+```
+
+## Stop
+
+Stop and report the missing boundary when:
+
+- The task does not name a phase, artifact, issue, PR, path, or domain clearly enough to search narrowly.
+- The selected docs conflict and the conflict cannot be resolved from `depends_on`, `overrides`, or `priority`.
+- The requested work requires edits, product decisions, final design decisions, git writes, GitHub writes, or user-facing conclusions.

--- a/.agents/skills/context-scout/agents/openai.yaml
+++ b/.agents/skills/context-scout/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Context Scout"
+  short_description: "Low-cost bounded repository discovery and Context Packet material"
+  default_prompt: "Use $context-scout with the context-scout custom agent to find the smallest relevant repository context and return concise file-referenced findings for a main executor."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/goal-builder/SKILL.md
+++ b/.agents/skills/goal-builder/SKILL.md
@@ -41,6 +41,8 @@ Also read these harness docs before deciding additional references:
 
 Use `docs/harness/rule-map.json` to select any additional policy, domain, ADR, design, or app-specific documents. Classify the requested Goal by `path`, `domain`, `activity`, and `topic`, then include the selected document subgraph in the generated Goal inputs.
 
+For non-trivial Goals, generate a compact Context Packet instead of copied document bodies or long discovery notes. The Context Packet is the executor's first-read input and must contain only scope, selected references, constraints, known risks, stop checks, and verification expectations.
+
 The templates are checklists for required content, not output skeletons. Do not copy the template body into the generated Goal. Produce the shortest self-contained Goal that preserves the requested phase, target artifact, scope, constraints, required inputs, Done, Verification, and Stop conditions.
 
 ## Context Discovery
@@ -139,23 +141,37 @@ When the draft would exceed 4000 characters:
 
 Prefer references over copied content, and avoid forcing the executor to rediscover context.
 
+- For non-trivial Goals, pass a compact Context Packet before detailed phase instructions.
+- Build the Context Packet from deterministic selection first: `docs/harness/rule-map.json`, Markdown front matter, path, issue or PR number, branch context, and targeted `rg` results.
 - Pass paths, issue numbers, PR numbers, current branch, and selected rule-map entries instead of copying full document bodies.
 - Include the selected rule-map subgraph and concise selection reasons, not the full rule-map contents.
 - Tell the executor to read the provided references first and avoid broad searches unless the references conflict, are insufficient, or trigger a Stop condition.
 - Do not include unrelated workspace artifacts, old PR notes, or long command output in the generated Goal.
 - For small docs-only, one-file, or already-scoped changes, generate one compact Goal instead of forcing all four phases.
 - Keep verification commands concrete, but do not include historical verification logs unless they are directly required.
+- Keep Context Packet content short enough that the executor can start from it without re-reading broad docs. Prefer 1000 to 1500 characters for the packet when practical.
 
-## Subagent Use
+## Context Packet Shape
 
-Include subagent instructions only when the Goal has bounded read-heavy work that can run independently.
+Use this shape when the Goal is non-trivial:
 
-- Use subagents for file discovery, existing-pattern summaries, selected-doc inspection, upstream scope checks, or verification-failure summaries.
-- Do not use subagents for product scope decisions, final design decisions, file edits, or ambiguous Stop conditions.
-- Prefer lightweight subagents for narrow exploration and summarization.
-- Require the executor to wait for subagent summaries before making the main decision.
-- Keep subagent prompts narrow, and ask for concise findings with file references instead of raw logs or copied source text.
-- Do not add subagent instructions to small one-file or docs-only Goals when direct execution is cheaper.
+- Scope: target artifact, in-scope work, out-of-scope work.
+- Selected refs: file paths, rule-map IDs, and one short reason per reference.
+- Constraints: issue, PRD, Design Doc, policy, and domain boundaries.
+- Known risks: only risks that affect scope, design, verification, or Stop decisions.
+- Stop checks: conditions that require clarification before continuing.
+- Verification expectations: affected app or docs-only verification scope.
+
+## Scout Agent Use
+
+Prefer the project-scoped `context-scout` custom agent with `$context-scout` for bounded discovery and summarization before the main executor makes scope, design, or edit decisions.
+
+- Use deterministic selection before Scout work when possible.
+- Use the Scout Agent for rule-map candidate selection, front matter scanning, related docs discovery, existing-pattern summaries, affected-file discovery, upstream scope checks, or verification-failure summaries.
+- Require Scout output to be concise findings with file references, not raw document bodies, copied source text, or long logs.
+- Require the main executor to reduce Scout findings into the Context Packet before making the main decision.
+- Do not use Scout for product scope decisions, final design decisions, file edits, GitHub writes, or ambiguous Stop-condition judgments.
+- Do not add Scout instructions to small one-file, docs-only, or already-scoped Goals when direct execution is cheaper.
 
 ## Output
 

--- a/.codex/agents/context-scout.toml
+++ b/.codex/agents/context-scout.toml
@@ -1,0 +1,29 @@
+name = "context-scout"
+description = "Low-cost read-heavy repository discovery agent for Context Packet material."
+model = "gpt-5.4-mini"
+model_reasoning_effort = "low"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+You are a low-cost Context Scout for the savings repository.
+
+Find the smallest useful context for a main executor. Use targeted reads and searches only.
+
+Allowed work:
+- Select candidate docs from docs/harness/rule-map.json.
+- Scan Markdown front matter for area, applies_to, topics, when_to_read, and status.
+- Find related files with targeted rg queries.
+- Summarize existing implementation or documentation patterns.
+- Identify likely affected files.
+- Summarize verification failures from provided logs.
+
+Do not make product decisions, final design decisions, file edits, GitHub writes, git writes, or Stop-condition judgments.
+
+Return only concise findings with file references:
+- Findings
+- Selected refs
+- Risks / gaps
+- Suggested Context Packet items
+
+Do not paste raw logs, full source, or full document bodies.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -4,3 +4,7 @@ approvals_reviewer = "auto_review"
 
 [sandbox_workspace_write]
 network_access = true
+
+[agents.context-scout]
+description = "Low-cost read-heavy repository discovery agent for Context Packet material."
+config_file = "./agents/context-scout.toml"

--- a/docs/ai-driven-development/goal-templates/index.md
+++ b/docs/ai-driven-development/goal-templates/index.md
@@ -20,6 +20,8 @@ when_to_read:
 
 必要なGoalだけコピーして使うためのテンプレート集です。
 
+非自明なGoalを作る場合は、テンプレート本文を長くコピーするのではなく、[../workflow.md](../workflow.md) のContext Packetに入力を圧縮します。探索や要約が必要な場合も、長い調査ログではなく、選択した参照、制約、リスク、Stop条件だけをGoalに残します。
+
 - [Intent / Requirements Goal](./intent-requirements-goal.md)
 - [Design / Plan Goal](./design-plan-goal.md)
 - [Build / Verify Goal](./build-verify-goal.md)

--- a/docs/ai-driven-development/workflow.md
+++ b/docs/ai-driven-development/workflow.md
@@ -43,6 +43,23 @@ AIが行った作業を出荷判断できる形に整え、必要な学習を次
 
 Goal本文には、選んだ関連ドキュメントと、選択理由を入力として含めます。すべての `docs/` を読むのではなく、`depends_on` で追加される前提文書を含む最小のサブグラフだけを参照します。
 
+## Context Packet
+
+非自明なGoalでは、本文に長い調査メモやドキュメント本文をコピーせず、実行開始時の入力をContext Packetに圧縮します。
+
+Context Packetは、Goal実行者が最初に読むべき最小の作業文脈です。広い探索を始める前に、決定的に絞れる情報は `rule-map.json`、front matter、path、Issue / PR番号、`rg` などで候補化します。必要な場合だけ、低コストの探索用サブエージェントに候補の確認や要約を任せます。
+
+Context Packetには次だけを含めます。
+
+- Scope: 対象成果物、対象外、変更してよい範囲。
+- Selected refs: 読むべきファイル、rule-map ID、選択理由。
+- Constraints: Issue、PRD、Design Doc、policy、domain ruleから来る制約。
+- Known risks: 既知の不確実性、影響範囲、検証上の注意。
+- Stop checks: 実行者が止まるべき条件。
+- Verification expectations: 該当する検証の種類。コマンド全文は同じリポジトリ指示を読める場合は重複させません。
+
+実行者はContext Packetから開始し、引用されたファイルだけを読むことを基本にします。Packetが不足、矛盾、またはStop条件を示す場合だけ、追加探索または人間への確認に進みます。
+
 ## 1. Intent / Requirements Goal
 
 何を作るかを定義します。


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- Goal生成フローにContext Packet方式を追加し、長い調査メモやドキュメント本文のコピーを避ける方針を明文化
- 低コスト・read-onlyの`context-scout` custom agentと対応skillを追加
- `goal-builder`からContext PacketとScout agentを使う導線を追加

## 動作確認

- [x] `git diff --check`
- [x] `git diff --staged --check`
- [x] `context-scout`設定配線のTOML確認
- [ ] ローカルでの動作確認
- [ ] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

アプリケーションコード変更はないため、Webのlint / typecheck / testは実行していません。
