### PR TITLE
docs: AIDD工程をフェーズ別モデルへ委譲

### DIFF
--- a/.agents/skills/aidd-cycle/SKILL.md
+++ b/.agents/skills/aidd-cycle/SKILL.md
@@ -6,8 +6,9 @@ description: Run one complete repository AI Driven Development cycle in a single
 # AIDD Cycle
 
 Run the repository AIDD workflow end to end. This skill owns cycle identity,
-phase transitions, and Goal execution. `goal-setting` owns construction of one
-phase Goal.
+phase transitions, Goal orchestration, and completion confirmation.
+`goal-setting` owns construction of one phase Goal. The executor assigned below
+owns execution of that Goal.
 
 ## Read First
 
@@ -57,7 +58,7 @@ For each phase in the workflow:
    artifacts and generated displays against the current Issue snapshot and the
    Design completion receipt.
 3. Execute only that Goal under its Context Packet and selected rule-map
-   subgraph.
+   subgraph, using the phase executor assigned below.
 4. For Requirements and Design, retain the validated temporary Goal JSON and
    run the artifact gates before completing the phase. After the Design gates
    succeed, capture the canonical Design completion receipt and record its path
@@ -75,6 +76,42 @@ For each phase in the workflow:
 
 Never have two phase Goals active at once. Never advance because files exist,
 tests happened to pass, or a phase draft was produced.
+
+## Phase Execution Assignment
+
+The parent agent remains the cycle orchestrator and keeps its currently
+selected model and reasoning effort. Assign each phase exactly as follows:
+
+| Phase | Executor | Model | Reasoning effort |
+| --- | --- | --- | --- |
+| Requirements | `worker` subagent | `gpt-5.6-sol` | `high` |
+| Design | `worker` subagent | `gpt-5.6-sol` | `high` |
+| Build | `worker` subagent | `gpt-5.6-luna` | `max` |
+| Ship | parent agent | current selection | current selection |
+
+For Requirements, Design, and Build:
+
+1. The parent sets or identifies the one active phase Goal before delegation.
+2. Spawn exactly one `worker` for the phase with the assigned `model` and
+   `reasoning_effort`. Use `fork_turns: "none"` so the explicit model override
+   is preserved.
+3. Give the worker a self-contained task containing the repository root,
+   current branch, phase, active Goal identity and Context Packet, required
+   workflow and validation references, upstream artifact or receipt identity,
+   read/write boundary, Verification, and Stop conditions.
+4. The worker executes only the active Goal. It must not create the next Goal,
+   start another phase, run Learn, or delegate further.
+5. Wait for the worker before doing more phase work. Reuse that worker for
+   same-phase continuation when possible, and never run two phase executors at
+   once.
+6. After the worker finishes, the parent calls `get_goal` and independently
+   confirms the required phase evidence. Advance only when the Goal is
+   terminal `complete`; otherwise continue or stop under the existing Goal
+   rules.
+
+If the assigned model, reasoning effort, or subagent capability is unavailable,
+preserve the active Goal and stop. Do not inherit, substitute, or silently run
+the delegated phase in the parent.
 
 ## Artifact Boundary
 

--- a/.agents/skills/aidd-cycle/SKILL.md
+++ b/.agents/skills/aidd-cycle/SKILL.md
@@ -17,6 +17,7 @@ owns execution of that Goal.
 - `.agents/skills/goal-setting/SKILL.md`
 - `docs/harness/rule-map.json`
 - `references/artifact-validation.md` when entering Requirements, Design, or Build
+- `.codex/config.toml` and the selected phase agent file before delegation
 
 The workflow is canonical. Do not add phase rules here or infer a phase from an
 artifact's mere existence.
@@ -82,36 +83,38 @@ tests happened to pass, or a phase draft was produced.
 The parent agent remains the cycle orchestrator and keeps its currently
 selected model and reasoning effort. Assign each phase exactly as follows:
 
-| Phase | Executor | Model | Reasoning effort |
-| --- | --- | --- | --- |
-| Requirements | `worker` subagent | `gpt-5.6-sol` | `high` |
-| Design | `worker` subagent | `gpt-5.6-sol` | `high` |
-| Build | `worker` subagent | `gpt-5.6-luna` | `max` |
-| Ship | parent agent | current selection | current selection |
+| Phase | Executor | Configuration |
+| --- | --- | --- |
+| Requirements | `aidd-requirements-design` | `.codex/agents/aidd-requirements-design.toml` |
+| Design | `aidd-requirements-design` | `.codex/agents/aidd-requirements-design.toml` |
+| Build | `aidd-build` | `.codex/agents/aidd-build.toml` |
+| Ship | parent agent | current selection |
 
 For Requirements, Design, and Build:
 
 1. The parent sets or identifies the one active phase Goal before delegation.
-2. Spawn exactly one `worker` for the phase with the assigned `model` and
-   `reasoning_effort`. Use `fork_turns: "none"` so the explicit model override
-   is preserved.
-3. Give the worker a self-contained task containing the repository root,
+2. Spawn exactly one registered project-scoped agent from the table. Its
+   configuration file, registered by `.codex/config.toml`, is the source of
+   truth for its model, reasoning effort, and phase instructions; do not
+   override those settings at the call site. Sandbox and approval settings
+   follow the parent turn's active runtime policy.
+3. Give the phase agent a self-contained task containing the repository root,
    current branch, phase, active Goal identity and Context Packet, required
    workflow and validation references, upstream artifact or receipt identity,
    read/write boundary, Verification, and Stop conditions.
-4. The worker executes only the active Goal. It must not create the next Goal,
-   start another phase, run Learn, or delegate further.
-5. Wait for the worker before doing more phase work. Reuse that worker for
+4. The phase agent executes only the active Goal. It must not create the next
+   Goal, start another phase, run Learn, or delegate further.
+5. Wait for the phase agent before doing more phase work. Reuse that agent for
    same-phase continuation when possible, and never run two phase executors at
    once.
-6. After the worker finishes, the parent calls `get_goal` and independently
-   confirms the required phase evidence. Advance only when the Goal is
-   terminal `complete`; otherwise continue or stop under the existing Goal
-   rules.
+6. After the phase agent finishes, the parent calls `get_goal` and
+   independently confirms the required phase evidence. Advance only when the
+   Goal is terminal `complete`; otherwise continue or stop under the existing
+   Goal rules.
 
-If the assigned model, reasoning effort, or subagent capability is unavailable,
-preserve the active Goal and stop. Do not inherit, substitute, or silently run
-the delegated phase in the parent.
+If the registered phase agent or its configured model and reasoning effort is
+unavailable, preserve the active Goal and stop. Do not inherit, substitute, or
+silently run the delegated phase in the parent.
 
 ## Artifact Boundary
 

--- a/.codex/agents/aidd-build.toml
+++ b/.codex/agents/aidd-build.toml
@@ -1,0 +1,14 @@
+name = "aidd-build"
+description = "Execute an active AIDD Build Goal with a cost-efficient maximum-effort model."
+model = "gpt-5.6-luna"
+model_reasoning_effort = "max"
+
+developer_instructions = """
+You execute exactly one active AIDD Build Goal prepared by the parent orchestrator.
+
+At the start, call get_goal and require the active Goal to match the Build phase and cycle in the delegated task. Read the repository AIDD workflow, the active Goal's Context Packet, the selected rule documents, the Design completion receipt, and the Build artifact-validation instructions before editing.
+
+Complete only the active Build Goal, including implementation, affected verification, the final Build Entry gate, completion evidence, and terminal Goal update. Preserve every upstream artifact and receipt as read-only and obey all Stop conditions.
+
+Do not create another Goal, start Ship or Learn, delegate further, or broaden the task beyond the active Goal. Return concise implementation, verification, gate, and Goal-state evidence to the parent orchestrator.
+"""

--- a/.codex/agents/aidd-requirements-design.toml
+++ b/.codex/agents/aidd-requirements-design.toml
@@ -1,0 +1,14 @@
+name = "aidd-requirements-design"
+description = "Execute an active AIDD Requirements or Design Goal with high reasoning."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
+
+developer_instructions = """
+You execute exactly one active AIDD Requirements or Design Goal prepared by the parent orchestrator.
+
+At the start, call get_goal and require the active Goal to match the phase and cycle in the delegated task. Read the repository AIDD workflow, the active Goal's Context Packet, the selected rule documents, and the applicable artifact-validation instructions before editing.
+
+Complete only the active phase, including its owned artifacts, required gates, completion evidence, and terminal Goal update. Preserve every upstream read-only boundary and Stop condition.
+
+Do not create another Goal, choose a later phase, run Build, Ship, or Learn, delegate further, or broaden the task beyond the active Goal. Return concise artifact, validation, and Goal-state evidence to the parent orchestrator.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -8,3 +8,11 @@ network_access = true
 [agents.context-scout]
 description = "Low-cost read-heavy repository discovery agent for Context Packet material."
 config_file = "./agents/context-scout.toml"
+
+[agents.aidd-requirements-design]
+description = "Execute an active AIDD Requirements or Design Goal with high reasoning."
+config_file = "./agents/aidd-requirements-design.toml"
+
+[agents.aidd-build]
+description = "Execute an active AIDD Build Goal with a cost-efficient maximum-effort model."
+config_file = "./agents/aidd-build.toml"


### PR DESCRIPTION
## 変更内容\n\n- AIDD cycleの親agentは、現在選択中のモデルのままGoal遷移・委譲結果の統合・Shipを担当\n- Requirements / Design用のproject-scoped agentをgpt-5.6-sol / highで登録\n- Build用のproject-scoped agentをgpt-5.6-luna / maxで登録\n- skillからcall-siteのmodel、reasoning_effort、fork_turns指定を削除し、custom agent設定を正本化\n- sandbox / approvalは親agentのruntime policyを継承し、指定agentやモデルが利用不能な場合は停止\n\n## 動作確認\n\n- [x] TOML parse、agent登録、モデル割当、sandbox_mode非指定を検証\n- [x] freshなCodex runtimeでaidd-requirements-design / aidd-build agent種別を認識することを確認\n- [x] skill frontmatter、命名、未完了TODOを検証\n- [x] git diff --check\n- [x] ai-driven.goal-templates、ai-driven.workflow、ai-driven.overviewとの整合性を確認\n\nアプリコード、build/type設定、DB migrationは変更していないため、Web verificationは実行していません。\n\n## Review instructions\n\n- .codex/config.tomlと.codex/agents/*.tomlの登録・モデル設定を確認してください。\n- .agents/skills/aidd-cycle/SKILL.mdが、各phaseを登録済みagentへ直列委譲し、親agentの責務を維持していることを確認してください。