### PR TITLE
feat: アカウントの言語設定を端末間で同期する

### DIFF
--- a/apps/api/supabase/migrations/20260822000000_add_user_language.sql
+++ b/apps/api/supabase/migrations/20260822000000_add_user_language.sql
@@ -1,0 +1,11 @@
+alter table public.users
+  add column language text
+    check (language in ('en', 'ja'));
+
+grant update (name, language) on table public.users to authenticated;
+
+drop trigger if exists trg_update_user_updated_at on public.users;
+create trigger trg_update_user_updated_at
+  before update of name, language on public.users
+  for each row
+  execute function public.update_user_updated_at();

--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -9,6 +9,7 @@ import { SupabaseSessionContext } from "../src/providers/supabase/SupabaseSessio
 import { ThemeProvider } from "../src/providers/theme/ThemeProvider"
 import { mockSession } from "../src/test/data/supabaseSession"
 import { authHandlers } from "../src/test/msw/handlers/auth"
+import { profileHandlers } from "../src/test/msw/handlers/profile"
 
 import "../src/assets/global.css"
 import "../src/i18n"
@@ -22,7 +23,7 @@ const preview: Preview = {
       },
     },
     msw: {
-      handlers: authHandlers,
+      handlers: [...authHandlers, ...profileHandlers],
     },
   },
   loaders: [

--- a/apps/web/src/app/Provider.tsx
+++ b/apps/web/src/app/Provider.tsx
@@ -2,6 +2,7 @@ import { QueryClientProvider } from "@tanstack/react-query"
 import type { ReactNode } from "react"
 
 import { createQueryClient } from "../lib/queryClient"
+import { LanguageSyncProvider } from "../providers/language/LanguageSyncProvider"
 import { SnackbarProvider } from "../providers/snackbar/SnackbarProvider"
 import { SupabaseSessionProvider } from "../providers/supabase/SupabaseSessionProvider"
 import { ThemeProvider } from "../providers/theme/ThemeProvider"
@@ -17,9 +18,11 @@ export function Provider({ children }: ProviderProps) {
   return (
     <QueryClientProvider client={queryClient}>
       <SupabaseSessionProvider>
-        <ThemeProvider>
-          <SnackbarProvider>{children}</SnackbarProvider>
-        </ThemeProvider>
+        <LanguageSyncProvider>
+          <ThemeProvider>
+            <SnackbarProvider>{children}</SnackbarProvider>
+          </ThemeProvider>
+        </LanguageSyncProvider>
       </SupabaseSessionProvider>
     </QueryClientProvider>
   )

--- a/apps/web/src/features/preferences/appearanceSettings/AppearanceSettings/AppearanceSettings.test.tsx
+++ b/apps/web/src/features/preferences/appearanceSettings/AppearanceSettings/AppearanceSettings.test.tsx
@@ -2,6 +2,8 @@ import { composeStories } from "@storybook/react-vite"
 import { afterEach, beforeEach, describe, expect, test } from "vite-plus/test"
 
 import { i18next } from "../../../../i18n"
+import { createProfileHandlers } from "../../../../test/msw/handlers/profile"
+import { server } from "../../../../test/msw/server"
 import { render, screen, waitFor } from "../../../../test/test-utils"
 import * as stories from "./AppearanceSettings.stories"
 
@@ -43,5 +45,22 @@ describe("AppearanceSettings", () => {
     expect(screen.getByRole("combobox", { name: "言語" })).toHaveTextContent("日本語")
     expect(screen.getByRole("combobox", { name: "テーマ" })).toHaveTextContent("ダーク")
     expect(window.localStorage.getItem("appLanguage")).toBe("ja")
+  })
+
+  test("アカウント保存に失敗した場合は変更前の言語へ戻す", async () => {
+    server.resetHandlers(
+      ...createProfileHandlers({
+        update: { error: true, errorResponse: { message: "Failed to save language." } },
+      }),
+    )
+    const { user } = render(<Default />)
+
+    await user.click(screen.getByRole("combobox", { name: "Language" }))
+    await user.click(await screen.findByRole("option", { name: "Japanese" }))
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: "Language" })).toHaveTextContent("English")
+      expect(window.localStorage.getItem("appLanguage")).toBe("en")
+    })
   })
 })

--- a/apps/web/src/features/preferences/appearanceSettings/LanguageSelect/LanguageSelect.tsx
+++ b/apps/web/src/features/preferences/appearanceSettings/LanguageSelect/LanguageSelect.tsx
@@ -3,18 +3,33 @@ import { useCallback } from "react"
 import { useTranslation } from "react-i18next"
 
 import { appLanguageLabelKeys, appLanguages, toAppLanguage } from "../../../../i18n"
+import { useSupabaseSession } from "../../../../providers/supabase/useSupabaseSession"
+import { useUpdateLanguage } from "../../../profile/profileSettings/useUpdateLanguage"
 
 const selectId = "appearance-language"
 
 export function LanguageSelect() {
   const { i18n, t } = useTranslation()
+  const { session } = useSupabaseSession()
+  const authUserId = session?.user.id
+  const { updateLanguage, isPending } = useUpdateLanguage(authUserId ?? "")
   const value = toAppLanguage(i18n.resolvedLanguage)
 
   const handleValueChange = useCallback(
-    (nextLanguage: string) => {
-      void i18n.changeLanguage(toAppLanguage(nextLanguage))
+    async (nextLanguage: string) => {
+      const nextAppLanguage = toAppLanguage(nextLanguage)
+      if (nextAppLanguage === value) return
+
+      try {
+        await i18n.changeLanguage(nextAppLanguage)
+        if (authUserId !== undefined) {
+          await updateLanguage(nextAppLanguage)
+        }
+      } catch {
+        await i18n.changeLanguage(value)
+      }
     },
-    [i18n],
+    [authUserId, i18n, updateLanguage, value],
   )
 
   return (
@@ -22,7 +37,12 @@ export function LanguageSelect() {
       <Text as="label" htmlFor={selectId} size="2" weight="bold">
         {t("language.label")}
       </Text>
-      <Select.Root size="2" value={value} onValueChange={handleValueChange}>
+      <Select.Root
+        size="2"
+        value={value}
+        onValueChange={(nextLanguage) => void handleValueChange(nextLanguage)}
+        disabled={isPending}
+      >
         <Select.Trigger id={selectId} />
         <Select.Content>
           {appLanguages.map((language) => (

--- a/apps/web/src/features/profile/profileSettings/AccountInformationForm/AccountInformationForm.stories.tsx
+++ b/apps/web/src/features/profile/profileSettings/AccountInformationForm/AccountInformationForm.stories.tsx
@@ -9,6 +9,7 @@ import { AccountInformationForm } from "./AccountInformationForm"
 const defaultProfile = {
   name: "Test User",
   email: "test@example.com",
+  language: null,
 }
 
 const meta = {

--- a/apps/web/src/features/profile/profileSettings/fetchProfile.integration.test.ts
+++ b/apps/web/src/features/profile/profileSettings/fetchProfile.integration.test.ts
@@ -15,16 +15,17 @@ describe("fetchProfile", () => {
     server.resetHandlers(...createProfileHandlers())
   })
 
-  it("現在ユーザーの表示名とemailを取得する", async () => {
+  it("現在ユーザーの表示名、email、言語を取得する", async () => {
     server.resetHandlers(
       ...createProfileHandlers({
-        get: { response: { name: "Taro", email: "taro@example.com" } },
+        get: { response: { name: "Taro", email: "taro@example.com", language: "ja" } },
       }),
     )
 
     await expect(fetchProfile("mock-user-id")).resolves.toEqual({
       name: "Taro",
       email: "taro@example.com",
+      language: "ja",
     })
   })
 
@@ -34,14 +35,14 @@ describe("fetchProfile", () => {
     server.use(
       http.get("*/rest/v1/users*", ({ request }) => {
         requestUrl = new URL(request.url)
-        return HttpResponse.json({ name: "Taro", email: "taro@example.com" })
+        return HttpResponse.json({ name: "Taro", email: "taro@example.com", language: null })
       }),
     )
 
     await fetchProfile("mock-user-id")
 
     expect(requestUrl?.searchParams.get("auth_user_id")).toBe("eq.mock-user-id")
-    expect(requestUrl?.searchParams.get("select")).toBe("name,email")
+    expect(requestUrl?.searchParams.get("select")).toBe("name,email,language")
   })
 
   it("Supabaseがエラーを返した場合にthrowする", async () => {
@@ -53,7 +54,7 @@ describe("fetchProfile", () => {
   it("レスポンスshapeが不正ならエラーにする", async () => {
     server.use(
       http.get("*/rest/v1/users*", () => {
-        return HttpResponse.json({ name: "Taro", email: "invalid-email" })
+        return HttpResponse.json({ name: "Taro", email: "invalid-email", language: null })
       }),
     )
 

--- a/apps/web/src/features/profile/profileSettings/fetchProfile.ts
+++ b/apps/web/src/features/profile/profileSettings/fetchProfile.ts
@@ -1,7 +1,7 @@
 import { getSupabaseClient } from "../../../lib/supabase"
 import { profileResponseSchema, type Profile } from "./profileSchema"
 
-const profileColumns = "name, email"
+const profileColumns = "name, email, language"
 
 export async function fetchProfile(authUserId: string): Promise<Profile> {
   const supabase = getSupabaseClient()

--- a/apps/web/src/features/profile/profileSettings/profileSchema.ts
+++ b/apps/web/src/features/profile/profileSettings/profileSchema.ts
@@ -3,6 +3,7 @@ import * as z from "zod"
 export const profileResponseSchema = z.object({
   name: z.string(),
   email: z.string().email(),
+  language: z.enum(["en", "ja"]).nullable().default(null),
 })
 
 export type Profile = z.infer<typeof profileResponseSchema>

--- a/apps/web/src/features/profile/profileSettings/updateLanguage.integration.test.ts
+++ b/apps/web/src/features/profile/profileSettings/updateLanguage.integration.test.ts
@@ -1,0 +1,57 @@
+import { HttpResponse, http } from "msw"
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test"
+
+import { createProfileHandlers } from "../../../test/msw/handlers/profile"
+import { server } from "../../../test/msw/server"
+import { supabaseTestClient } from "../../../test/utils/createSupabaseTestClient"
+import { updateLanguage } from "./updateLanguage"
+
+vi.mock("../../../lib/supabase", () => ({
+  getSupabaseClient: () => supabaseTestClient,
+}))
+
+describe("updateLanguage", () => {
+  beforeEach(() => {
+    server.resetHandlers(...createProfileHandlers())
+  })
+
+  it("現在ユーザーのlanguageだけを更新する", async () => {
+    let requestUrl: URL | undefined
+    let requestBody: unknown
+
+    server.use(
+      http.patch("*/rest/v1/users*", async ({ request }) => {
+        requestUrl = new URL(request.url)
+        requestBody = await request.json()
+        return HttpResponse.json({ auth_user_id: "mock-user-id" })
+      }),
+    )
+
+    await updateLanguage({ authUserId: "mock-user-id", language: "ja" })
+
+    expect(requestUrl?.searchParams.get("auth_user_id")).toBe("eq.mock-user-id")
+    expect(requestBody).toEqual({ language: "ja" })
+  })
+
+  it("Supabaseがエラーを返した場合にthrowする", async () => {
+    server.resetHandlers(
+      ...createProfileHandlers({
+        update: { error: true, errorResponse: { message: "Failed to save language." } },
+      }),
+    )
+
+    await expect(updateLanguage({ authUserId: "mock-user-id", language: "ja" })).rejects.toThrow(
+      "Failed to save language.",
+    )
+  })
+
+  it("更新対象が0件なら成功扱いにしない", async () => {
+    server.use(
+      http.patch("*/rest/v1/users*", () => {
+        return HttpResponse.json([])
+      }),
+    )
+
+    await expect(updateLanguage({ authUserId: "mock-user-id", language: "ja" })).rejects.toThrow()
+  })
+})

--- a/apps/web/src/features/profile/profileSettings/updateLanguage.ts
+++ b/apps/web/src/features/profile/profileSettings/updateLanguage.ts
@@ -1,0 +1,24 @@
+import { getSupabaseClient } from "../../../lib/supabase"
+
+export interface UpdateLanguageInput {
+  authUserId: string
+  language: "en" | "ja"
+}
+
+export async function updateLanguage({ authUserId, language }: UpdateLanguageInput): Promise<void> {
+  const supabase = getSupabaseClient()
+  const { data, error } = await supabase
+    .from("users")
+    .update({ language })
+    .eq("auth_user_id", authUserId)
+    .select("auth_user_id")
+    .single()
+
+  if (error) {
+    throw error
+  }
+
+  if (!data || Array.isArray(data) || data.auth_user_id !== authUserId) {
+    throw new Error("Unable to confirm language update.")
+  }
+}

--- a/apps/web/src/features/profile/profileSettings/useUpdateLanguage.ts
+++ b/apps/web/src/features/profile/profileSettings/useUpdateLanguage.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { useCallback } from "react"
+
+import { profileQueryKeys } from "./profileQueryKeys"
+import { updateLanguage as updateLanguageRecord } from "./updateLanguage"
+
+interface UseUpdateLanguageReturn {
+  updateLanguage: (language: "en" | "ja") => Promise<void>
+  isPending: boolean
+}
+
+export function useUpdateLanguage(authUserId: string): UseUpdateLanguageReturn {
+  const queryClient = useQueryClient()
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: async (language: "en" | "ja") => {
+      await updateLanguageRecord({ authUserId, language })
+      await queryClient.refetchQueries(
+        {
+          queryKey: profileQueryKeys.current(authUserId),
+          type: "all",
+        },
+        { throwOnError: true },
+      )
+    },
+  })
+
+  const updateLanguage = useCallback(
+    async (language: "en" | "ja") => {
+      await mutateAsync(language)
+    },
+    [mutateAsync],
+  )
+
+  return { updateLanguage, isPending }
+}

--- a/apps/web/src/providers/language/LanguageSyncProvider.test.tsx
+++ b/apps/web/src/providers/language/LanguageSyncProvider.test.tsx
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, test } from "vite-plus/test"
+
+import { i18next } from "../../i18n"
+import { createProfileHandlers } from "../../test/msw/handlers/profile"
+import { server } from "../../test/msw/server"
+import { render, screen, waitFor } from "../../test/test-utils"
+import { LanguageSyncProvider } from "./LanguageSyncProvider"
+
+describe("LanguageSyncProvider", () => {
+  beforeEach(async () => {
+    window.localStorage.clear()
+    await i18next.changeLanguage("en")
+    server.resetHandlers(...createProfileHandlers())
+  })
+
+  test("保存済みのアカウント言語を端末へ反映する", async () => {
+    server.resetHandlers(
+      ...createProfileHandlers({
+        get: { response: { name: "Test User", email: "test@example.com", language: "ja" } },
+      }),
+    )
+
+    render(
+      <LanguageSyncProvider>
+        <span>Application</span>
+      </LanguageSyncProvider>,
+    )
+
+    expect(screen.getByText("Application")).toBeInTheDocument()
+    await waitFor(() => {
+      expect(i18next.resolvedLanguage).toBe("ja")
+      expect(window.localStorage.getItem("appLanguage")).toBe("ja")
+    })
+  })
+
+  test("アカウントが未設定なら既存の端末言語を維持する", async () => {
+    await i18next.changeLanguage("ja")
+
+    render(
+      <LanguageSyncProvider>
+        <span>Application</span>
+      </LanguageSyncProvider>,
+    )
+
+    await waitFor(() => expect(window.localStorage.getItem("appLanguage")).toBe("ja"))
+    expect(i18next.resolvedLanguage).toBe("ja")
+  })
+
+  test("取得に失敗してもアプリを表示し続ける", async () => {
+    server.resetHandlers(...createProfileHandlers({ get: { error: true } }))
+
+    render(
+      <LanguageSyncProvider>
+        <span>Application</span>
+      </LanguageSyncProvider>,
+    )
+
+    expect(screen.getByText("Application")).toBeInTheDocument()
+    await waitFor(() => expect(i18next.resolvedLanguage).toBe("en"))
+  })
+})

--- a/apps/web/src/providers/language/LanguageSyncProvider.tsx
+++ b/apps/web/src/providers/language/LanguageSyncProvider.tsx
@@ -1,0 +1,40 @@
+import { useQuery } from "@tanstack/react-query"
+import { type ReactNode, useEffect, useRef } from "react"
+
+import { fetchProfile } from "../../features/profile/profileSettings/fetchProfile"
+import { profileQueryKeys } from "../../features/profile/profileSettings/profileQueryKeys"
+import { i18next } from "../../i18n"
+import { useSupabaseSession } from "../supabase/useSupabaseSession"
+
+interface LanguageSyncProviderProps {
+  children: ReactNode
+}
+
+export function LanguageSyncProvider({ children }: LanguageSyncProviderProps) {
+  const { session, status } = useSupabaseSession()
+  const authUserId = session?.user.id
+  const appliedUserIdRef = useRef<string | null>(null)
+
+  const { data: profile } = useQuery({
+    queryKey: profileQueryKeys.current(authUserId ?? ""),
+    queryFn: async () => fetchProfile(authUserId ?? ""),
+    enabled: status === "authenticated" && authUserId !== undefined,
+    staleTime: 3000,
+  })
+
+  useEffect(() => {
+    if (status !== "authenticated" || authUserId === undefined) {
+      appliedUserIdRef.current = null
+      return
+    }
+
+    if (profile === undefined || appliedUserIdRef.current === authUserId) return
+
+    appliedUserIdRef.current = authUserId
+    if (profile.language !== null) {
+      void i18next.changeLanguage(profile.language)
+    }
+  }, [authUserId, profile, status])
+
+  return <>{children}</>
+}

--- a/apps/web/src/test/msw/handlers/profile.ts
+++ b/apps/web/src/test/msw/handlers/profile.ts
@@ -6,10 +6,15 @@ const USERS_REST_URL = "*/rest/v1/users*"
 export interface ProfileResponse {
   name: string
   email: string
+  language: "en" | "ja" | null
+}
+
+type ProfileResponseInput = Omit<ProfileResponse, "language"> & {
+  language?: ProfileResponse["language"]
 }
 
 interface ProfileGetOptions {
-  response?: ProfileResponse
+  response?: ProfileResponseInput
   error?: boolean
   errorOnce?: boolean
   durationOrMode?: number | DelayMode | undefined
@@ -21,7 +26,12 @@ interface ProfileUpdateOptions {
   durationOrMode?: number | DelayMode | undefined
 }
 
-const profileBodySchema = z.object({ name: z.string() })
+const profileBodySchema = z
+  .object({
+    name: z.string().optional(),
+    language: z.enum(["en", "ja"]).optional(),
+  })
+  .strict()
 
 export function createProfileHandlers({
   get = {},
@@ -30,9 +40,11 @@ export function createProfileHandlers({
   get?: ProfileGetOptions
   update?: ProfileUpdateOptions
 } = {}) {
-  let profile: ProfileResponse = get.response ?? {
+  let profile: ProfileResponse = {
     name: "Test User",
     email: "test@example.com",
+    language: null,
+    ...get.response,
   }
   let hasErrored = false
 
@@ -58,7 +70,7 @@ export function createProfileHandlers({
       }
 
       const body = profileBodySchema.parse(await request.json())
-      profile = { ...profile, name: body.name }
+      profile = { ...profile, ...body }
 
       return HttpResponse.json({ auth_user_id: "mock-user-id" })
     }),

--- a/apps/web/src/types/database.types.ts
+++ b/apps/web/src/types/database.types.ts
@@ -314,6 +314,7 @@ export type Database = {
           created_at: string | null
           email: string
           id: number
+          language: string | null
           legacy_external_id: string | null
           name: string
           updated_at: string | null
@@ -323,6 +324,7 @@ export type Database = {
           created_at?: string | null
           email: string
           id?: never
+          language?: string | null
           legacy_external_id?: string | null
           name: string
           updated_at?: string | null
@@ -332,6 +334,7 @@ export type Database = {
           created_at?: string | null
           email?: string
           id?: never
+          language?: string | null
           legacy_external_id?: string | null
           name?: string
           updated_at?: string | null

--- a/docs/ai-driven-development/workspaces/1563-issue-345418f11192/.aidd/design-completion.json
+++ b/docs/ai-driven-development/workspaces/1563-issue-345418f11192/.aidd/design-completion.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": 1,
+  "kind": "design_completion",
+  "issue": {
+    "id": "kosnu/savings#1563",
+    "title": "言語設定をアカウントに保存して端末間で同期する",
+    "url": "https://github.com/kosnu/savings/issues/1563",
+    "updated_at": "2026-08-01T15:52:57Z",
+    "body_sha256": "7cff29ec2a1a443569aebc540d93b761214dd5d7fcd627e3e4babd3f5cb95e9c"
+  },
+  "workspace": "1563-issue-345418f11192",
+  "design_goal_sha256": "45deaf7e22703d3e82c337335b5544be574161f5a72c41cfb1dd7e02f08599ab",
+  "rule_map": {
+    "path": "docs/harness/rule-map.json",
+    "sha256": "e2b4aaee40567d2ba88d730bec170aa36f62b26d94038484c515c6ec2379395c"
+  },
+  "selected_rules": [
+    {
+      "id": "domain.user",
+      "path": "docs/harness/domain/user.md",
+      "sha256": "6a61239d096b4e2f06989606f6563e477769403d2c39aa40e7c371e55e58db47"
+    }
+  ],
+  "artifacts": {
+    "requirements": {
+      "source": {
+        "path": "docs/ai-driven-development/workspaces/1563-issue-345418f11192/requirements.json",
+        "sha256": "c43d7a9a1ee41753fe5bf51ad7653f6bd8e95ebd6214c0dd669a8c1ced2b879f"
+      },
+      "display": {
+        "path": "docs/ai-driven-development/workspaces/1563-issue-345418f11192/requirements.md",
+        "sha256": "e4c755f74fa2ec09820bff130fb4050e46157b97c60aed1a4cf651fc4b4b5d11"
+      }
+    },
+    "design": {
+      "source": {
+        "path": "docs/ai-driven-development/workspaces/1563-issue-345418f11192/design-doc.json",
+        "sha256": "bee7992f0e2faf6060cc57c1425a34d534c53107620c360e4c1727041820f05a"
+      },
+      "display": {
+        "path": "docs/ai-driven-development/workspaces/1563-issue-345418f11192/design-doc.md",
+        "sha256": "88fd074aa2211f54bbfc6ebfbae956bf05532b6fb1d6aaf4816219e27bc3b37a"
+      }
+    }
+  }
+}

--- a/docs/ai-driven-development/workspaces/1563-issue-345418f11192/design-doc.json
+++ b/docs/ai-driven-development/workspaces/1563-issue-345418f11192/design-doc.json
@@ -1,0 +1,475 @@
+{
+  "schema_version": 2,
+  "kind": "design",
+  "workspace": "1563-issue-345418f11192",
+  "display": {
+    "path": "design-doc.md",
+    "preamble": "---\ntitle: \"Design Doc: 言語設定をアカウントに保存して端末間で同期する\"\ndoc_type: design-doc\nstatus: proposed\narea: web\napplies_to:\n  - apps/web\n  - apps/api\ntopics:\n  - user\n  - auth\n  - language\n  - synchronization\n  - database\nwhen_to_read:\n  - Issue #1563の言語設定同期を実装または検証するとき\n---"
+  },
+  "validation": {
+    "mode": "managed",
+    "sections": [
+      {
+        "id": "context",
+        "heading": "入力と前提",
+        "blocks": [
+          {
+            "id": "context-body",
+            "type": "markdown",
+            "markdown": "- Requirements canonical source: `docs/ai-driven-development/workspaces/1563-issue-345418f11192/requirements.json`\n- Requirements SHA-256: `c43d7a9a1ee41753fe5bf51ad7653f6bd8e95ebd6214c0dd669a8c1ced2b879f`\n- Requirements Input Gate / Completeness Gate: artifact検証成功。\n- Git `HEAD`の同workspace Design baseline: なし。\n- Requirementsと生成requirements.mdはread-onlyとし、BuildはこのDesignのreceiptを上流identityとして扱う。"
+          }
+        ]
+      },
+      {
+        "id": "rule-selection",
+        "heading": "Rule Selection",
+        "blocks": [
+          {
+            "id": "rule-selection-body",
+            "type": "markdown",
+            "markdown": "- Direct/selected: `domain.user`。public.users.languageをアカウント所有・認証境界のユーザードメインとして設計する。\n- Dependency closure: なし。\n- Conflict decision: 既存のprofile update allowlistはlanguage追加範囲だけを拡張し、他の列へ広げない。"
+          }
+        ]
+      },
+      {
+        "id": "architecture",
+        "heading": "採用する構成",
+        "blocks": [
+          {
+            "id": "architecture-body",
+            "type": "markdown",
+            "markdown": "### 永続化とAPI\n\n`public.users.language`を既存の言語値と同じ型制約で追加し、Supabase migration、生成型、プロフィール取得・更新APIの順に同期する。更新RPCまたは既存mutationは認証済みの自身の行だけを対象にし、RLSとサーバー側allowlistで二重に境界を守る。\n\n### Web状態\n\nログイン時はアカウント値を取得してlanguage stateを初期化し、selector変更は既存のlocalStorage書き込みとアカウントmutationを同一の状態遷移として扱う。サーバー値が存在する場合を優先し、未設定時だけ既存端末値、最後に安全な既定言語へ進む。"
+          }
+        ]
+      },
+      {
+        "id": "data-contract",
+        "heading": "データ・API境界",
+        "blocks": [
+          {
+            "id": "data-contract-body",
+            "type": "markdown",
+            "markdown": "- migrationは`public.users.language`をnullableな既存互換値として追加し、対応値を日本語・英語へ限定する。\n- profile updateの入力schemaとAPI型は`name`と`language`だけを更新可能列として明示する。\n- RLSは`auth.uid()`と対象行の所有者を照合し、他ユーザー・未認証・許可外列の更新を拒否する。\n- 取得失敗と保存失敗はAPIエラーをUI全体へ伝播させず、言語状態のfallbackと再試行境界へ変換する。"
+          }
+        ]
+      },
+      {
+        "id": "state-flow",
+        "heading": "状態遷移と優先順位",
+        "blocks": [
+          {
+            "id": "state-flow-body",
+            "type": "markdown",
+            "markdown": "1. 認証済みセッション確立後にアカウントlanguageを取得する。\n2. 有効なアカウント値があれば端末値より優先して適用し、localStorageを同期する。\n3. アカウント値が未設定なら既存localStorage値を検証して適用し、アカウントへ推測値を強制保存しない。\n4. 端末値も無効または取得に失敗した場合は既定言語で利用を継続する。\n5. 言語変更時はUIを先に反映し、保存失敗時は直前値または既定値へ戻せる状態を保持する。"
+          }
+        ]
+      },
+      {
+        "id": "requirement-design",
+        "heading": "要求別設計根拠",
+        "blocks": [
+          {
+            "id": "fr-1-design-evidence",
+            "type": "evidence",
+            "role": "design",
+            "owner_id": "FR-1",
+            "product_behavior_ids": ["PB-6"],
+            "text": "永続化列、migration、生成型、プロフィール契約を同じ所有責務へ結び付ける。"
+          },
+          {
+            "id": "fr-2-design-evidence",
+            "type": "evidence",
+            "role": "design",
+            "owner_id": "FR-2",
+            "product_behavior_ids": ["PB-2"],
+            "text": "セッション確立後の取得結果をlanguage state初期化へ渡し、別端末でも同じアカウント値を利用する。"
+          },
+          {
+            "id": "fr-3-design-evidence",
+            "type": "evidence",
+            "role": "design",
+            "owner_id": "FR-3",
+            "product_behavior_ids": ["PB-1"],
+            "text": "selector変更を許可値へ正規化し、プロフィール更新mutationと端末キャッシュへ一貫して反映する。"
+          },
+          {
+            "id": "fr-4-design-evidence",
+            "type": "evidence",
+            "role": "design",
+            "owner_id": "FR-4",
+            "product_behavior_ids": ["PB-3"],
+            "text": "アカウント値、端末値、既定値の優先順位を初期化関数の単一分岐として固定する。"
+          },
+          {
+            "id": "fr-5-design-evidence",
+            "type": "evidence",
+            "role": "design",
+            "owner_id": "FR-5",
+            "product_behavior_ids": ["PB-4"],
+            "text": "未設定と通信失敗を非致命的な状態として扱い、既定値または直前値でアプリを継続可能にする。"
+          },
+          {
+            "id": "nfr-1-design-evidence",
+            "type": "evidence",
+            "role": "design",
+            "owner_id": "NFR-1",
+            "product_behavior_ids": [],
+            "text": "既存の日本語・英語localeと翻訳リソースを変更せず、同期経路だけを追加する。"
+          },
+          {
+            "id": "nfr-2-design-evidence",
+            "type": "evidence",
+            "role": "design",
+            "owner_id": "NFR-2",
+            "product_behavior_ids": ["PB-5"],
+            "text": "認証ユーザー自身の行とlanguage列だけを更新可能にするAPI、RLS、サーバーallowlistを重ねる。"
+          },
+          {
+            "id": "nfr-3-design-evidence",
+            "type": "evidence",
+            "role": "design",
+            "owner_id": "NFR-3",
+            "product_behavior_ids": ["PB-7"],
+            "text": "プロフィール更新の許可列をnameと言語へ明示し、その他の列を入力schemaから排除する。"
+          },
+          {
+            "id": "ac-1-design-evidence",
+            "type": "evidence",
+            "role": "design",
+            "owner_id": "AC-1",
+            "product_behavior_ids": [],
+            "text": "migration、型、API、RLSの各契約をアカウント所有責務の一つの設計根拠へ対応付ける。"
+          },
+          {
+            "id": "ac-2-design-evidence",
+            "type": "evidence",
+            "role": "design",
+            "owner_id": "AC-2",
+            "product_behavior_ids": [],
+            "text": "ログイン初期化のloading境界を保ち、取得済みlanguageが初期表示へ反映される順序を固定する。"
+          },
+          {
+            "id": "ac-3-design-evidence",
+            "type": "evidence",
+            "role": "design",
+            "owner_id": "AC-3",
+            "product_behavior_ids": [],
+            "text": "変更イベント、mutation、成功後の再取得を同じ言語保存フローとして設計する。"
+          },
+          {
+            "id": "ac-4-design-evidence",
+            "type": "evidence",
+            "role": "design",
+            "owner_id": "AC-4",
+            "product_behavior_ids": [],
+            "text": "共有アカウントの取得を端末初期化より先に実行し、端末間で同じ値を選ぶ。"
+          },
+          {
+            "id": "ac-5-design-evidence",
+            "type": "evidence",
+            "role": "design",
+            "owner_id": "AC-5",
+            "product_behavior_ids": [],
+            "text": "未設定、取得失敗、保存失敗を個別のfallbackと再試行境界へ分解する。"
+          },
+          {
+            "id": "ac-6-design-evidence",
+            "type": "evidence",
+            "role": "design",
+            "owner_id": "AC-6",
+            "product_behavior_ids": [],
+            "text": "既存localeの表示責務を同期機能から分離し、日本語・英語の表示契約を保持する。"
+          },
+          {
+            "id": "ac-7-design-evidence",
+            "type": "evidence",
+            "role": "design",
+            "owner_id": "AC-7",
+            "product_behavior_ids": [],
+            "text": "DB、型、API、RLS、更新条件、Web回帰を一つの検証計画に組み込む。"
+          }
+        ]
+      },
+      {
+        "id": "verification",
+        "heading": "検証方針",
+        "blocks": [
+          {
+            "id": "fr-1-verification-evidence",
+            "type": "evidence",
+            "role": "verification",
+            "owner_id": "FR-1",
+            "text": "migration、生成型、プロフィール取得更新の整合と所有行制約をAPI・DBテストで確認する。"
+          },
+          {
+            "id": "fr-2-verification-evidence",
+            "type": "evidence",
+            "role": "verification",
+            "owner_id": "FR-2",
+            "text": "保存済み言語のログイン反映を複数端末fixtureで確認し、取得失敗でも画面が継続することを検証する。"
+          },
+          {
+            "id": "fr-3-verification-evidence",
+            "type": "evidence",
+            "role": "verification",
+            "owner_id": "FR-3",
+            "text": "selector変更のpayload、成功後の再取得、保存失敗時の復元をunit・integration testで確認する。"
+          },
+          {
+            "id": "fr-4-verification-evidence",
+            "type": "evidence",
+            "role": "verification",
+            "owner_id": "FR-4",
+            "text": "アカウント値ありなしと端末値ありなしの組合せで、採用値とlocalStorage同期結果を表にして検証する。"
+          },
+          {
+            "id": "fr-5-verification-evidence",
+            "type": "evidence",
+            "role": "verification",
+            "owner_id": "FR-5",
+            "text": "未設定・取得失敗・保存失敗を再現し、既定値または直前値で利用可能な状態を保つことを確認する。"
+          },
+          {
+            "id": "nfr-1-verification-evidence",
+            "type": "evidence",
+            "role": "verification",
+            "owner_id": "NFR-1",
+            "text": "日本語と英語の主要画面、selector、既存翻訳キーの回帰テストを実行する。"
+          },
+          {
+            "id": "nfr-2-verification-evidence",
+            "type": "evidence",
+            "role": "verification",
+            "owner_id": "NFR-2",
+            "text": "別ユーザー、未認証、許可外列の更新がAPIとRLSで拒否されることをnegative testで確認する。"
+          },
+          {
+            "id": "nfr-3-verification-evidence",
+            "type": "evidence",
+            "role": "verification",
+            "owner_id": "NFR-3",
+            "text": "nameと言語の更新だけが通り、他のプロフィール列がrejectされるallowlist回帰を確認する。"
+          },
+          {
+            "id": "ac-1-verification-evidence",
+            "type": "evidence",
+            "role": "verification",
+            "owner_id": "AC-1",
+            "text": "保存先と所有責務に対応するmigration・型・API・RLSの証拠をレビューと自動検証で確認する。"
+          },
+          {
+            "id": "ac-2-verification-evidence",
+            "type": "evidence",
+            "role": "verification",
+            "owner_id": "AC-2",
+            "text": "ログインfixtureで保存済み言語が初期表示へ反映され、loading中に誤った既定値を確定しないことを確認する。"
+          },
+          {
+            "id": "ac-3-verification-evidence",
+            "type": "evidence",
+            "role": "verification",
+            "owner_id": "AC-3",
+            "text": "言語変更後の更新payloadと再取得値を確認し、アカウント保存の永続性を検証する。"
+          },
+          {
+            "id": "ac-4-verification-evidence",
+            "type": "evidence",
+            "role": "verification",
+            "owner_id": "AC-4",
+            "text": "端末Aで変更した値が端末Bの新規ログインで反映されるシナリオをintegration testで確認する。"
+          },
+          {
+            "id": "ac-5-verification-evidence",
+            "type": "evidence",
+            "role": "verification",
+            "owner_id": "AC-5",
+            "text": "3種類の異常系でアプリが利用不能にならず、定義したfallbackと再試行表示を確認する。"
+          },
+          {
+            "id": "ac-6-verification-evidence",
+            "type": "evidence",
+            "role": "verification",
+            "owner_id": "AC-6",
+            "text": "既存の日本語・英語主要画面と翻訳リソースのunit・integration回帰を実行する。"
+          },
+          {
+            "id": "ac-7-verification-evidence",
+            "type": "evidence",
+            "role": "verification",
+            "owner_id": "AC-7",
+            "text": "DB migration検証、型check、API/RLSテスト、Web lint・typecheck・unit integrationを記録する。"
+          }
+        ]
+      },
+      {
+        "id": "implementation-scope",
+        "heading": "変更対象",
+        "blocks": [
+          {
+            "id": "implementation-scope-body",
+            "type": "markdown",
+            "markdown": "- `apps/api`またはSupabase migration: users.language列、型、RLS、更新条件。\n- `apps/web`のprofile mutation、ログイン初期化、language selector、localStorage同期とfallback。\n- API/MSW fixture、unit/integration test、必要な生成型。\n- RequirementsとDesignのcanonical JSON/Markdownはphase境界に従い、BuildでDesign完了後に固定する。"
+          }
+        ]
+      },
+      {
+        "id": "risks",
+        "heading": "リスクと確認事項",
+        "blocks": [
+          {
+            "id": "risks-body",
+            "type": "markdown",
+            "markdown": "- アカウント値を強制的に推測保存すると既存利用者の意図しない変更になるため、未設定時の保存は明示操作に限定する。\n- RLSだけでなくAPI allowlistも確認し、他列更新の混入を防ぐ。\n- 保存失敗でUIだけ新言語にならないよう、直前値または既定値への復元を検証する。\n- migration適用順と生成型の不一致があればBuildを完了せず停止する。"
+          }
+        ]
+      }
+    ],
+    "product_behaviors": [
+      {
+        "id": "PB-1",
+        "type": "user_operation",
+        "change": "changed",
+        "requirement_id": "FR-3"
+      },
+      {
+        "id": "PB-2",
+        "type": "state_transition",
+        "change": "changed",
+        "requirement_id": "FR-2"
+      },
+      {
+        "id": "PB-3",
+        "type": "state_transition",
+        "change": "changed",
+        "requirement_id": "FR-4"
+      },
+      {
+        "id": "PB-4",
+        "type": "state_transition",
+        "change": "changed",
+        "requirement_id": "FR-5"
+      },
+      {
+        "id": "PB-5",
+        "type": "user_operation",
+        "change": "changed",
+        "requirement_id": "NFR-2"
+      },
+      {
+        "id": "PB-6",
+        "type": "state_transition",
+        "change": "changed",
+        "requirement_id": "FR-1"
+      },
+      {
+        "id": "PB-7",
+        "type": "state_transition",
+        "change": "changed",
+        "requirement_id": "NFR-3"
+      }
+    ],
+    "coverage_gate": {
+      "requirements_sha256": "c43d7a9a1ee41753fe5bf51ad7653f6bd8e95ebd6214c0dd669a8c1ced2b879f",
+      "workspace": "1563-issue-345418f11192",
+      "requirement_ids": [
+        "FR-1",
+        "FR-2",
+        "FR-3",
+        "FR-4",
+        "FR-5",
+        "NFR-1",
+        "NFR-2",
+        "NFR-3",
+        "AC-1",
+        "AC-2",
+        "AC-3",
+        "AC-4",
+        "AC-5",
+        "AC-6",
+        "AC-7"
+      ],
+      "baseline": {
+        "source": "none",
+        "body_sha256": null
+      },
+      "coverage": [
+        {
+          "id": "FR-1",
+          "design_block_id": "fr-1-design-evidence",
+          "verification_block_id": "fr-1-verification-evidence"
+        },
+        {
+          "id": "FR-2",
+          "design_block_id": "fr-2-design-evidence",
+          "verification_block_id": "fr-2-verification-evidence"
+        },
+        {
+          "id": "FR-3",
+          "design_block_id": "fr-3-design-evidence",
+          "verification_block_id": "fr-3-verification-evidence"
+        },
+        {
+          "id": "FR-4",
+          "design_block_id": "fr-4-design-evidence",
+          "verification_block_id": "fr-4-verification-evidence"
+        },
+        {
+          "id": "FR-5",
+          "design_block_id": "fr-5-design-evidence",
+          "verification_block_id": "fr-5-verification-evidence"
+        },
+        {
+          "id": "NFR-1",
+          "design_block_id": "nfr-1-design-evidence",
+          "verification_block_id": "nfr-1-verification-evidence"
+        },
+        {
+          "id": "NFR-2",
+          "design_block_id": "nfr-2-design-evidence",
+          "verification_block_id": "nfr-2-verification-evidence"
+        },
+        {
+          "id": "NFR-3",
+          "design_block_id": "nfr-3-design-evidence",
+          "verification_block_id": "nfr-3-verification-evidence"
+        },
+        {
+          "id": "AC-1",
+          "design_block_id": "ac-1-design-evidence",
+          "verification_block_id": "ac-1-verification-evidence"
+        },
+        {
+          "id": "AC-2",
+          "design_block_id": "ac-2-design-evidence",
+          "verification_block_id": "ac-2-verification-evidence"
+        },
+        {
+          "id": "AC-3",
+          "design_block_id": "ac-3-design-evidence",
+          "verification_block_id": "ac-3-verification-evidence"
+        },
+        {
+          "id": "AC-4",
+          "design_block_id": "ac-4-design-evidence",
+          "verification_block_id": "ac-4-verification-evidence"
+        },
+        {
+          "id": "AC-5",
+          "design_block_id": "ac-5-design-evidence",
+          "verification_block_id": "ac-5-verification-evidence"
+        },
+        {
+          "id": "AC-6",
+          "design_block_id": "ac-6-design-evidence",
+          "verification_block_id": "ac-6-verification-evidence"
+        },
+        {
+          "id": "AC-7",
+          "design_block_id": "ac-7-design-evidence",
+          "verification_block_id": "ac-7-verification-evidence"
+        }
+      ],
+      "baseline_sections": []
+    }
+  }
+}

--- a/docs/ai-driven-development/workspaces/1563-issue-345418f11192/design-doc.md
+++ b/docs/ai-driven-development/workspaces/1563-issue-345418f11192/design-doc.md
@@ -1,0 +1,118 @@
+---
+title: "Design Doc: 言語設定をアカウントに保存して端末間で同期する"
+doc_type: design-doc
+status: proposed
+area: web
+applies_to:
+  - apps/web
+  - apps/api
+topics:
+  - user
+  - auth
+  - language
+  - synchronization
+  - database
+when_to_read:
+  - Issue #1563の言語設定同期を実装または検証するとき
+---
+
+## 入力と前提
+
+- Requirements canonical source: `docs/ai-driven-development/workspaces/1563-issue-345418f11192/requirements.json`
+- Requirements SHA-256: `c43d7a9a1ee41753fe5bf51ad7653f6bd8e95ebd6214c0dd669a8c1ced2b879f`
+- Requirements Input Gate / Completeness Gate: artifact検証成功。
+- Git `HEAD`の同workspace Design baseline: なし。
+- Requirementsと生成requirements.mdはread-onlyとし、BuildはこのDesignのreceiptを上流identityとして扱う。
+
+## Rule Selection
+
+- Direct/selected: `domain.user`。public.users.languageをアカウント所有・認証境界のユーザードメインとして設計する。
+- Dependency closure: なし。
+- Conflict decision: 既存のprofile update allowlistはlanguage追加範囲だけを拡張し、他の列へ広げない。
+
+## 採用する構成
+
+### 永続化とAPI
+
+`public.users.language`を既存の言語値と同じ型制約で追加し、Supabase migration、生成型、プロフィール取得・更新APIの順に同期する。更新RPCまたは既存mutationは認証済みの自身の行だけを対象にし、RLSとサーバー側allowlistで二重に境界を守る。
+
+### Web状態
+
+ログイン時はアカウント値を取得してlanguage stateを初期化し、selector変更は既存のlocalStorage書き込みとアカウントmutationを同一の状態遷移として扱う。サーバー値が存在する場合を優先し、未設定時だけ既存端末値、最後に安全な既定言語へ進む。
+
+## データ・API境界
+
+- migrationは`public.users.language`をnullableな既存互換値として追加し、対応値を日本語・英語へ限定する。
+- profile updateの入力schemaとAPI型は`name`と`language`だけを更新可能列として明示する。
+- RLSは`auth.uid()`と対象行の所有者を照合し、他ユーザー・未認証・許可外列の更新を拒否する。
+- 取得失敗と保存失敗はAPIエラーをUI全体へ伝播させず、言語状態のfallbackと再試行境界へ変換する。
+
+## 状態遷移と優先順位
+
+1. 認証済みセッション確立後にアカウントlanguageを取得する。
+2. 有効なアカウント値があれば端末値より優先して適用し、localStorageを同期する。
+3. アカウント値が未設定なら既存localStorage値を検証して適用し、アカウントへ推測値を強制保存しない。
+4. 端末値も無効または取得に失敗した場合は既定言語で利用を継続する。
+5. 言語変更時はUIを先に反映し、保存失敗時は直前値または既定値へ戻せる状態を保持する。
+
+## 要求別設計根拠
+
+FR\-1 design: 永続化列、migration、生成型、プロフィール契約を同じ所有責務へ結び付ける。
+FR\-2 design: セッション確立後の取得結果をlanguage state初期化へ渡し、別端末でも同じアカウント値を利用する。
+FR\-3 design: selector変更を許可値へ正規化し、プロフィール更新mutationと端末キャッシュへ一貫して反映する。
+FR\-4 design: アカウント値、端末値、既定値の優先順位を初期化関数の単一分岐として固定する。
+FR\-5 design: 未設定と通信失敗を非致命的な状態として扱い、既定値または直前値でアプリを継続可能にする。
+NFR\-1 design: 既存の日本語・英語localeと翻訳リソースを変更せず、同期経路だけを追加する。
+NFR\-2 design: 認証ユーザー自身の行とlanguage列だけを更新可能にするAPI、RLS、サーバーallowlistを重ねる。
+NFR\-3 design: プロフィール更新の許可列をnameと言語へ明示し、その他の列を入力schemaから排除する。
+AC\-1 design: migration、型、API、RLSの各契約をアカウント所有責務の一つの設計根拠へ対応付ける。
+AC\-2 design: ログイン初期化のloading境界を保ち、取得済みlanguageが初期表示へ反映される順序を固定する。
+AC\-3 design: 変更イベント、mutation、成功後の再取得を同じ言語保存フローとして設計する。
+AC\-4 design: 共有アカウントの取得を端末初期化より先に実行し、端末間で同じ値を選ぶ。
+AC\-5 design: 未設定、取得失敗、保存失敗を個別のfallbackと再試行境界へ分解する。
+AC\-6 design: 既存localeの表示責務を同期機能から分離し、日本語・英語の表示契約を保持する。
+AC\-7 design: DB、型、API、RLS、更新条件、Web回帰を一つの検証計画に組み込む。
+
+## 検証方針
+
+FR\-1 verification: migration、生成型、プロフィール取得更新の整合と所有行制約をAPI・DBテストで確認する。
+FR\-2 verification: 保存済み言語のログイン反映を複数端末fixtureで確認し、取得失敗でも画面が継続することを検証する。
+FR\-3 verification: selector変更のpayload、成功後の再取得、保存失敗時の復元をunit・integration testで確認する。
+FR\-4 verification: アカウント値ありなしと端末値ありなしの組合せで、採用値とlocalStorage同期結果を表にして検証する。
+FR\-5 verification: 未設定・取得失敗・保存失敗を再現し、既定値または直前値で利用可能な状態を保つことを確認する。
+NFR\-1 verification: 日本語と英語の主要画面、selector、既存翻訳キーの回帰テストを実行する。
+NFR\-2 verification: 別ユーザー、未認証、許可外列の更新がAPIとRLSで拒否されることをnegative testで確認する。
+NFR\-3 verification: nameと言語の更新だけが通り、他のプロフィール列がrejectされるallowlist回帰を確認する。
+AC\-1 verification: 保存先と所有責務に対応するmigration・型・API・RLSの証拠をレビューと自動検証で確認する。
+AC\-2 verification: ログインfixtureで保存済み言語が初期表示へ反映され、loading中に誤った既定値を確定しないことを確認する。
+AC\-3 verification: 言語変更後の更新payloadと再取得値を確認し、アカウント保存の永続性を検証する。
+AC\-4 verification: 端末Aで変更した値が端末Bの新規ログインで反映されるシナリオをintegration testで確認する。
+AC\-5 verification: 3種類の異常系でアプリが利用不能にならず、定義したfallbackと再試行表示を確認する。
+AC\-6 verification: 既存の日本語・英語主要画面と翻訳リソースのunit・integration回帰を実行する。
+AC\-7 verification: DB migration検証、型check、API\/RLSテスト、Web lint・typecheck・unit integrationを記録する。
+
+## 変更対象
+
+- `apps/api`またはSupabase migration: users.language列、型、RLS、更新条件。
+- `apps/web`のprofile mutation、ログイン初期化、language selector、localStorage同期とfallback。
+- API/MSW fixture、unit/integration test、必要な生成型。
+- RequirementsとDesignのcanonical JSON/Markdownはphase境界に従い、BuildでDesign完了後に固定する。
+
+## リスクと確認事項
+
+- アカウント値を強制的に推測保存すると既存利用者の意図しない変更になるため、未設定時の保存は明示操作に限定する。
+- RLSだけでなくAPI allowlistも確認し、他列更新の混入を防ぐ。
+- 保存失敗でUIだけ新言語にならないよう、直前値または既定値への復元を検証する。
+- migration適用順と生成型の不一致があればBuildを完了せず停止する。
+
+## Product Behavior Trace
+
+```json
+[{"id":"PB-1","type":"user_operation","change":"changed","requirement_id":"FR-3"},{"id":"PB-2","type":"state_transition","change":"changed","requirement_id":"FR-2"},{"id":"PB-3","type":"state_transition","change":"changed","requirement_id":"FR-4"},{"id":"PB-4","type":"state_transition","change":"changed","requirement_id":"FR-5"},{"id":"PB-5","type":"user_operation","change":"changed","requirement_id":"NFR-2"},{"id":"PB-6","type":"state_transition","change":"changed","requirement_id":"FR-1"},{"id":"PB-7","type":"state_transition","change":"changed","requirement_id":"NFR-3"}]
+```
+
+## Design Coverage Gate
+
+```json
+{"requirements_sha256":"c43d7a9a1ee41753fe5bf51ad7653f6bd8e95ebd6214c0dd669a8c1ced2b879f","workspace":"1563-issue-345418f11192","requirement_ids":["FR-1","FR-2","FR-3","FR-4","FR-5","NFR-1","NFR-2","NFR-3","AC-1","AC-2","AC-3","AC-4","AC-5","AC-6","AC-7"],"baseline":{"source":"none","body_sha256":null},"coverage":[{"id":"FR-1","design_block_id":"fr-1-design-evidence","verification_block_id":"fr-1-verification-evidence"},{"id":"FR-2","design_block_id":"fr-2-design-evidence","verification_block_id":"fr-2-verification-evidence"},{"id":"FR-3","design_block_id":"fr-3-design-evidence","verification_block_id":"fr-3-verification-evidence"},{"id":"FR-4","design_block_id":"fr-4-design-evidence","verification_block_id":"fr-4-verification-evidence"},{"id":"FR-5","design_block_id":"fr-5-design-evidence","verification_block_id":"fr-5-verification-evidence"},{"id":"NFR-1","design_block_id":"nfr-1-design-evidence","verification_block_id":"nfr-1-verification-evidence"},{"id":"NFR-2","design_block_id":"nfr-2-design-evidence","verification_block_id":"nfr-2-verification-evidence"},{"id":"NFR-3","design_block_id":"nfr-3-design-evidence","verification_block_id":"nfr-3-verification-evidence"},{"id":"AC-1","design_block_id":"ac-1-design-evidence","verification_block_id":"ac-1-verification-evidence"},{"id":"AC-2","design_block_id":"ac-2-design-evidence","verification_block_id":"ac-2-verification-evidence"},{"id":"AC-3","design_block_id":"ac-3-design-evidence","verification_block_id":"ac-3-verification-evidence"},{"id":"AC-4","design_block_id":"ac-4-design-evidence","verification_block_id":"ac-4-verification-evidence"},{"id":"AC-5","design_block_id":"ac-5-design-evidence","verification_block_id":"ac-5-verification-evidence"},{"id":"AC-6","design_block_id":"ac-6-design-evidence","verification_block_id":"ac-6-verification-evidence"},{"id":"AC-7","design_block_id":"ac-7-design-evidence","verification_block_id":"ac-7-verification-evidence"}],"baseline_sections":[]}
+```

--- a/docs/ai-driven-development/workspaces/1563-issue-345418f11192/requirements.json
+++ b/docs/ai-driven-development/workspaces/1563-issue-345418f11192/requirements.json
@@ -1,0 +1,357 @@
+{
+  "schema_version": 2,
+  "kind": "requirements",
+  "workspace": "1563-issue-345418f11192",
+  "display": {
+    "path": "requirements.md",
+    "preamble": "---\ntitle: \"Requirements: 言語設定をアカウントに保存して端末間で同期する\"\ndoc_type: requirements\nstatus: proposed\narea: web\napplies_to:\n  - apps/web\n  - apps/api\ntopics:\n  - user\n  - auth\n  - language\n  - synchronization\nwhen_to_read:\n  - Issue #1563の言語設定同期を設計、実装、検証するとき\n---"
+  },
+  "validation": {
+    "mode": "managed",
+    "cycle_start_issue_title": "言語設定をアカウントに保存して端末間で同期する",
+    "input_gate": {
+      "task_context": {
+        "source": "issue_body",
+        "issue": "kosnu/savings#1563",
+        "url": "https://github.com/kosnu/savings/issues/1563",
+        "updated_at": "2026-08-01T15:52:57Z",
+        "body_sha256": "7cff29ec2a1a443569aebc540d93b761214dd5d7fcd627e3e4babd3f5cb95e9c"
+      },
+      "direct_rules": [
+        {
+          "id": "domain.user",
+          "issue_evidence": "public.users.language",
+          "match": {
+            "field": "domains",
+            "value": "user"
+          },
+          "reason": "アカウントの言語列をユーザードメインの責務として定義する。"
+        }
+      ],
+      "depends_on": []
+    },
+    "completeness_gate": {
+      "issue_body_sha256": "7cff29ec2a1a443569aebc540d93b761214dd5d7fcd627e3e4babd3f5cb95e9c",
+      "workspace": "1563-issue-345418f11192",
+      "baseline": {
+        "source": "none",
+        "body_sha256": null
+      },
+      "requirements": [
+        {
+          "id": "FR-1",
+          "status": "new",
+          "issue_evidence": "永続的な保存先として追加する"
+        },
+        {
+          "id": "FR-2",
+          "status": "new",
+          "issue_evidence": "ログイン時の言語設定取得"
+        },
+        {
+          "id": "FR-3",
+          "status": "new",
+          "issue_evidence": "言語変更時の保存"
+        },
+        {
+          "id": "FR-4",
+          "status": "new",
+          "issue_evidence": "既存localStorage値との優先順位"
+        },
+        {
+          "id": "FR-5",
+          "status": "new",
+          "issue_evidence": "言語設定を取得・保存できたか"
+        },
+        {
+          "id": "NFR-1",
+          "status": "new",
+          "issue_evidence": "対応言語は既存の日本語と英語を維持する"
+        },
+        {
+          "id": "NFR-2",
+          "status": "new",
+          "issue_evidence": "クライアントが自身の `language` を更新できるよう"
+        },
+        {
+          "id": "NFR-3",
+          "status": "new",
+          "issue_evidence": "既存の `name` のみというルールは `language` の追加範囲で変更し"
+        },
+        {
+          "id": "AC-1",
+          "status": "new",
+          "issue_evidence": "言語設定の保存先と所有責務が定義されている"
+        },
+        {
+          "id": "AC-2",
+          "status": "new",
+          "issue_evidence": "ログイン時に保存済み言語が反映される"
+        },
+        {
+          "id": "AC-3",
+          "status": "new",
+          "issue_evidence": "言語変更がアカウントへ保存される"
+        },
+        {
+          "id": "AC-4",
+          "status": "new",
+          "issue_evidence": "別端末で同じ言語設定が反映される"
+        },
+        {
+          "id": "AC-5",
+          "status": "new",
+          "issue_evidence": "未設定・取得失敗・保存失敗時の挙動が定義されている"
+        },
+        {
+          "id": "AC-6",
+          "status": "new",
+          "issue_evidence": "既存の日本語・英語表示が壊れていない"
+        },
+        {
+          "id": "AC-7",
+          "status": "new",
+          "issue_evidence": "必要な検証ができる"
+        }
+      ],
+      "sections": [
+        {
+          "id": "background",
+          "status": "new",
+          "issue_evidence": "現在の言語設定はブラウザの `localStorage` にだけ保存される"
+        },
+        {
+          "id": "users",
+          "status": "new",
+          "issue_evidence": "同じユーザーが別端末や別ブラウザでログインしても"
+        },
+        {
+          "id": "stories",
+          "status": "new",
+          "issue_evidence": "プロフィール設定として選択した言語が"
+        },
+        {
+          "id": "scope",
+          "status": "new",
+          "issue_evidence": "### 対象"
+        },
+        {
+          "id": "functional",
+          "status": "new",
+          "issue_evidence": "- 言語設定の保存先"
+        },
+        {
+          "id": "non-functional",
+          "status": "new",
+          "issue_evidence": "- 対応言語は既存の日本語と英語を維持する"
+        },
+        {
+          "id": "acceptance",
+          "status": "new",
+          "issue_evidence": "## 成功条件"
+        },
+        {
+          "id": "qa",
+          "status": "new",
+          "issue_evidence": "## 判断したいこと"
+        },
+        {
+          "id": "technical",
+          "status": "new",
+          "issue_evidence": "必要なDB migration、型・API境界、RLS・更新条件、回帰テストを同期して変更する"
+        }
+      ],
+      "retired": []
+    },
+    "requirements": [
+      {
+        "id": "FR-1",
+        "section_id": "functional",
+        "text": "言語設定はpublic.users.languageを永続的な保存先として追加する。ブラウザだけに分散させずアカウントが所有する。"
+      },
+      {
+        "id": "FR-2",
+        "section_id": "functional",
+        "text": "ログイン時の言語設定取得により、認証済みユーザーの保存済み言語を現在の端末へ反映する。"
+      },
+      {
+        "id": "FR-3",
+        "section_id": "functional",
+        "text": "言語変更時の保存を実行し、選択した日本語または英語をアカウントへ記録する。"
+      },
+      {
+        "id": "FR-4",
+        "section_id": "functional",
+        "text": "既存localStorage値との優先順位を明示し、アカウント設定と端末設定の競合時に決定的な値を採用する。"
+      },
+      {
+        "id": "FR-5",
+        "section_id": "functional",
+        "text": "言語設定を取得・保存できたかを判断できるよう、各種未設定や取得・保存の失敗時の挙動を定義し、失敗してもアプリを利用不能にせず安全な既定値へ戻す。"
+      },
+      {
+        "id": "NFR-1",
+        "section_id": "non-functional",
+        "text": "対応言語は既存の日本語と英語を維持する。"
+      },
+      {
+        "id": "NFR-2",
+        "section_id": "non-functional",
+        "text": "クライアントが自身の `language` を更新できるようにし、認証・RLS・API境界で他ユーザーのデータ更新を許可しない。"
+      },
+      {
+        "id": "NFR-3",
+        "section_id": "non-functional",
+        "text": "既存の `name` のみというルールは `language` の追加範囲で変更し、他のプロフィール列は更新可能にしない。"
+      },
+      {
+        "id": "AC-1",
+        "section_id": "acceptance",
+        "text": "言語設定の保存先と所有責務が定義されていることを確認できる。"
+      },
+      {
+        "id": "AC-2",
+        "section_id": "acceptance",
+        "text": "ログイン時に保存済み言語が反映されることを確認できる。"
+      },
+      {
+        "id": "AC-3",
+        "section_id": "acceptance",
+        "text": "言語変更がアカウントへ保存されることを確認できる。"
+      },
+      {
+        "id": "AC-4",
+        "section_id": "acceptance",
+        "text": "別端末で同じ言語設定が反映されることを確認できる。"
+      },
+      {
+        "id": "AC-5",
+        "section_id": "acceptance",
+        "text": "未設定・取得失敗・保存失敗時の挙動が定義されていることを確認できる。"
+      },
+      {
+        "id": "AC-6",
+        "section_id": "acceptance",
+        "text": "既存の日本語・英語表示が壊れていないことを回帰検証する。"
+      },
+      {
+        "id": "AC-7",
+        "section_id": "acceptance",
+        "text": "必要な検証ができるよう、migration・型・API境界・RLS・更新条件・回帰テストを同期する。"
+      }
+    ],
+    "sections": [
+      {
+        "id": "background",
+        "heading": "背景",
+        "blocks": [
+          {
+            "id": "background-body",
+            "type": "markdown",
+            "markdown": "現在の言語設定はブラウザの `localStorage` にだけ保存される。同じアカウントの設定がブラウザ外へ共有されず、端末ごとに異なる言語状態になる課題を解消する。"
+          }
+        ]
+      },
+      {
+        "id": "users",
+        "heading": "対象ユーザーと利用シーン",
+        "blocks": [
+          {
+            "id": "users-body",
+            "type": "markdown",
+            "markdown": "同じユーザーが別端末や別ブラウザでログインしても、アカウントを起点に同じ言語を利用できるユーザーシナリオを対象とする。未認証ユーザーのアカウント設定は対象外とする。"
+          }
+        ]
+      },
+      {
+        "id": "stories",
+        "heading": "ユーザーストーリー",
+        "blocks": [
+          {
+            "id": "stories-body",
+            "type": "markdown",
+            "markdown": "プロフィール設定として選択した言語がアカウントに保存され、次のログイン時に端末へ反映されてほしい。利用者は設定の取得・保存結果を判断でき、失敗時もアプリを継続利用したい。"
+          }
+        ]
+      },
+      {
+        "id": "scope",
+        "heading": "スコープ",
+        "blocks": [
+          {
+            "id": "scope-body",
+            "type": "markdown",
+            "markdown": "### 対象\n\n- 保存先とログイン時取得の責務\n- 言語変更時の保存と既存localStorage値との優先順位\n- 未設定・取得失敗・保存失敗時の挙動\n\n### 対象外\n\n- 対応言語の追加\n- テーマ設定の同期\n- 未認証ユーザーのアカウント設定\n- その他のプロフィール項目"
+          }
+        ]
+      },
+      {
+        "id": "functional",
+        "heading": "機能要件",
+        "blocks": [
+          {
+            "id": "functional-body",
+            "type": "markdown",
+            "markdown": "機能として次を定義する。\n\n- 言語設定の保存先\n- ログイン時の保存値取得\n- 言語変更時の保存\n- アカウント設定と端末設定の優先順位\n- 未設定・取得失敗・保存失敗時の安全な継続"
+          },
+          {
+            "id": "functional-requirements",
+            "type": "requirements"
+          }
+        ]
+      },
+      {
+        "id": "non-functional",
+        "heading": "非機能要件",
+        "blocks": [
+          {
+            "id": "non-functional-body",
+            "type": "markdown",
+            "markdown": "- 対応言語は既存の日本語と英語を維持する\n- 認証済みユーザー自身のlanguageだけを更新対象にする\n- DB migration、型・API境界、RLS・更新条件、回帰テストを同期する"
+          },
+          {
+            "id": "non-functional-requirements",
+            "type": "requirements"
+          }
+        ]
+      },
+      {
+        "id": "acceptance",
+        "heading": "受け入れ条件",
+        "blocks": [
+          {
+            "id": "acceptance-body",
+            "type": "markdown",
+            "markdown": "## 成功条件\n\n保存先、ログイン時反映、変更保存、端末間同期、異常系、既存表示、検証可能性を確認できること。"
+          },
+          {
+            "id": "acceptance-requirements",
+            "type": "requirements"
+          }
+        ]
+      },
+      {
+        "id": "qa",
+        "heading": "Q&A",
+        "blocks": [
+          {
+            "id": "qa-body",
+            "type": "markdown",
+            "markdown": "## 判断したいこと\n\n- アカウント設定と端末設定のどちらを優先するか\n- 言語設定を取得・保存できたか\n- 未設定や失敗時にどの既定値で継続するか"
+          }
+        ]
+      },
+      {
+        "id": "technical",
+        "heading": "技術的考慮事項",
+        "blocks": [
+          {
+            "id": "technical-body",
+            "type": "markdown",
+            "markdown": "必要なDB migration、型・API境界、RLS・更新条件、回帰テストを同期して変更する。既存のプロフィール更新境界をlanguageの追加範囲に限って拡張し、他のプロフィール列へ波及させない。"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/ai-driven-development/workspaces/1563-issue-345418f11192/requirements.md
+++ b/docs/ai-driven-development/workspaces/1563-issue-345418f11192/requirements.md
@@ -1,0 +1,116 @@
+---
+title: "Requirements: 言語設定をアカウントに保存して端末間で同期する"
+doc_type: requirements
+status: proposed
+area: web
+applies_to:
+  - apps/web
+  - apps/api
+topics:
+  - user
+  - auth
+  - language
+  - synchronization
+when_to_read:
+  - Issue #1563の言語設定同期を設計、実装、検証するとき
+---
+
+## Cycle Identity
+
+- Cycle-start Issue title: 言語設定をアカウントに保存して端末間で同期する
+
+## Requirements Input Gate
+
+```json
+{"task_context":{"source":"issue_body","issue":"kosnu/savings#1563","url":"https://github.com/kosnu/savings/issues/1563","updated_at":"2026-08-01T15:52:57Z","body_sha256":"7cff29ec2a1a443569aebc540d93b761214dd5d7fcd627e3e4babd3f5cb95e9c"},"direct_rules":[{"id":"domain.user","issue_evidence":"public.users.language","match":{"field":"domains","value":"user"},"reason":"アカウントの言語列をユーザードメインの責務として定義する。"}],"depends_on":[]}
+```
+
+## Requirements Completeness Gate
+
+```json
+{"issue_body_sha256":"7cff29ec2a1a443569aebc540d93b761214dd5d7fcd627e3e4babd3f5cb95e9c","workspace":"1563-issue-345418f11192","baseline":{"source":"none","body_sha256":null},"requirements":[{"id":"FR-1","status":"new","issue_evidence":"永続的な保存先として追加する"},{"id":"FR-2","status":"new","issue_evidence":"ログイン時の言語設定取得"},{"id":"FR-3","status":"new","issue_evidence":"言語変更時の保存"},{"id":"FR-4","status":"new","issue_evidence":"既存localStorage値との優先順位"},{"id":"FR-5","status":"new","issue_evidence":"言語設定を取得・保存できたか"},{"id":"NFR-1","status":"new","issue_evidence":"対応言語は既存の日本語と英語を維持する"},{"id":"NFR-2","status":"new","issue_evidence":"クライアントが自身の `language` を更新できるよう"},{"id":"NFR-3","status":"new","issue_evidence":"既存の `name` のみというルールは `language` の追加範囲で変更し"},{"id":"AC-1","status":"new","issue_evidence":"言語設定の保存先と所有責務が定義されている"},{"id":"AC-2","status":"new","issue_evidence":"ログイン時に保存済み言語が反映される"},{"id":"AC-3","status":"new","issue_evidence":"言語変更がアカウントへ保存される"},{"id":"AC-4","status":"new","issue_evidence":"別端末で同じ言語設定が反映される"},{"id":"AC-5","status":"new","issue_evidence":"未設定・取得失敗・保存失敗時の挙動が定義されている"},{"id":"AC-6","status":"new","issue_evidence":"既存の日本語・英語表示が壊れていない"},{"id":"AC-7","status":"new","issue_evidence":"必要な検証ができる"}],"sections":[{"id":"background","status":"new","issue_evidence":"現在の言語設定はブラウザの `localStorage` にだけ保存される"},{"id":"users","status":"new","issue_evidence":"同じユーザーが別端末や別ブラウザでログインしても"},{"id":"stories","status":"new","issue_evidence":"プロフィール設定として選択した言語が"},{"id":"scope","status":"new","issue_evidence":"### 対象"},{"id":"functional","status":"new","issue_evidence":"- 言語設定の保存先"},{"id":"non-functional","status":"new","issue_evidence":"- 対応言語は既存の日本語と英語を維持する"},{"id":"acceptance","status":"new","issue_evidence":"## 成功条件"},{"id":"qa","status":"new","issue_evidence":"## 判断したいこと"},{"id":"technical","status":"new","issue_evidence":"必要なDB migration、型・API境界、RLS・更新条件、回帰テストを同期して変更する"}],"retired":[]}
+```
+
+## 背景
+
+現在の言語設定はブラウザの `localStorage` にだけ保存される。同じアカウントの設定がブラウザ外へ共有されず、端末ごとに異なる言語状態になる課題を解消する。
+
+## 対象ユーザーと利用シーン
+
+同じユーザーが別端末や別ブラウザでログインしても、アカウントを起点に同じ言語を利用できるユーザーシナリオを対象とする。未認証ユーザーのアカウント設定は対象外とする。
+
+## ユーザーストーリー
+
+プロフィール設定として選択した言語がアカウントに保存され、次のログイン時に端末へ反映されてほしい。利用者は設定の取得・保存結果を判断でき、失敗時もアプリを継続利用したい。
+
+## スコープ
+
+### 対象
+
+- 保存先とログイン時取得の責務
+- 言語変更時の保存と既存localStorage値との優先順位
+- 未設定・取得失敗・保存失敗時の挙動
+
+### 対象外
+
+- 対応言語の追加
+- テーマ設定の同期
+- 未認証ユーザーのアカウント設定
+- その他のプロフィール項目
+
+## 機能要件
+
+機能として次を定義する。
+
+- 言語設定の保存先
+- ログイン時の保存値取得
+- 言語変更時の保存
+- アカウント設定と端末設定の優先順位
+- 未設定・取得失敗・保存失敗時の安全な継続
+
+- FR-1: 言語設定はpublic\.users\.languageを永続的な保存先として追加する。ブラウザだけに分散させずアカウントが所有する。
+- FR-2: ログイン時の言語設定取得により、認証済みユーザーの保存済み言語を現在の端末へ反映する。
+- FR-3: 言語変更時の保存を実行し、選択した日本語または英語をアカウントへ記録する。
+- FR-4: 既存localStorage値との優先順位を明示し、アカウント設定と端末設定の競合時に決定的な値を採用する。
+- FR-5: 言語設定を取得・保存できたかを判断できるよう、各種未設定や取得・保存の失敗時の挙動を定義し、失敗してもアプリを利用不能にせず安全な既定値へ戻す。
+
+## 非機能要件
+
+- 対応言語は既存の日本語と英語を維持する
+- 認証済みユーザー自身のlanguageだけを更新対象にする
+- DB migration、型・API境界、RLS・更新条件、回帰テストを同期する
+
+- NFR-1: 対応言語は既存の日本語と英語を維持する。
+- NFR-2: クライアントが自身の \`language\` を更新できるようにし、認証・RLS・API境界で他ユーザーのデータ更新を許可しない。
+- NFR-3: 既存の \`name\` のみというルールは \`language\` の追加範囲で変更し、他のプロフィール列は更新可能にしない。
+
+## 受け入れ条件
+
+## 成功条件
+
+保存先、ログイン時反映、変更保存、端末間同期、異常系、既存表示、検証可能性を確認できること。
+
+- AC-1: 言語設定の保存先と所有責務が定義されていることを確認できる。
+- AC-2: ログイン時に保存済み言語が反映されることを確認できる。
+- AC-3: 言語変更がアカウントへ保存されることを確認できる。
+- AC-4: 別端末で同じ言語設定が反映されることを確認できる。
+- AC-5: 未設定・取得失敗・保存失敗時の挙動が定義されていることを確認できる。
+- AC-6: 既存の日本語・英語表示が壊れていないことを回帰検証する。
+- AC-7: 必要な検証ができるよう、migration・型・API境界・RLS・更新条件・回帰テストを同期する。
+
+## Q\&A
+
+## 判断したいこと
+
+- アカウント設定と端末設定のどちらを優先するか
+- 言語設定を取得・保存できたか
+- 未設定や失敗時にどの既定値で継続するか
+
+## 技術的考慮事項
+
+必要なDB migration、型・API境界、RLS・更新条件、回帰テストを同期して変更する。既存のプロフィール更新境界をlanguageの追加範囲に限って拡張し、他のプロフィール列へ波及させない。
+
+## Rule Selection
+
+- Direct: `domain.user`。アカウントの言語列をユーザードメインの責務として定義する。
+- Conflict: none。


### PR DESCRIPTION
## 関連Issue

Closes #1563

## 変更内容

- `public.users.language` と更新権限・更新日時トリガーを追加
- プロフィール取得・言語更新API、ログイン時のアカウント言語反映、localStorage優先順位と保存失敗時の復元を実装
- MSW fixture、プロフィール回帰テスト、言語同期テスト、AIDD Requirements / Design成果物を追加

## 動作確認

- [x] `pnpm run web:format`
- [x] `pnpm run web:lint`
- [x] `pnpm run web:format-check`
- [x] `pnpm run web:typecheck`
- [x] `pnpm run web:test:unit-integration`（135 files / 671 tests）
- Build Entry Gate（receipt SHA-256一致）

## 補足

- Supabase DBテストはローカルPostgres未起動（127.0.0.1:54322接続拒否）のため未実行です。
- 対応言語は既存の日本語・英語に限定し、未設定時は端末値を維持します。

## Review instructions

- `docs/harness/rule-map.json` も参照し、関連ルールとの整合性を見てください。
