### PR TITLE
docs: AGENTS.md に Code Review Rules の参照手順を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,12 @@ Personal savings management app. Monorepo with two apps (`apps/web/` and `apps/a
 - When changing an existing workflow, command path, or configuration surface, follow the established pattern in the same layer unless there is a clear reason to change it.
 - If you intentionally diverge from an existing pattern, explain why before applying the change.
 
+## Code Review Rules
+
+- If the review target involves design decisions or policies, read
+  `docs/harness/rule-map.json` and select the applicable active documents.
+- Confirm that the diff does not conflict with the rules in the selected documents.
+
 ## Agent Operating Guidance
 
 Use these rules to apply the repository conventions efficiently without weakening the mandatory rules below.


### PR DESCRIPTION
## 関連Issue

Closes #1640

## 変更内容

- `AGENTS.md` に `Code Review Rules` を追加。
- 設計判断やポリシーに関係するレビューで、`docs/harness/rule-map.json` の該当文書を選定し、差分との整合性を確認する手順を英語で明記。

## 動作確認

- `git diff --check` 成功。
- `git diff --staged --check` 成功。
- 文書変更のみのためアプリ検証は未実施。

## Review instructions

- `docs/harness/rule-map.json` も参照し、関連ルールとの整合性を見てください。