### PR TITLE
docs: goal-builderの文字数上限を下げる

### DIFF
--- a/.agents/skills/goal-builder/SKILL.md
+++ b/.agents/skills/goal-builder/SKILL.md
@@ -117,11 +117,11 @@ Do not make unrelated repository changes while generating a Goal.
 
 ## Output Budget
 
-The generated `/goal` input must be 4000 characters or less, including any note before the Markdown Goal.
+The generated `/goal` input must be 3800 characters or less, including any note before the Markdown Goal.
 
-This is a hard response gate, not a best-effort target. Draft for 3600 characters or less so final edits have room. Before returning the Goal, measure the exact character count of the full response text. If tooling is available, write the candidate response to a temporary file outside the repository and run `wc -m` against that file. Do not rely on approximate token counts or visual length.
+This is a hard response gate, not a best-effort target. Draft for 3400 characters or less so final edits have room. Before returning the Goal, measure the exact character count of the full response text. If tooling is available, write the candidate response to a temporary file outside the repository and run `wc -m` against that file. Do not rely on approximate token counts or visual length.
 
-When the draft would exceed 4000 characters:
+When the draft would exceed 3800 characters:
 
 - Keep the Goal self-contained, but compress wording before returning it.
 - Prefer paths, issue or PR numbers, and concise evidence summaries over copied source text.
@@ -132,8 +132,8 @@ When the draft would exceed 4000 characters:
 - Merge repeated constraints into one bullet when they point to the same boundary.
 - Replace template checklist wording with phase-specific done checks that are traceable to the current request.
 - Do not omit phase, target artifact path, scope, constraints, required inputs, Done, Verification, or Stop sections.
-- After compression, measure the full response text again. Repeat until it is 4000 characters or less.
-- If the Goal still cannot fit within 4000 characters without losing required execution context, return a concise note naming the missing compression decision instead of producing an oversized Goal.
+- After compression, measure the full response text again. Repeat until it is 3800 characters or less.
+- If the Goal still cannot fit within 3800 characters without losing required execution context, return a concise note naming the missing compression decision instead of producing an oversized Goal.
 
 ## Token Budget
 


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- goal-builder の `/goal` 生成上限を 3800 文字に変更した
- 下書き目標と超過時の圧縮条件も 3800 文字基準に揃えた

## 動作確認

- [ ] ローカルでの動作確認
- [ ] テストの実行
- [ ] UIの確認（スクリーンショット等）

docs/skill 定義のみの変更のため、アプリ検証は対象外。

## 補足

なし
