### PR TITLE
プログレスバーのUIと更新アニメーションを改善

### DIFF
--- a/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
+++ b/apps/web/src/app/routes/PaymentsPage/PaymentsPage.test.tsx
@@ -32,13 +32,13 @@ import { PaymentsPage } from "./PaymentsPage"
 const { Default } = composeStories(stories)
 const createdPaymentFormInput = {
   amount: 54321,
-  categoryName: entertainmentCat.name,
+  categoryName: foodCat.name,
   date: "2025/06/15",
   note: "作成テスト用の支払い",
 }
 const createdPayment = mapPaymentToRow({
   id: 999,
-  categoryId: entertainmentCat.id,
+  categoryId: foodCat.id,
   note: createdPaymentFormInput.note,
   amount: createdPaymentFormInput.amount,
   date: new Date("2025-06-15T00:00:00+09:00"),
@@ -396,6 +396,12 @@ describe("PaymentsPage", () => {
 
     const paymentList = await screen.findByLabelText("payment-list")
     expect(await within(paymentList).findAllByRole("button", { name: /コンビニ/ })).toHaveLength(2)
+    const monthlyProgress = await screen.findByRole("progressbar", {
+      name: "Monthly total budget progress",
+    })
+    const categoryProgress = await screen.findByRole("progressbar", {
+      name: "Food budget progress",
+    })
 
     await user.click(screen.getByRole("button", { name: /create payment/i }))
 
@@ -421,7 +427,11 @@ describe("PaymentsPage", () => {
           response: createdPayment,
         },
       }),
-      ...createCategoryHandlers(),
+      ...createCategoryHandlers({
+        get: {
+          paymentRows: [...initialPaymentRows, createdPayment],
+        },
+      }),
       ...createMonthlyBudgetHandlers({
         get: { response: { ...monthlyBudgets[2], amount: 25000 } },
       }),
@@ -430,6 +440,20 @@ describe("PaymentsPage", () => {
 
     await waitFor(() => {
       expect(screen.queryByRole("dialog", { name: /create payment/i })).not.toBeInTheDocument()
+      expect(screen.getByRole("progressbar", { name: "Monthly total budget progress" })).toBe(
+        monthlyProgress,
+      )
+      expect(screen.getByRole("progressbar", { name: "Food budget progress" })).toBe(
+        categoryProgress,
+      )
+      expect(monthlyProgress).toHaveAttribute(
+        "aria-valuetext",
+        "Spent ¥59,321 of ¥25,000. ¥34,321 over.",
+      )
+      expect(categoryProgress).toHaveAttribute(
+        "aria-valuetext",
+        "Spent ¥55,321 of ¥30,000. ¥25,321 over.",
+      )
     })
 
     view.rerenderStory()

--- a/apps/web/src/features/budgets/components/BudgetProgress/BudgetProgress.module.css
+++ b/apps/web/src/features/budgets/components/BudgetProgress/BudgetProgress.module.css
@@ -1,0 +1,18 @@
+.progress > * {
+  border-radius: inherit;
+  animation: progress-fill 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+  transition: transform 0.8s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+@keyframes progress-fill {
+  from {
+    transform: scaleX(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress > * {
+    animation: none;
+    transition: none;
+  }
+}

--- a/apps/web/src/features/budgets/components/BudgetProgress/BudgetProgress.tsx
+++ b/apps/web/src/features/budgets/components/BudgetProgress/BudgetProgress.tsx
@@ -1,5 +1,7 @@
 import { Progress } from "@radix-ui/themes"
 
+import styles from "./BudgetProgress.module.css"
+
 interface BudgetProgressProps {
   amount: number
   ariaLabel: string
@@ -22,8 +24,10 @@ export function BudgetProgress({
     <Progress
       aria-label={ariaLabel}
       aria-valuetext={ariaValueText}
+      className={styles.progress}
       color={status === "over" ? "yellow" : "green"}
       max={max}
+      radius="full"
       size="2"
       value={value}
     />

--- a/apps/web/src/features/summaryByMonth/CategoryTotals/CategoryTotals.tsx
+++ b/apps/web/src/features/summaryByMonth/CategoryTotals/CategoryTotals.tsx
@@ -27,34 +27,23 @@ export function CategoryTotals({ cacheScope }: CategoryTotalsProps) {
       resetKeys={[cacheScope ?? "default", targetMonthKey]}
     >
       <Suspense fallback={<CategoryTotalsLoading />}>
-        <CategoryTotalsResolved promise={promise} targetMonthKey={targetMonthKey} />
+        <CategoryTotalsResolved
+          key={`${cacheScope ?? "default"}:${targetMonthKey}`}
+          promise={promise}
+        />
       </Suspense>
     </ErrorBoundary>
   )
 }
 
-function CategoryTotalsResolved({
-  promise,
-  targetMonthKey,
-}: {
-  promise: Promise<CategoryTotalsData>
-  targetMonthKey: string
-}) {
+function CategoryTotalsResolved({ promise }: { promise: Promise<CategoryTotalsData> }) {
   const categoryTotals = use(promise)
 
   if (categoryTotals.length === 0) {
     return null
   }
 
-  const categoryTotalsKey = [
-    targetMonthKey,
-    ...categoryTotals.map(
-      (total) =>
-        `${total.key}:${total.kind}:${total.totalAmount}:${total.budgetStatus}:${total.budgetAmount ?? "none"}:${total.pinned ? "1" : "0"}`,
-    ),
-  ].join(":")
-
-  return <CategoryTotalsContent key={categoryTotalsKey} categoryTotals={categoryTotals} />
+  return <CategoryTotalsContent categoryTotals={categoryTotals} />
 }
 
 function CategoryTotalsLoading() {


### PR DESCRIPTION
## 変更内容

- 進捗バーの終端を丸くし、0.8秒で自然に減速するアニメーションを追加
- 動きを減らす設定ではアニメーションを無効化
- 同月内の支払い追加ではProgressのDOMを維持し、直前の進捗から新しい値へ遷移
- 支払い作成フローで月次・カテゴリ進捗の継続を検証

## 動作確認

- [x] pnpm run web:format
- [x] pnpm run web:lint
- [x] pnpm run web:format-check
- [x] pnpm run web:typecheck
- [x] pnpm run web:test:unit-integration
- [x] pnpm run web:test:storybook

## 補足

- 関連Issueなし

## Review instructions

- docs/harness/rule-map.json も参照し、関連ルールとの整合性を見てください。