### PR TITLE
fix: 支払い一覧の表示幅を調整

### DIFF
--- a/apps/web/src/app/routes/PaymentsPage/PaymentsPage.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentsPage.tsx
@@ -10,7 +10,7 @@ export function PaymentsPage() {
   const [paymentsPageCacheScope] = useState(() => `payments-page-${crypto.randomUUID()}`)
 
   return (
-    <Container size="4">
+    <Container size="2">
       <Flex direction="column" gap="3">
         <Summary cacheScope={paymentsPageCacheScope} />
         <Flex align="center" gap="3">


### PR DESCRIPTION
## 関連Issue

- closes #1475

## 変更内容

- 支払いページのコンテナサイズを 2 に変更し、支払いメモと金額が左右に離れすぎないようにした

## 動作確認

- [x] pnpm run web:format
- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] pnpm run web:test:unit-integration
- [x] pnpm --filter web exec vp test run --project integration src/app/routes/PaymentsPage/PaymentsPage.test.tsx --reporter=dot --silent

## 補足

- 最終差分は支払いページの Container size 変更のみ