### PR TITLE
refactor: Webの重複する変換・query処理を共通化

### DIFF
--- a/apps/web/src/domain/categoryBudget.ts
+++ b/apps/web/src/domain/categoryBudget.ts
@@ -1,0 +1,36 @@
+import * as z from "zod"
+
+const effectiveCategoryBudgetSchema = z
+  .object({
+    category_id: z.number(),
+    status: z.enum(["amount", "none"]),
+    amount: z.number().nullable(),
+  })
+  .refine(
+    (value) =>
+      (value.status === "amount" && value.amount !== null) ||
+      (value.status === "none" && value.amount === null),
+  )
+
+export interface CategoryBudgetState {
+  status: "amount" | "none" | "unset"
+  amount: number | null
+}
+
+export function toCategoryBudgetMap(value: unknown): Map<number, CategoryBudgetState> {
+  const result = z.array(effectiveCategoryBudgetSchema).safeParse(value)
+
+  if (!result.success) {
+    throw new Error("Invalid category budget response")
+  }
+
+  return new Map(
+    result.data.map((budget) => [
+      budget.category_id,
+      {
+        status: budget.status,
+        amount: budget.status === "amount" ? budget.amount : null,
+      },
+    ]),
+  )
+}

--- a/apps/web/src/features/budgets/createMonthlyBudget/CreateMonthlyBudgetForm/CreateMonthlyBudgetForm.test.tsx
+++ b/apps/web/src/features/budgets/createMonthlyBudget/CreateMonthlyBudgetForm/CreateMonthlyBudgetForm.test.tsx
@@ -6,7 +6,11 @@ import { server } from "../../../../test/msw/server"
 import { act, render, screen, waitFor, within } from "../../../../test/test-utils"
 import { createDeferred } from "../../../../test/utils/createDeferred"
 import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../../utils/postgresError"
-import { fillCreateMonthlyBudgetForm, selectBudgetMonth } from "../../test/utils/budgetCreationForm"
+import {
+  fillCreateMonthlyBudgetForm,
+  getCurrentBudgetMonth,
+  selectBudgetMonth,
+} from "../../test/utils/budgetCreationForm"
 import * as stories from "./CreateMonthlyBudgetForm.stories"
 
 const { Default } = composeStories(stories)
@@ -285,15 +289,3 @@ describe("CreateMonthlyBudgetForm", () => {
     expect(onSuccess).not.toHaveBeenCalled()
   })
 })
-
-function getCurrentBudgetMonth() {
-  const now = new Date()
-  const year = now.getFullYear()
-  const month = now.getMonth() + 1
-
-  return {
-    year: String(year),
-    month: String(month),
-    effectiveFrom: `${year}-${String(month).padStart(2, "0")}-01`,
-  }
-}

--- a/apps/web/src/features/budgets/createMonthlyBudget/CreateMonthlyBudgetModal/CreateMonthlyBudgetModal.test.tsx
+++ b/apps/web/src/features/budgets/createMonthlyBudget/CreateMonthlyBudgetModal/CreateMonthlyBudgetModal.test.tsx
@@ -5,7 +5,10 @@ import { afterEach, describe, expect, test, vi } from "vite-plus/test"
 import { server } from "../../../../test/msw/server"
 import { act, fireEvent, render, screen, waitFor, within } from "../../../../test/test-utils"
 import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../../utils/postgresError"
-import { fillCreateMonthlyBudgetForm } from "../../test/utils/budgetCreationForm"
+import {
+  fillCreateMonthlyBudgetForm,
+  getCurrentBudgetMonth,
+} from "../../test/utils/budgetCreationForm"
 import * as stories from "./CreateMonthlyBudgetModal.stories"
 
 const { Default } = composeStories(stories)
@@ -153,14 +156,3 @@ describe("CreateMonthlyBudgetModal", () => {
     expect(screen.getByRole("dialog", { name: "Create monthly budget" })).toBeInTheDocument()
   })
 })
-
-function getCurrentBudgetMonth() {
-  const now = new Date()
-  const year = now.getFullYear()
-  const month = now.getMonth() + 1
-
-  return {
-    year: String(year),
-    month: String(month),
-  }
-}

--- a/apps/web/src/features/budgets/createMonthlyBudget/useCreateMonthlyBudget.ts
+++ b/apps/web/src/features/budgets/createMonthlyBudget/useCreateMonthlyBudget.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
-import { monthlyBudgetQueryKeys } from "../queryKeys"
+import { invalidateMonthlyBudgetQueries } from "../queryKeys"
 import { createMonthlyBudget as createMonthlyBudgetRecord } from "./createMonthlyBudget"
 import type { MonthlyBudgetWriteInput } from "./monthlyBudgetFormMappers"
 
@@ -16,10 +16,7 @@ export function useCreateMonthlyBudget(): UseCreateMonthlyBudgetReturn {
   const { mutateAsync, isPending } = useMutation({
     mutationFn: createMonthlyBudgetRecord,
     onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: monthlyBudgetQueryKeys.listAll }),
-        queryClient.invalidateQueries({ queryKey: monthlyBudgetQueryKeys.effectiveAll }),
-      ])
+      await invalidateMonthlyBudgetQueries(queryClient)
     },
   })
 

--- a/apps/web/src/features/budgets/latestMonthlyBudget/LatestMonthlyBudget/LatestMonthlyBudget.test.tsx
+++ b/apps/web/src/features/budgets/latestMonthlyBudget/LatestMonthlyBudget/LatestMonthlyBudget.test.tsx
@@ -7,7 +7,10 @@ import { createMonthlyBudgetHandlers } from "../../../../test/msw/handlers/month
 import { server } from "../../../../test/msw/server"
 import { act, render, screen, waitFor, within } from "../../../../test/test-utils"
 import { POSTGRES_UNIQUE_VIOLATION_CODE } from "../../../../utils/postgresError"
-import { fillCreateMonthlyBudgetForm } from "../../test/utils/budgetCreationForm"
+import {
+  fillCreateMonthlyBudgetForm,
+  getCurrentBudgetMonth,
+} from "../../test/utils/budgetCreationForm"
 import * as stories from "./LatestMonthlyBudget.stories"
 
 const { Default, Empty, FetchError, Loading } = composeStories(stories)
@@ -275,17 +278,3 @@ describe("LatestMonthlyBudget", () => {
     )
   })
 })
-
-function getCurrentBudgetMonth() {
-  const now = new Date()
-  const year = now.getFullYear()
-  const month = now.getMonth() + 1
-
-  return {
-    year: String(year),
-    month: String(month),
-    yearNumber: year,
-    monthNumber: month,
-    effectiveFrom: `${year}-${String(month).padStart(2, "0")}-01`,
-  }
-}

--- a/apps/web/src/features/budgets/queryKeys.ts
+++ b/apps/web/src/features/budgets/queryKeys.ts
@@ -1,6 +1,15 @@
+import type { QueryClient } from "@tanstack/react-query"
+
 export const monthlyBudgetQueryKeys = {
   listAll: ["monthlyBudgets"],
   list: (limit: number) => ["monthlyBudgets", limit] as const,
   effectiveAll: ["effectiveMonthlyBudget"],
   effective: (targetMonth: string) => ["effectiveMonthlyBudget", targetMonth] as const,
 } as const
+
+export async function invalidateMonthlyBudgetQueries(queryClient: QueryClient): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: monthlyBudgetQueryKeys.listAll }),
+    queryClient.invalidateQueries({ queryKey: monthlyBudgetQueryKeys.effectiveAll }),
+  ])
+}

--- a/apps/web/src/features/budgets/removeMonthlyBudget/useRemoveMonthlyBudget.ts
+++ b/apps/web/src/features/budgets/removeMonthlyBudget/useRemoveMonthlyBudget.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
-import { monthlyBudgetQueryKeys } from "../queryKeys"
+import { invalidateMonthlyBudgetQueries } from "../queryKeys"
 import { removeMonthlyBudget as removeMonthlyBudgetRecord } from "./removeMonthlyBudget"
 
 interface UseRemoveMonthlyBudgetReturn {
@@ -15,10 +15,7 @@ export function useRemoveMonthlyBudget(): UseRemoveMonthlyBudgetReturn {
   const { mutateAsync, isPending } = useMutation({
     mutationFn: removeMonthlyBudgetRecord,
     onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: monthlyBudgetQueryKeys.listAll }),
-        queryClient.invalidateQueries({ queryKey: monthlyBudgetQueryKeys.effectiveAll }),
-      ])
+      await invalidateMonthlyBudgetQueries(queryClient)
     },
   })
 

--- a/apps/web/src/features/budgets/test/utils/budgetCreationForm.ts
+++ b/apps/web/src/features/budgets/test/utils/budgetCreationForm.ts
@@ -55,6 +55,20 @@ export async function fillCreateMonthlyBudgetForm({
   await typeBudgetAmount({ user, amount, fieldScope })
 }
 
+export function getCurrentBudgetMonth() {
+  const now = new Date()
+  const year = now.getFullYear()
+  const month = now.getMonth() + 1
+
+  return {
+    year: String(year),
+    month: String(month),
+    yearNumber: year,
+    monthNumber: month,
+    effectiveFrom: `${year}-${String(month).padStart(2, "0")}-01`,
+  }
+}
+
 function getMonthOptionName(month: string): string {
   return new Intl.DateTimeFormat("en-US", { month: "long" }).format(
     new Date(2025, Number(month) - 1, 1),

--- a/apps/web/src/features/budgets/updateMonthlyBudget/useUpdateMonthlyBudget.ts
+++ b/apps/web/src/features/budgets/updateMonthlyBudget/useUpdateMonthlyBudget.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
-import { monthlyBudgetQueryKeys } from "../queryKeys"
+import { invalidateMonthlyBudgetQueries } from "../queryKeys"
 import type { MonthlyBudgetUpdateInput } from "./monthlyBudgetUpdateMappers"
 import { updateMonthlyBudget as updateMonthlyBudgetRecord } from "./updateMonthlyBudget"
 
@@ -16,10 +16,7 @@ export function useUpdateMonthlyBudget(): UseUpdateMonthlyBudgetReturn {
   const { mutateAsync, isPending } = useMutation({
     mutationFn: updateMonthlyBudgetRecord,
     onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: monthlyBudgetQueryKeys.listAll }),
-        queryClient.invalidateQueries({ queryKey: monthlyBudgetQueryKeys.effectiveAll }),
-      ])
+      await invalidateMonthlyBudgetQueries(queryClient)
     },
   })
 

--- a/apps/web/src/features/categories/components/CategoryFormFields/CategoryFormFields.stories.tsx
+++ b/apps/web/src/features/categories/components/CategoryFormFields/CategoryFormFields.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { useState } from "react"
+import { fn } from "storybook/test"
+
+import { CategoryFormFields } from "./CategoryFormFields"
+
+const meta = {
+  title: "Features/Categories/Components/CategoryFormFields",
+  component: CategoryFormFields,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    name: "",
+    nameErrors: [],
+    budgetAmount: "",
+    budgetErrors: [],
+    pinned: false,
+    disabled: false,
+    onNameChange: fn(),
+    onBudgetAmountChange: fn(),
+    onPinnedChange: fn(),
+  },
+  render: (args) => {
+    const [name, setName] = useState(args.name)
+    const [budgetAmount, setBudgetAmount] = useState(args.budgetAmount)
+    const [pinned, setPinned] = useState(args.pinned)
+
+    return (
+      <CategoryFormFields
+        {...args}
+        name={name}
+        budgetAmount={budgetAmount}
+        pinned={pinned}
+        onNameChange={(nextName) => {
+          setName(nextName)
+          args.onNameChange(nextName)
+        }}
+        onBudgetAmountChange={(nextBudgetAmount) => {
+          setBudgetAmount(nextBudgetAmount)
+          args.onBudgetAmountChange(nextBudgetAmount)
+        }}
+        onPinnedChange={(nextPinned) => {
+          setPinned(nextPinned)
+          args.onPinnedChange(nextPinned)
+        }}
+      />
+    )
+  },
+} satisfies Meta<typeof CategoryFormFields>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const ValidationError: Story = {
+  args: {
+    nameErrors: [{ message: "Category name cannot be empty" }],
+    budgetErrors: [{ message: "Amount must be a number" }],
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    name: "Food",
+    budgetAmount: "30000",
+    pinned: true,
+    disabled: true,
+  },
+}

--- a/apps/web/src/features/categories/components/CategoryFormFields/CategoryFormFields.tsx
+++ b/apps/web/src/features/categories/components/CategoryFormFields/CategoryFormFields.tsx
@@ -1,0 +1,100 @@
+import { Checkbox, Flex, Text, TextField } from "@radix-ui/themes"
+import type { StandardSchemaV1Issue } from "@tanstack/react-form"
+import { useId } from "react"
+import { useTranslation } from "react-i18next"
+
+import { AmountInput } from "../../../../components/inputs/AmountInput"
+import { BaseField, FieldLabel, FieldMessages } from "../../../../components/inputs/BaseField"
+import { getErrorMessages } from "../../../../utils/getErrorMessages"
+
+interface CategoryFormFieldsProps {
+  name: string
+  nameErrors: (StandardSchemaV1Issue | undefined)[]
+  budgetAmount: string | number | undefined
+  budgetErrors: (StandardSchemaV1Issue | undefined)[]
+  pinned: boolean
+  disabled: boolean
+  onNameChange: (name: string) => void
+  onBudgetAmountChange: (budgetAmount: string | number | undefined) => void
+  onPinnedChange: (pinned: boolean) => void
+}
+
+export function CategoryFormFields({
+  name,
+  nameErrors,
+  budgetAmount,
+  budgetErrors,
+  pinned,
+  disabled,
+  onNameChange,
+  onBudgetAmountChange,
+  onPinnedChange,
+}: CategoryFormFieldsProps) {
+  const nameInputId = useId()
+  const nameErrorId = useId()
+  const budgetInputId = useId()
+  const budgetMessagesId = useId()
+  const pinnedInputId = useId()
+  const { t } = useTranslation()
+  const nameErrorMessages = getErrorMessages(nameErrors) ?? []
+  const hasNameError = nameErrorMessages.length > 0
+  const budgetErrorMessages = getErrorMessages(budgetErrors) ?? []
+  const hasBudgetError = budgetErrorMessages.length > 0
+  const budgetMessages = hasBudgetError ? budgetErrorMessages : [t("categories.budgetHelp")]
+
+  return (
+    <Flex direction="column" gap="3">
+      <BaseField>
+        <FieldLabel htmlFor={nameInputId} required>
+          {t("categories.name")}
+        </FieldLabel>
+        <TextField.Root
+          autoFocus
+          disabled={disabled}
+          id={nameInputId}
+          name="name"
+          value={name}
+          aria-label={t("categories.name")}
+          aria-describedby={hasNameError ? nameErrorId : undefined}
+          aria-invalid={hasNameError}
+          onChange={(event) => {
+            onNameChange(event.target.value)
+          }}
+        />
+        <span id={nameErrorId}>
+          <FieldMessages error={hasNameError} messages={nameErrorMessages} />
+        </span>
+      </BaseField>
+      <BaseField>
+        <FieldLabel htmlFor={budgetInputId}>{t("categories.budget")}</FieldLabel>
+        <AmountInput
+          disabled={disabled}
+          id={budgetInputId}
+          name="budgetAmount"
+          value={budgetAmount === undefined ? "" : String(budgetAmount)}
+          aria-label={t("categories.budget")}
+          aria-describedby={budgetMessagesId}
+          aria-invalid={hasBudgetError}
+          onChange={onBudgetAmountChange}
+        />
+        <span id={budgetMessagesId}>
+          <FieldMessages error={hasBudgetError} messages={budgetMessages} />
+        </span>
+      </BaseField>
+      <Text as="label" size="2" htmlFor={pinnedInputId}>
+        <Flex gap="2" align="center">
+          <Checkbox
+            id={pinnedInputId}
+            name="pinned"
+            checked={pinned}
+            disabled={disabled}
+            onCheckedChange={(nextChecked) => {
+              onPinnedChange(nextChecked === true)
+            }}
+          />
+          {t("categories.pinCategory")}
+        </Flex>
+      </Text>
+    </Flex>
+  )
+}

--- a/apps/web/src/features/categories/components/CategoryFormFields/index.ts
+++ b/apps/web/src/features/categories/components/CategoryFormFields/index.ts
@@ -1,0 +1,1 @@
+export { CategoryFormFields } from "./CategoryFormFields"

--- a/apps/web/src/features/categories/createCategory/CreateCategoryForm/CreateCategoryForm.tsx
+++ b/apps/web/src/features/categories/createCategory/CreateCategoryForm/CreateCategoryForm.tsx
@@ -1,16 +1,14 @@
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons"
-import { Callout, Checkbox, Flex, Text, TextField } from "@radix-ui/themes"
+import { Callout, Flex } from "@radix-ui/themes"
 import { useForm } from "@tanstack/react-form"
-import { useCallback, useId, useState } from "react"
+import { useCallback, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { CancelButton } from "../../../../components/buttons/CancelButton"
 import { SubmitButton } from "../../../../components/buttons/SubmitButton"
-import { AmountInput } from "../../../../components/inputs/AmountInput"
-import { BaseField, FieldLabel, FieldMessages } from "../../../../components/inputs/BaseField"
 import { translateMessage } from "../../../../i18n/translateMessage"
-import { getErrorMessages } from "../../../../utils/getErrorMessages"
 import { CATEGORY_PIN_LIMIT, categoryPinLimitErrorMessage } from "../../categoryPinLimitError"
+import { CategoryFormFields } from "../../components/CategoryFormFields"
 import { toCategoryCreateErrorMessage } from "../categoryCreateError"
 import { categoryCreateSchema, type CategoryCreateFormValues } from "../categoryCreateSchema"
 import { useCreateCategory } from "../useCreateCategory"
@@ -32,11 +30,6 @@ export function CreateCategoryForm({
   onSuccess,
   onCancel,
 }: CreateCategoryFormProps) {
-  const nameInputId = useId()
-  const nameErrorId = useId()
-  const budgetInputId = useId()
-  const budgetMessagesId = useId()
-  const pinnedInputId = useId()
   const { t } = useTranslation()
   const { createCategory, isPending } = useCreateCategory()
   const [submitErrorMessage, setSubmitErrorMessage] = useState<string | undefined>()
@@ -97,87 +90,38 @@ export function CreateCategoryForm({
         ) : null}
         <form.Subscribe selector={(state) => state.isSubmitting}>
           {(isSubmitting) => (
-            <Flex direction="column" gap="3">
-              <form.Field name="name">
-                {(field) => {
-                  const errorMessages = getErrorMessages(field.state.meta.errors) ?? []
-                  const hasError = !field.state.meta.isValid && errorMessages.length > 0
-
-                  return (
-                    <BaseField>
-                      <FieldLabel htmlFor={nameInputId} required>
-                        {t("categories.name")}
-                      </FieldLabel>
-                      <TextField.Root
-                        autoFocus
-                        disabled={isSubmitting || isPending}
-                        id={nameInputId}
-                        name="name"
-                        value={field.state.value}
-                        aria-label={t("categories.name")}
-                        aria-describedby={hasError ? nameErrorId : undefined}
-                        aria-invalid={hasError}
-                        onChange={(event) => {
-                          field.handleChange(event.target.value)
-                          setSubmitErrorMessage(undefined)
-                        }}
-                      />
-                      <span id={nameErrorId}>
-                        <FieldMessages error={hasError} messages={errorMessages} />
-                      </span>
-                    </BaseField>
-                  )
-                }}
-              </form.Field>
-              <form.Field name="budgetAmount">
-                {(field) => {
-                  const errorMessages = getErrorMessages(field.state.meta.errors) ?? []
-                  const hasError = !field.state.meta.isValid && errorMessages.length > 0
-                  const messages = hasError ? errorMessages : [t("categories.budgetHelp")]
-
-                  return (
-                    <BaseField>
-                      <FieldLabel htmlFor={budgetInputId}>{t("categories.budget")}</FieldLabel>
-                      <AmountInput
-                        disabled={isSubmitting || isPending}
-                        id={budgetInputId}
-                        name="budgetAmount"
-                        value={field.state.value === undefined ? "" : String(field.state.value)}
-                        aria-label={t("categories.budget")}
-                        aria-describedby={budgetMessagesId}
-                        aria-invalid={hasError}
-                        onChange={(value) => {
-                          field.handleChange(value)
-                          setSubmitErrorMessage(undefined)
-                        }}
-                      />
-                      <span id={budgetMessagesId}>
-                        <FieldMessages error={hasError} messages={messages} />
-                      </span>
-                    </BaseField>
-                  )
-                }}
-              </form.Field>
-              <form.Field name="pinned">
-                {(field) => (
-                  <Text as="label" size="2" htmlFor={pinnedInputId}>
-                    <Flex gap="2" align="center">
-                      <Checkbox
-                        id={pinnedInputId}
-                        name="pinned"
-                        checked={field.state.value}
-                        disabled={isSubmitting || isPending}
-                        onCheckedChange={(nextChecked) => {
-                          field.handleChange(nextChecked === true)
-                          setSubmitErrorMessage(undefined)
-                        }}
-                      />
-                      {t("categories.pinCategory")}
-                    </Flex>
-                  </Text>
-                )}
-              </form.Field>
-            </Flex>
+            <form.Field name="name">
+              {(nameField) => (
+                <form.Field name="budgetAmount">
+                  {(budgetField) => (
+                    <form.Field name="pinned">
+                      {(pinnedField) => (
+                        <CategoryFormFields
+                          name={nameField.state.value}
+                          nameErrors={nameField.state.meta.errors}
+                          budgetAmount={budgetField.state.value}
+                          budgetErrors={budgetField.state.meta.errors}
+                          pinned={pinnedField.state.value}
+                          disabled={isSubmitting || isPending}
+                          onNameChange={(name) => {
+                            nameField.handleChange(name)
+                            setSubmitErrorMessage(undefined)
+                          }}
+                          onBudgetAmountChange={(budgetAmount) => {
+                            budgetField.handleChange(budgetAmount)
+                            setSubmitErrorMessage(undefined)
+                          }}
+                          onPinnedChange={(pinned) => {
+                            pinnedField.handleChange(pinned)
+                            setSubmitErrorMessage(undefined)
+                          }}
+                        />
+                      )}
+                    </form.Field>
+                  )}
+                </form.Field>
+              )}
+            </form.Field>
           )}
         </form.Subscribe>
         <form.Subscribe selector={(state) => state.isSubmitting}>

--- a/apps/web/src/features/categories/listCategorySettings/fetchCategorySettingsItems.ts
+++ b/apps/web/src/features/categories/listCategorySettings/fetchCategorySettingsItems.ts
@@ -1,5 +1,6 @@
 import * as z from "zod"
 
+import { toCategoryBudgetMap, type CategoryBudgetState } from "../../../domain/categoryBudget"
 import { toDateOnlyString } from "../../../domain/date"
 import { getSupabaseClient } from "../../../lib/supabase"
 import type { CategorySettingsItem } from "./types"
@@ -88,39 +89,4 @@ function toCategorySettingsItem(
     budgetStatus: budgetState.status,
     budgetAmount: budgetState.amount,
   }
-}
-
-const effectiveCategoryBudgetSchema = z
-  .object({
-    category_id: z.number(),
-    status: z.enum(["amount", "none"]),
-    amount: z.number().nullable(),
-  })
-  .refine(
-    (value) =>
-      (value.status === "amount" && value.amount !== null) ||
-      (value.status === "none" && value.amount === null),
-  )
-
-type CategoryBudgetState = {
-  status: "amount" | "none" | "unset"
-  amount: number | null
-}
-
-function toCategoryBudgetMap(value: unknown): Map<number, CategoryBudgetState> {
-  const result = z.array(effectiveCategoryBudgetSchema).safeParse(value)
-
-  if (!result.success) {
-    throw new Error("Invalid category budget response")
-  }
-
-  return new Map(
-    result.data.map((budget) => [
-      budget.category_id,
-      {
-        status: budget.status,
-        amount: budget.status === "amount" ? budget.amount : null,
-      },
-    ]),
-  )
 }

--- a/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.tsx
+++ b/apps/web/src/features/categories/updateCategoryName/UpdateCategoryNameForm/UpdateCategoryNameForm.tsx
@@ -1,19 +1,17 @@
 import { ExclamationTriangleIcon } from "@radix-ui/react-icons"
-import { Callout, Checkbox, Flex, Text, TextField } from "@radix-ui/themes"
+import { Callout, Flex } from "@radix-ui/themes"
 import { useForm } from "@tanstack/react-form"
-import { useCallback, useId, useState } from "react"
+import { useCallback, useState } from "react"
 import { useTranslation } from "react-i18next"
 import * as z from "zod"
 
 import { CancelButton } from "../../../../components/buttons/CancelButton"
 import { SubmitButton } from "../../../../components/buttons/SubmitButton"
-import { AmountInput } from "../../../../components/inputs/AmountInput"
-import { BaseField, FieldLabel, FieldMessages } from "../../../../components/inputs/BaseField"
 import { optionalAmountFieldSchema } from "../../../../domain/amount"
 import { translateMessage } from "../../../../i18n/translateMessage"
-import { getErrorMessages } from "../../../../utils/getErrorMessages"
 import { CATEGORY_PIN_LIMIT, categoryPinLimitErrorMessage } from "../../categoryPinLimitError"
 import { categoryNameSchema } from "../../categorySchema"
+import { CategoryFormFields } from "../../components/CategoryFormFields"
 import { toCategoryNameUpdateErrorMessage } from "../categoryNameUpdateError"
 import { useUpdateCategoryName } from "../useUpdateCategoryName"
 
@@ -48,11 +46,6 @@ export function UpdateCategoryNameForm({
   onSuccess,
   onCancel,
 }: UpdateCategoryNameFormProps) {
-  const nameInputId = useId()
-  const nameErrorId = useId()
-  const budgetInputId = useId()
-  const budgetMessagesId = useId()
-  const pinnedInputId = useId()
   const { t } = useTranslation()
   const { updateCategoryName, isPending } = useUpdateCategoryName()
   const [submitErrorMessage, setSubmitErrorMessage] = useState<string | undefined>()
@@ -133,89 +126,38 @@ export function UpdateCategoryNameForm({
             <Callout.Text>{translateMessage(t, submitErrorMessage)}</Callout.Text>
           </Callout.Root>
         ) : null}
-        <Flex direction="column" gap="3">
-          <form.Field name="name">
-            {(field) => {
-              const isValid = field.state.meta.isValid
-              const errorMessages = getErrorMessages(field.state.meta.errors) ?? []
-              const hasError = !isValid && errorMessages.length > 0
-
-              return (
-                <BaseField>
-                  <FieldLabel htmlFor={nameInputId} required>
-                    {t("categories.name")}
-                  </FieldLabel>
-                  <TextField.Root
-                    autoFocus
-                    disabled={isPending}
-                    id={nameInputId}
-                    name="name"
-                    value={field.state.value}
-                    aria-label={t("categories.name")}
-                    aria-describedby={hasError ? nameErrorId : undefined}
-                    aria-invalid={hasError}
-                    onChange={(event) => {
-                      field.handleChange(event.target.value)
-                      setSubmitErrorMessage(undefined)
-                    }}
-                  />
-                  <span id={nameErrorId}>
-                    <FieldMessages error={!isValid} messages={errorMessages} />
-                  </span>
-                </BaseField>
-              )
-            }}
-          </form.Field>
-          <form.Field name="budgetAmount">
-            {(field) => {
-              const isValid = field.state.meta.isValid
-              const errorMessages = getErrorMessages(field.state.meta.errors) ?? []
-              const hasError = !isValid && errorMessages.length > 0
-              const messages = hasError ? errorMessages : [t("categories.budgetHelp")]
-
-              return (
-                <BaseField>
-                  <FieldLabel htmlFor={budgetInputId}>{t("categories.budget")}</FieldLabel>
-                  <AmountInput
-                    disabled={isPending}
-                    id={budgetInputId}
-                    name="budgetAmount"
-                    value={field.state.value === undefined ? "" : String(field.state.value)}
-                    aria-label={t("categories.budget")}
-                    aria-describedby={budgetMessagesId}
-                    aria-invalid={hasError}
-                    onChange={(value) => {
-                      field.handleChange(value)
-                      setSubmitErrorMessage(undefined)
-                    }}
-                  />
-                  <span id={budgetMessagesId}>
-                    <FieldMessages error={hasError} messages={messages} />
-                  </span>
-                </BaseField>
-              )
-            }}
-          </form.Field>
-          <form.Field name="pinned">
-            {(field) => (
-              <Text as="label" size="2" htmlFor={pinnedInputId}>
-                <Flex gap="2" align="center">
-                  <Checkbox
-                    id={pinnedInputId}
-                    name="pinned"
-                    checked={field.state.value}
-                    disabled={isPending}
-                    onCheckedChange={(nextChecked) => {
-                      field.handleChange(nextChecked === true)
-                      setSubmitErrorMessage(undefined)
-                    }}
-                  />
-                  {t("categories.pinCategory")}
-                </Flex>
-              </Text>
-            )}
-          </form.Field>
-        </Flex>
+        <form.Field name="name">
+          {(nameField) => (
+            <form.Field name="budgetAmount">
+              {(budgetField) => (
+                <form.Field name="pinned">
+                  {(pinnedField) => (
+                    <CategoryFormFields
+                      name={nameField.state.value}
+                      nameErrors={nameField.state.meta.errors}
+                      budgetAmount={budgetField.state.value}
+                      budgetErrors={budgetField.state.meta.errors}
+                      pinned={pinnedField.state.value}
+                      disabled={isPending}
+                      onNameChange={(name) => {
+                        nameField.handleChange(name)
+                        setSubmitErrorMessage(undefined)
+                      }}
+                      onBudgetAmountChange={(budgetAmount) => {
+                        budgetField.handleChange(budgetAmount)
+                        setSubmitErrorMessage(undefined)
+                      }}
+                      onPinnedChange={(pinned) => {
+                        pinnedField.handleChange(pinned)
+                        setSubmitErrorMessage(undefined)
+                      }}
+                    />
+                  )}
+                </form.Field>
+              )}
+            </form.Field>
+          )}
+        </form.Field>
         <form.Subscribe selector={(state) => state.isSubmitting}>
           {(isSubmitting) => (
             <Flex gap="3" justify="end">

--- a/apps/web/src/features/payments/createPayment/useCreatePayment.ts
+++ b/apps/web/src/features/payments/createPayment/useCreatePayment.ts
@@ -2,9 +2,8 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
 import { getSupabaseClient } from "../../../lib/supabase"
-import { summaryQueryKeys } from "../../summaryByMonth"
+import { invalidatePaymentMutationQueries } from "../invalidatePaymentMutationQueries"
 import { type PaymentWriteInput, toPaymentWriteInsert } from "../paymentFormMappers"
-import { paymentQueryKeys } from "../queryKeys"
 
 async function postPayment(value: PaymentWriteInput): Promise<void> {
   const supabase = getSupabaseClient()
@@ -30,11 +29,7 @@ export function useCreatePayment(
   const { mutateAsync, isPending } = useMutation({
     mutationFn: postPayment,
     onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: paymentQueryKeys.all }),
-        queryClient.invalidateQueries({ queryKey: summaryQueryKeys.totalExpendituresAll }),
-        queryClient.invalidateQueries({ queryKey: summaryQueryKeys.categoryTotalsAll }),
-      ])
+      await invalidatePaymentMutationQueries(queryClient)
       onSuccess?.()
     },
     onError: (error) => {

--- a/apps/web/src/features/payments/deletePayment/useDeletePayment.ts
+++ b/apps/web/src/features/payments/deletePayment/useDeletePayment.ts
@@ -2,8 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
 import type { PaymentId } from "../../../types/payment"
-import { summaryQueryKeys } from "../../summaryByMonth"
-import { paymentQueryKeys } from "../queryKeys"
+import { invalidatePaymentMutationQueries } from "../invalidatePaymentMutationQueries"
 import { removePayment } from "./removePayment"
 
 interface UseDeletePaymentReturn {
@@ -20,12 +19,7 @@ export function useDeletePayment(
   const { mutateAsync, isPending } = useMutation({
     mutationFn: async (paymentId: PaymentId) => removePayment(paymentId),
     onSuccess: async (__, paymentId) => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: paymentQueryKeys.all }),
-        queryClient.invalidateQueries({ queryKey: paymentQueryKeys.details(paymentId) }),
-        queryClient.invalidateQueries({ queryKey: summaryQueryKeys.totalExpendituresAll }),
-        queryClient.invalidateQueries({ queryKey: summaryQueryKeys.categoryTotalsAll }),
-      ])
+      await invalidatePaymentMutationQueries(queryClient, paymentId)
       onSuccess?.()
     },
     onError: (error) => {

--- a/apps/web/src/features/payments/invalidatePaymentMutationQueries.ts
+++ b/apps/web/src/features/payments/invalidatePaymentMutationQueries.ts
@@ -1,0 +1,24 @@
+import type { QueryClient } from "@tanstack/react-query"
+
+import type { PaymentId } from "../../types/payment"
+import { summaryQueryKeys } from "../summaryByMonth"
+import { paymentQueryKeys } from "./queryKeys"
+
+export async function invalidatePaymentMutationQueries(
+  queryClient: QueryClient,
+  paymentId?: PaymentId,
+): Promise<void> {
+  const detailQueryKeys = paymentId === undefined ? [] : [paymentQueryKeys.details(paymentId)]
+  const queryKeys = [
+    paymentQueryKeys.all,
+    ...detailQueryKeys,
+    summaryQueryKeys.totalExpendituresAll,
+    summaryQueryKeys.categoryTotalsAll,
+  ]
+
+  await Promise.all(
+    queryKeys.map(async (queryKey) => {
+      await queryClient.invalidateQueries({ queryKey })
+    }),
+  )
+}

--- a/apps/web/src/features/payments/listPayment/fetchPayments.ts
+++ b/apps/web/src/features/payments/listPayment/fetchPayments.ts
@@ -1,28 +1,7 @@
-import * as z from "zod"
-
-import { parseDateOnlyStringToLocalDate, toDateOnlyString } from "../../../domain/date"
+import { toDateOnlyString } from "../../../domain/date"
 import { getSupabaseClient } from "../../../lib/supabase"
 import type { Payment } from "../../../types/payment"
-
-const paymentCategorySchema = z
-  .object({
-    id: z.number(),
-    name: z.string(),
-  })
-  .nullable()
-
-const paymentRowSchema = z.object({
-  id: z.number(),
-  note: z.string().nullable(),
-  amount: z.number(),
-  date: z.string(),
-  created_at: z.string().nullable(),
-  updated_at: z.string().nullable(),
-  book_id: z.number(),
-  category: paymentCategorySchema.optional(),
-})
-
-type PaymentRow = z.infer<typeof paymentRowSchema>
+import { toPayment } from "../paymentResponseMappers"
 
 interface FetchPaymentsOptions {
   categoryId?: number | null
@@ -72,29 +51,5 @@ export async function fetchPayments(
     throw error
   }
 
-  return (data ?? []).map((value) => {
-    const row = normalizePaymentRow(value)
-
-    return {
-      id: row.id,
-      categoryId: row.category?.id ?? null,
-      category: row.category ?? null,
-      note: row.note ?? "",
-      amount: row.amount,
-      date: parseDateOnlyStringToLocalDate(row.date),
-      bookId: row.book_id,
-      createdDate: row.created_at ? new Date(row.created_at) : new Date(),
-      updatedDate: row.updated_at ? new Date(row.updated_at) : new Date(),
-    }
-  })
-}
-
-function normalizePaymentRow(value: unknown): PaymentRow {
-  const result = paymentRowSchema.safeParse(value)
-
-  if (!result.success) {
-    throw new Error("Invalid payment response")
-  }
-
-  return result.data
+  return (data ?? []).map(toPayment)
 }

--- a/apps/web/src/features/payments/paymentDetails/fetchPaymentDetails.ts
+++ b/apps/web/src/features/payments/paymentDetails/fetchPaymentDetails.ts
@@ -1,28 +1,6 @@
-import * as z from "zod"
-
-import { parseDateOnlyStringToLocalDate } from "../../../domain/date"
 import { getSupabaseClient } from "../../../lib/supabase"
 import type { PaymentDetails, PaymentId } from "../../../types/payment"
-
-const paymentCategorySchema = z
-  .object({
-    id: z.number(),
-    name: z.string(),
-  })
-  .nullable()
-
-const paymentDetailsRowSchema = z.object({
-  id: z.number(),
-  note: z.string().nullable(),
-  amount: z.number(),
-  date: z.string(),
-  created_at: z.string().nullable(),
-  updated_at: z.string().nullable(),
-  book_id: z.number(),
-  category: paymentCategorySchema,
-})
-
-type PaymentDetailsRow = z.infer<typeof paymentDetailsRowSchema>
+import { toPaymentDetails } from "../paymentResponseMappers"
 
 export async function fetchPaymentDetails(paymentId: PaymentId): Promise<PaymentDetails | null> {
   const supabase = getSupabaseClient()
@@ -54,26 +32,5 @@ export async function fetchPaymentDetails(paymentId: PaymentId): Promise<Payment
     return null
   }
 
-  const row = normalizePaymentDetailsRow(data)
-
-  return {
-    id: row.id,
-    note: row.note ?? "",
-    amount: row.amount,
-    date: parseDateOnlyStringToLocalDate(row.date),
-    bookId: row.book_id,
-    createdDate: row.created_at ? new Date(row.created_at) : new Date(),
-    updatedDate: row.updated_at ? new Date(row.updated_at) : new Date(),
-    category: row.category,
-  }
-}
-
-function normalizePaymentDetailsRow(value: unknown): PaymentDetailsRow {
-  const result = paymentDetailsRowSchema.safeParse(value)
-
-  if (!result.success) {
-    throw new Error("Invalid payment details response")
-  }
-
-  return result.data
+  return toPaymentDetails(data)
 }

--- a/apps/web/src/features/payments/paymentResponseMappers.ts
+++ b/apps/web/src/features/payments/paymentResponseMappers.ts
@@ -1,0 +1,74 @@
+import * as z from "zod"
+
+import { parseDateOnlyStringToLocalDate } from "../../domain/date"
+import type { Payment, PaymentDetails } from "../../types/payment"
+
+const paymentCategoryResponseSchema = z
+  .object({
+    id: z.number(),
+    name: z.string(),
+  })
+  .nullable()
+
+const paymentResponseSchema = z.object({
+  id: z.number(),
+  note: z.string().nullable(),
+  amount: z.number(),
+  date: z.string(),
+  created_at: z.string().nullable(),
+  updated_at: z.string().nullable(),
+  book_id: z.number(),
+})
+
+const paymentListResponseSchema = paymentResponseSchema.extend({
+  category: paymentCategoryResponseSchema.optional(),
+})
+
+const paymentDetailsResponseSchema = paymentResponseSchema.extend({
+  category: paymentCategoryResponseSchema,
+})
+
+type PaymentResponse = z.infer<typeof paymentResponseSchema>
+
+export function toPayment(value: unknown): Payment {
+  const result = paymentListResponseSchema.safeParse(value)
+
+  if (!result.success) {
+    throw new Error("Invalid payment response")
+  }
+
+  const row = result.data
+
+  return {
+    ...toCommonPayment(row),
+    categoryId: row.category?.id ?? null,
+    category: row.category ?? null,
+  }
+}
+
+export function toPaymentDetails(value: unknown): PaymentDetails {
+  const result = paymentDetailsResponseSchema.safeParse(value)
+
+  if (!result.success) {
+    throw new Error("Invalid payment details response")
+  }
+
+  const row = result.data
+
+  return {
+    ...toCommonPayment(row),
+    category: row.category,
+  }
+}
+
+function toCommonPayment(row: PaymentResponse) {
+  return {
+    id: row.id,
+    note: row.note ?? "",
+    amount: row.amount,
+    date: parseDateOnlyStringToLocalDate(row.date),
+    bookId: row.book_id,
+    createdDate: row.created_at ? new Date(row.created_at) : new Date(),
+    updatedDate: row.updated_at ? new Date(row.updated_at) : new Date(),
+  }
+}

--- a/apps/web/src/features/payments/updatePayment/useUpdatePayment.ts
+++ b/apps/web/src/features/payments/updatePayment/useUpdatePayment.ts
@@ -2,9 +2,8 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCallback } from "react"
 
 import type { PaymentId } from "../../../types/payment"
-import { summaryQueryKeys } from "../../summaryByMonth"
+import { invalidatePaymentMutationQueries } from "../invalidatePaymentMutationQueries"
 import type { PaymentUpdatePatch } from "../paymentFormMappers"
-import { paymentQueryKeys } from "../queryKeys"
 import { updatePayment as updatePaymentRecord } from "./updatePayment"
 
 interface UpdatePaymentInput {
@@ -27,12 +26,7 @@ export function useUpdatePayment(
     mutationFn: async ({ paymentId, patch }: UpdatePaymentInput) =>
       updatePaymentRecord(paymentId, patch),
     onSuccess: async (_, { paymentId }) => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: paymentQueryKeys.all }),
-        queryClient.invalidateQueries({ queryKey: paymentQueryKeys.details(paymentId) }),
-        queryClient.invalidateQueries({ queryKey: summaryQueryKeys.totalExpendituresAll }),
-        queryClient.invalidateQueries({ queryKey: summaryQueryKeys.categoryTotalsAll }),
-      ])
+      await invalidatePaymentMutationQueries(queryClient, paymentId)
       onSuccess?.()
     },
     onError: (error) => {

--- a/apps/web/src/features/summaryByMonth/CategoryTotals/fetchCategoryTotals.ts
+++ b/apps/web/src/features/summaryByMonth/CategoryTotals/fetchCategoryTotals.ts
@@ -1,5 +1,6 @@
 import * as z from "zod"
 
+import { toCategoryBudgetMap, type CategoryBudgetState } from "../../../domain/categoryBudget"
 import { toDateOnlyString } from "../../../domain/date"
 import { getSupabaseClient } from "../../../lib/supabase"
 
@@ -164,41 +165,6 @@ function toCategoryTotal(
     pinned: (row.category_pins ?? []).some((pin) => pin.category_id === row.id),
     kind: "category",
   }
-}
-
-const effectiveCategoryBudgetSchema = z
-  .object({
-    category_id: z.number(),
-    status: z.enum(["amount", "none"]),
-    amount: z.number().nullable(),
-  })
-  .refine(
-    (value) =>
-      (value.status === "amount" && value.amount !== null) ||
-      (value.status === "none" && value.amount === null),
-  )
-
-type CategoryBudgetState = {
-  status: "amount" | "none" | "unset"
-  amount: number | null
-}
-
-function toCategoryBudgetMap(value: unknown): Map<number, CategoryBudgetState> {
-  const result = z.array(effectiveCategoryBudgetSchema).safeParse(value)
-
-  if (!result.success) {
-    throw new Error("Invalid category budget response")
-  }
-
-  return new Map(
-    result.data.map((budget) => [
-      budget.category_id,
-      {
-        status: budget.status,
-        amount: budget.status === "amount" ? budget.amount : null,
-      },
-    ]),
-  )
 }
 
 function compareCategoryTotals(left: CategoryTotal, right: CategoryTotal): number {


### PR DESCRIPTION
## 変更内容

- Category予算APIレスポンスの変換処理を共通化
- 月次予算queryとPayment mutation後の無効化処理を共通化
- Payment一覧・詳細のレスポンス変換処理を共通化
- Category作成・編集フォームのfield UIを共通化
- 月次予算テストの現在年月生成を共通化

## 動作確認

- [x] `pnpm run web:format`
- [x] `pnpm run web:lint`
- [x] `pnpm run web:format-check`
- [x] `pnpm run web:typecheck`
- [x] `pnpm run web:test:unit-integration`（128 files / 609 tests）

## 補足

- Storybook browser-test対象の変更はありません。
- UI・API・DBの振る舞いは変更せず、重複処理の整理に限定しています。

## Review instructions

- `docs/harness/rule-map.json` も参照し、関連ルールとの整合性を見てください。