### PR TITLE
category budgetのtrigger順序を固定

### DIFF
--- a/apps/api/supabase/migrations/20260705000000_order_category_budget_ownership_triggers.sql
+++ b/apps/api/supabase/migrations/20260705000000_order_category_budget_ownership_triggers.sql
@@ -1,0 +1,68 @@
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_trigger
+    where tgrelid = 'public.category_budgets'::regclass
+      and tgname = 'trg_10_set_category_budget_ownership'
+  ) then
+    create trigger trg_10_set_category_budget_ownership
+      before insert on public.category_budgets
+      for each row
+      execute function public.set_category_budget_ownership();
+  end if;
+
+  if not exists (
+    select 1
+    from pg_trigger
+    where tgrelid = 'public.category_budgets'::regclass
+      and tgname = 'trg_10_keep_category_budget_book_id'
+  ) then
+    create trigger trg_10_keep_category_budget_book_id
+      before update on public.category_budgets
+      for each row
+      execute function public.keep_category_budget_book_id();
+  end if;
+
+  if not exists (
+    select 1
+    from pg_trigger
+    where tgrelid = 'public.category_budgets'::regclass
+      and tgname = 'trg_20_ensure_category_budget_category_book'
+  ) then
+    create trigger trg_20_ensure_category_budget_category_book
+      before insert or update of book_id, category_id on public.category_budgets
+      for each row
+      execute function public.ensure_category_budget_category_book();
+  end if;
+
+  drop trigger if exists trg_set_category_budget_ownership on public.category_budgets;
+  drop trigger if exists trg_keep_category_budget_book_id on public.category_budgets;
+  drop trigger if exists trg_ensure_category_budget_category_book on public.category_budgets;
+
+  if not exists (
+    select 1
+    from pg_trigger ownership_trigger
+    join pg_trigger validation_trigger
+      on validation_trigger.tgrelid = ownership_trigger.tgrelid
+    where ownership_trigger.tgrelid = 'public.category_budgets'::regclass
+      and ownership_trigger.tgname = 'trg_10_set_category_budget_ownership'
+      and validation_trigger.tgname = 'trg_20_ensure_category_budget_category_book'
+      and ownership_trigger.tgname < validation_trigger.tgname
+  ) then
+    raise exception 'category_budgets insert ownership trigger must run before category book validation.';
+  end if;
+
+  if not exists (
+    select 1
+    from pg_trigger keep_trigger
+    join pg_trigger validation_trigger
+      on validation_trigger.tgrelid = keep_trigger.tgrelid
+    where keep_trigger.tgrelid = 'public.category_budgets'::regclass
+      and keep_trigger.tgname = 'trg_10_keep_category_budget_book_id'
+      and validation_trigger.tgname = 'trg_20_ensure_category_budget_category_book'
+      and keep_trigger.tgname < validation_trigger.tgname
+  ) then
+    raise exception 'category_budgets update book ownership trigger must run before category book validation.';
+  end if;
+end $$;

--- a/docs/harness/domain/book.md
+++ b/docs/harness/domain/book.md
@@ -28,3 +28,5 @@ when_to_read:
 - Book-owned dataの作成時に所有先Bookが未指定の場合、認証ユーザーのdefault bookを使う。
 - Book-owned dataは、対象Bookのmemberだけが参照・作成・更新・削除できる。
 - Book-owned dataの所有先Bookは更新時に維持される。
+- 同じテーブルでBook ownership補完・維持triggerと、`new.book_id` に依存する検証triggerを併用する場合、検証triggerは補完・維持triggerより後に実行される名前にする。
+- trigger実行順に依存する場合は、自然な動詞順に頼らず `trg_10_...`、`trg_20_...` のような番号付き命名で順序を固定する。


### PR DESCRIPTION
## 関連Issue

closes #1478

## 変更内容

- `category_budgets` の ownership 補完・維持 trigger を `trg_10_*` に、カテゴリ所属検証 trigger を `trg_20_*` に付け直した
- 旧 trigger を削除する前に新 trigger を作成し、migration 適用中に検証 trigger が外れる窓を避けた
- Book ownership trigger と `new.book_id` 依存の検証 trigger を併用する場合の順序制御ルールを domain doc に追加した

## 動作確認

- [x] `pnpm run api:migrations:up`
- [x] `psql -f apps/api/supabase/migrations/20260705000000_order_category_budget_ownership_triggers.sql`
- [x] `category_budgets` への `book_id` 省略 INSERT が default book に補完されることを rollback 付き SQL で確認
- [x] `category_budgets.book_id` 変更 UPDATE が既存 `book_id` に維持されることを rollback 付き SQL で確認
- [ ] UIの確認（DB migration / docs のみのため対象外）

## 補足

- API 専用テストは未定義のため、migration 適用と直接 SQL で確認しています。

## Review instructions

- `docs/harness/rule-map.json` も参照し、関連ルールとの整合性を見てください。
