### PR TITLE
docs: domain layer policyの名称を整理

### DIFF
--- a/apps/web/docs/policies/domain-layer-rules.md
+++ b/apps/web/docs/policies/domain-layer-rules.md
@@ -1,5 +1,5 @@
 ---
-title: Domain Rules
+title: Domain Layer Rules
 doc_type: policy
 status: accepted
 area: web
@@ -8,7 +8,7 @@ applies_to:
   - apps/web/src/features
   - apps/web/src/utils
 topics:
-  - domain-rules
+  - domain-layer
   - project-structure
   - frontend-architecture
 when_to_read:
@@ -17,11 +17,13 @@ when_to_read:
   - Webアプリ内の値ルールの配置に迷うとき
 ---
 
-# Domain Rules
+# Domain Layer Rules
 
-`apps/web/src/domain` は、複数 feature で共有される値概念のルールを置く場所です。
+この文書は、`apps/web/src/domain` に置くコードの責務と配置ルールです。
 
-UIコンポーネントや特定画面の都合ではなく、入力、保存、比較、表示変換などで同じ扱いにすべき値ルールを集約します。
+UI上の文言、表示判断、状態表現、ドメイン値の見せ方は [Domain UI Rules](./domain-ui-rules.md) に従います。この文書では、UI判断そのものではなく、複数 feature で共有する値ルールをどの layer に置くかを扱います。
+
+UIコンポーネントや特定画面の都合ではなく、入力、保存、比較、表示変換などで同じ扱いにすべき値ルールを `apps/web/src/domain` に集約します。
 APIやDB契約の型を置くだけの場所ではなく、Webアプリ内で一貫させたい振る舞いを持つものを対象にします。
 
 ## 置くもの

--- a/apps/web/docs/policies/domain-ui-rules.md
+++ b/apps/web/docs/policies/domain-ui-rules.md
@@ -26,6 +26,7 @@ when_to_read:
 この文書は、ドメイン固有のUI判断で守るべき意味のルールです。
 
 UIの土台、文字階層、余白、variant、フォーム、overlay、responsiveは [Web Design Rules](./design-rules.md) に従います。この文書は、画面にどの情報を持たせるか、どの項目をどの順番で表示するか、どのコンポーネントで実装するかを固定しません。
+複数 feature で共有する schema、parser、formatter、form value 変換などのコード配置は [Domain Layer Rules](./domain-layer-rules.md) に従います。この文書では、`apps/web/src/domain` へ何を置くかは扱いません。
 
 AI agent は、ドメイン値を扱うUIを作るとき、この文書を「混同してはいけない意味」と「Design / Planで決めるべき判断対象」の基準として使います。具体的な表示順、入力順、列構成、件数、文言は、Requirements / Designで決めます。
 

--- a/apps/web/docs/policies/feature-directory.md
+++ b/apps/web/docs/policies/feature-directory.md
@@ -80,7 +80,7 @@ feature 共通ディレクトリを追加する場合は、既存の共通ディ
 
 ### 複数Featureで共有するコード
 
-複数 feature で共有される値ルールは、`apps/web/docs/policies/domain-rules.md` に従って `apps/web/src/domain` への切り出しを検討します。
+複数 feature で共有される値ルールは、`apps/web/docs/policies/domain-layer-rules.md` に従って `apps/web/src/domain` への切り出しを検討します。
 
 複数 feature で共有される UI は、`apps/web/src/components` に置くか、feature 間で共有してよい公開コンポーネントとして扱えるかを確認します。
 

--- a/docs/harness/rule-map.json
+++ b/docs/harness/rule-map.json
@@ -309,13 +309,13 @@
       "priority": 88
     },
     {
-      "id": "web.domain-rules",
-      "file": "apps/web/docs/policies/domain-rules.md",
+      "id": "web.domain-layer-rules",
+      "file": "apps/web/docs/policies/domain-layer-rules.md",
       "applies_to": {
         "paths": ["apps/web/src/domain/**", "apps/web/src/features/**", "apps/web/src/utils/**"],
         "domains": ["web", "domain"],
         "activities": ["add_domain_rule", "move_value_rule", "review_frontend_domain_boundary"],
-        "topics": ["domain-rules", "frontend-architecture", "project-structure"]
+        "topics": ["domain-layer", "frontend-architecture", "project-structure"]
       },
       "depends_on": [],
       "overrides": [],


### PR DESCRIPTION
## Summary
- Domain Rules を Domain Layer Rules に改名し、src/domain の配置ルールであることを明確化
- Domain UI Rules と feature-directory / rule-map の参照を新名称に更新

## Verification
- ruby -rjson -e 'JSON.parse(File.read("docs/harness/rule-map.json")); puts "ok"'
- git diff --check
- app verification は docs-only 変更のため未実行