### PR TITLE
docs: GitHub instructionsを索引参照に寄せる

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,9 +1,11 @@
 # Copilot Instructions for Savings Repository
 
-## Language
+## Repository Instructions
 
-Respond and comment in **Japanese**.
+- Respond and comment in **Japanese**.
+- Follow `AGENTS.md`.
+- Use `docs/harness/rule-map.json` as the index for task-specific repository documents.
 
-## General Rules
+## Path-Specific Instructions
 
 - Path-specific rules in `.github/instructions/*.instructions.md` take priority.

--- a/.github/instructions/apps-web.instructions.md
+++ b/.github/instructions/apps-web.instructions.md
@@ -4,18 +4,7 @@ applyTo: "apps/web/**"
 
 # Copilot Instructions for Web Frontend (apps/web/)
 
-## Rules
+## Repository Instructions
 
-- Before Web verification for application code changes, run `pnpm run web:format` from the repository root.
-- Then run Web verification from the repository root with `pnpm run web:lint`, `pnpm run web:format-check`, `pnpm run web:typecheck`, and `pnpm run web:test:unit-integration`.
-- Run `pnpm run web:test:storybook` only when the change affects `browser-test` tagged stories, `apps/web/.storybook-test/`, or Storybook browser-test configuration.
-- Use `pnpm install` from the repository root for installing/updating dependencies.
-- Add new components manually, following `apps/web/docs/policies/component-structure.md`.
-
-## References
-
-- `apps/web/README.md`
-- `apps/web/docs/adr/feature_directory.md`
-- `apps/web/docs/policies/msw-handlers.md`
-- `apps/web/docs/policies/suspense-boundaries.md`
-- `apps/web/docs/policies/test-policy.md`
+- Follow `AGENTS.md`.
+- Use `docs/harness/rule-map.json` as the index for Web-specific documents and verification rules.


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- .github/copilot-instructions.md を AGENTS.md と docs/harness/rule-map.json の参照中心に整理
- .github/instructions/apps-web.instructions.md から詳細なWeb手順を削り、索引参照に集約
- 日本語応答ルールは維持

## 動作確認

- [x] git diff --check
- [ ] ローカルでの動作確認
- [ ] テストの実行
- [ ] UIの確認（スクリーンショット等）

## 補足

文書変更のみのため、アプリ検証は未実行です。