### PR TITLE
feat: 全ページに横余白を追加

### DIFF
--- a/apps/web/src/app/AppLayout/AppLayout.module.css
+++ b/apps/web/src/app/AppLayout/AppLayout.module.css
@@ -8,5 +8,6 @@
 .main {
   /* Main部分を伸縮可能にする */
   flex-grow: 1;
-  padding: var(--space-2);
+  padding-block: var(--space-2);
+  padding-inline: var(--space-4);
 }

--- a/apps/web/src/app/routes/AuthPage/AuthPage.tsx
+++ b/apps/web/src/app/routes/AuthPage/AuthPage.tsx
@@ -10,7 +10,7 @@ export function AuthPage() {
   const { t } = useTranslation()
 
   return (
-    <Container size="2">
+    <Container px="4" size="2">
       <Flex direction="column" gap="3">
         <Text asChild size="5" weight="bold">
           <h2>{t("auth.title")}</h2>

--- a/apps/web/src/app/routes/ErrorPage/ErrorPage.tsx
+++ b/apps/web/src/app/routes/ErrorPage/ErrorPage.tsx
@@ -13,7 +13,7 @@ export function ErrorPage({ error }: ErrorComponentProps) {
   }, [error])
 
   return (
-    <Container id={`error-page-${id}`} size="2">
+    <Container id={`error-page-${id}`} px="4" size="2">
       <Flex align="start" direction="column" gap="4">
         <Flex align="center" gap="2">
           <ExclamationTriangleIcon aria-hidden width="22" height="22" />

--- a/apps/web/src/app/routes/TopPage/TopPage.tsx
+++ b/apps/web/src/app/routes/TopPage/TopPage.tsx
@@ -7,7 +7,7 @@ export function TopPage() {
 
   return (
     <>
-      <Container size="2">
+      <Container px="4" size="2">
         <Flex direction="column" gap="3">
           <Text asChild size="5" weight="bold">
             <h2>{t("app.name")}</h2>


### PR DESCRIPTION
## 変更内容

- 認証済み・公開・エラー画面の横余白を 16px に統一

## 動作確認

- pnpm run web:format
- pnpm run web:lint
- pnpm run web:format-check
- pnpm run web:typecheck
- pnpm run web:test:unit-integration（119 files / 565 tests）

## Review instructions

- docs/harness/rule-map.json の web.design-system-brand と web.design-rules との整合性を確認してください。