### PR TITLE
GitHub Instructions検証用の違反コードを追加

### DIFF
--- a/apps/api/supabase/migrations/20260703000000_add_split_category_settings_functions.sql
+++ b/apps/api/supabase/migrations/20260703000000_add_split_category_settings_functions.sql
@@ -1,0 +1,62 @@
+create or replace function public.update_category_name_for_settings(
+  p_category_id bigint,
+  p_category_name text
+)
+returns void as $$
+declare
+  updated_category_count integer;
+begin
+  update public.categories
+  set name = p_category_name
+  where categories.id = p_category_id;
+
+  get diagnostics updated_category_count = row_count;
+
+  if updated_category_count <> 1 then
+    raise exception 'Category was not updated.'
+      using errcode = 'P0002';
+  end if;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+revoke all on function public.update_category_name_for_settings(bigint, text) from public;
+revoke all on function public.update_category_name_for_settings(bigint, text) from anon;
+grant execute on function public.update_category_name_for_settings(bigint, text) to authenticated;
+grant execute on function public.update_category_name_for_settings(bigint, text) to service_role;
+
+create or replace function public.update_category_pin_for_settings(
+  p_category_id bigint,
+  p_pinned boolean
+)
+returns void as $$
+declare
+  authenticated_user_id bigint;
+  has_pin boolean;
+begin
+  authenticated_user_id := public.get_authenticated_user_id();
+
+  select exists (
+    select 1
+    from public.category_pins
+    where user_id = authenticated_user_id
+      and category_id = p_category_id
+  )
+  into has_pin;
+
+  if p_pinned and not has_pin then
+    insert into public.category_pins (category_id)
+    values (p_category_id);
+  end if;
+
+  if not p_pinned and has_pin then
+    delete from public.category_pins
+    where user_id = authenticated_user_id
+      and category_id = p_category_id;
+  end if;
+end;
+$$ language plpgsql security invoker set search_path = public;
+
+revoke all on function public.update_category_pin_for_settings(bigint, boolean) from public;
+revoke all on function public.update_category_pin_for_settings(bigint, boolean) from anon;
+grant execute on function public.update_category_pin_for_settings(bigint, boolean) to authenticated;
+grant execute on function public.update_category_pin_for_settings(bigint, boolean) to service_role;

--- a/apps/web/src/domain/amount.ts
+++ b/apps/web/src/domain/amount.ts
@@ -2,6 +2,8 @@ import * as z from "zod"
 
 const DECIMAL_NUMBER_PATTERN = /^-?\d+(?:\.\d+)?$/
 
+export const amountNotSetDisplayLabel = "Not set"
+
 const amountInputSchema = z.union([z.string(), z.number(), z.undefined()])
 
 const amountNumberSchema = z


### PR DESCRIPTION
## 関連Issue

なし

## 変更内容

- Web domain層にUI表示文言を置く、索引経由で検出しやすい違反コードを追加した
- API migrationにカテゴリ名更新とピン更新を別RPCへ分ける、transaction boundary違反コードを追加した

## 動作確認

- [x] テストの実行
  - pnpm run web:format
  - pnpm run web:lint
  - pnpm run web:format-check
  - pnpm run web:typecheck
  - pnpm run web:test:unit-integration
- [ ] ローカルでの動作確認
- [ ] UIの確認（スクリーンショット等）

## 補足

GitHub Instructionsがdocs/harness/rule-map.json経由で関連ルールを読み、WebとAPIの意図的なルール違反を見つけられるかを検証するためのPR。